### PR TITLE
Add shared Playground experiment diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Config-driven Python workflows for semi-automated participation in tabular Kaggl
 - Load and validate a single repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Infer `task_type` and `primary_metric` from config or Kaggle metadata.
-- Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`.
+- Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Build preprocessing artifacts under `artifacts/<competition_slug>/preprocess/`.
 - Train baseline cross-validated models with fold-local preprocessing:
   - regression: `ElasticNet`
   - binary classification: `LogisticRegression`
-- Write fold metrics, CV summary, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
+- Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
 - Validate predictions against `sample_submission.csv` and optionally submit to Kaggle.
 
 ## Tooling
@@ -31,7 +31,7 @@ Config-driven Python workflows for semi-automated participation in tabular Kaggl
 3. Keep a project `config.yaml` at repository root.
 4. Run `uv run python main.py`.
 
-The current pipeline fetches competition data if needed, runs EDA, writes preprocessing artifacts, trains a baseline CV model, writes prediction artifacts, and prepares a validated submission file.
+The current pipeline fetches competition data if needed, runs config-aware EDA, writes preprocessing artifacts, trains a baseline CV model with task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
 
 ## Config Overview
 Required key:
@@ -63,6 +63,7 @@ If competition metadata keys are omitted, the pipeline attempts inference from K
 - EDA reports: `reports/<competition_slug>/`
 - Preprocessing artifacts: `artifacts/<competition_slug>/preprocess/`
 - Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
+  - includes `fold_metrics.csv`, `cv_summary.csv`, `run_diagnostics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `run_manifest.json`
 - Run ledger: `artifacts/<competition_slug>/train/runs.csv`
 - Submission ledger: `artifacts/<competition_slug>/train/submissions.csv`
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -15,14 +15,14 @@ Technical reference for the current repository design. Use GitHub issues and pul
 8. Train the baseline model with fold-local preprocessing:
    - regression: `ElasticNet`
    - binary classification: `LogisticRegression`
-9. Write fold metrics, CV summary, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
+9. Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Validate predictions against `sample_submission.csv`, write `submission.csv`, and optionally submit to Kaggle.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading, data fetch, EDA, preprocessing, training, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema and loading.
 - `src/tabular_shenanigans/data.py`: Kaggle metadata lookup, competition download, zip access, and target inference.
-- `src/tabular_shenanigans/eda.py`: numeric and schema-oriented EDA summaries written to CSV.
+- `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and sklearn preprocessing pipelines.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/train.py`: baseline model selection, fold training, artifact writing, and run ledger updates.
@@ -55,14 +55,22 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 - Competition files downloaded under `data/<competition_slug>/`
 - EDA summary printed to terminal
 - EDA report CSV files under `reports/<competition_slug>/`
+  - `columns_train.csv`
+  - `columns_test.csv`
+  - `missingness_summary.csv`
+  - `categorical_cardinality_summary.csv`
+  - `target_summary.csv`
+  - `feature_type_counts.csv`
+  - `run_summary.csv`
 - Preprocessed feature/target CSV files under `artifacts/<competition_slug>/preprocess/`
 - Training artifacts under `artifacts/<competition_slug>/train/<run_id>/`:
   - `fold_metrics.csv`
   - `cv_summary.csv`
+  - `run_diagnostics.csv`
   - `oof_predictions.csv`
   - `test_predictions.csv`
   - `run_manifest.json`
-- Append-only training ledger at `artifacts/<competition_slug>/train/runs.csv`
+- Training ledger at `artifacts/<competition_slug>/train/runs.csv` with task, metric, CV metadata, task-aware target summary fields, and artifact paths
 - Submission artifact in each run dir:
   - `submission.csv`
 - Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv`
@@ -75,6 +83,7 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 - Target inference must resolve to exactly one column
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Metric resolution must produce a supported metric compatible with the resolved task type
+- CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
 - Submission output must match the schema and row count of `sample_submission.csv`
 - Fail fast is the default behavior; errors are surfaced directly with minimal wrapping
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,13 @@ def main() -> None:
     )
     data_dir = fetch_competition_data(config.competition_slug)
     print(f"Data ready: {data_dir}")
-    report_dir = run_eda(config.competition_slug)
+    report_dir = run_eda(
+        competition_slug=config.competition_slug,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
+        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+    )
     print(f"EDA reports ready: {report_dir}")
     artifact_dir = run_preprocessing(
         competition_slug=config.competition_slug,

--- a/src/tabular_shenanigans/cv.py
+++ b/src/tabular_shenanigans/cv.py
@@ -7,10 +7,17 @@ from sklearn.model_selection import KFold, StratifiedKFold
 
 
 def build_splitter(task_type: str, n_splits: int, shuffle: bool, random_state: int) -> KFold | StratifiedKFold:
+    splitter_kwargs = {
+        "n_splits": n_splits,
+        "shuffle": shuffle,
+    }
+    if shuffle:
+        splitter_kwargs["random_state"] = random_state
+
     if task_type == "regression":
-        return KFold(n_splits=n_splits, shuffle=shuffle, random_state=random_state)
+        return KFold(**splitter_kwargs)
     if task_type == "binary":
-        return StratifiedKFold(n_splits=n_splits, shuffle=shuffle, random_state=random_state)
+        return StratifiedKFold(**splitter_kwargs)
     raise ValueError(f"Unsupported task_type for CV splitter: {task_type}")
 
 

--- a/src/tabular_shenanigans/eda.py
+++ b/src/tabular_shenanigans/eda.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 from tabular_shenanigans.data import find_competition_zip, infer_target_column, read_csv_from_zip
+from tabular_shenanigans.preprocess import prepare_feature_frames, summarize_feature_types
 
 
 def _column_summary(df: pd.DataFrame) -> pd.DataFrame:
@@ -16,6 +17,44 @@ def _column_summary(df: pd.DataFrame) -> pd.DataFrame:
         }
     )
     return summary
+
+
+def _missingness_summary(train_df: pd.DataFrame, test_df: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for dataset_name, df in (("train", train_df), ("test", test_df)):
+        for column in df.columns:
+            rows.append(
+                {
+                    "dataset": dataset_name,
+                    "column": column,
+                    "null_count": int(df[column].isna().sum()),
+                    "null_pct": float(df[column].isna().mean()),
+                }
+            )
+    return pd.DataFrame(rows, columns=["dataset", "column", "null_count", "null_pct"]).sort_values(
+        ["dataset", "null_pct", "column"],
+        ascending=[True, False, True],
+    )
+
+
+def _categorical_cardinality_summary(train_df: pd.DataFrame, test_df: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for dataset_name, df in (("train", train_df), ("test", test_df)):
+        categorical_columns = df.select_dtypes(exclude=["number"]).columns.tolist()
+        for column in categorical_columns:
+            rows.append(
+                {
+                    "dataset": dataset_name,
+                    "column": column,
+                    "nunique": int(df[column].nunique(dropna=False)),
+                    "null_count": int(df[column].isna().sum()),
+                    "null_pct": float(df[column].isna().mean()),
+                }
+            )
+    return pd.DataFrame(
+        rows,
+        columns=["dataset", "column", "nunique", "null_count", "null_pct"],
+    ).sort_values(["dataset", "nunique", "column"], ascending=[True, False, True])
 
 
 def _target_summary(train_df: pd.DataFrame, target_column: str) -> pd.DataFrame:
@@ -39,18 +78,44 @@ def _target_summary(train_df: pd.DataFrame, target_column: str) -> pd.DataFrame:
     )
 
 
-def run_eda(competition_slug: str) -> Path:
+def run_eda(
+    competition_slug: str,
+    force_categorical: list[str] | None = None,
+    force_numeric: list[str] | None = None,
+    drop_columns: list[str] | None = None,
+    low_cardinality_int_threshold: int | None = None,
+) -> Path:
     zip_path = find_competition_zip(competition_slug)
     train_df = read_csv_from_zip(zip_path, "train.csv")
     test_df = read_csv_from_zip(zip_path, "test.csv")
     target_column = infer_target_column(train_df, test_df)
+    x_train_raw, _, _ = prepare_feature_frames(
+        train_df=train_df,
+        test_df=test_df,
+        target_column=target_column,
+        force_categorical=force_categorical,
+        force_numeric=force_numeric,
+        drop_columns=drop_columns,
+    )
 
     report_dir = Path("reports") / competition_slug
     report_dir.mkdir(parents=True, exist_ok=True)
 
     _column_summary(train_df).to_csv(report_dir / "columns_train.csv", index=False)
     _column_summary(test_df).to_csv(report_dir / "columns_test.csv", index=False)
+    _missingness_summary(train_df, test_df).to_csv(report_dir / "missingness_summary.csv", index=False)
+    _categorical_cardinality_summary(train_df, test_df).to_csv(
+        report_dir / "categorical_cardinality_summary.csv",
+        index=False,
+    )
     _target_summary(train_df, target_column).to_csv(report_dir / "target_summary.csv", index=False)
+    feature_type_counts = summarize_feature_types(
+        x_train_raw=x_train_raw,
+        force_categorical=force_categorical,
+        force_numeric=force_numeric,
+        low_cardinality_int_threshold=low_cardinality_int_threshold,
+    )
+    feature_type_counts.to_csv(report_dir / "feature_type_counts.csv", index=False)
 
     run_summary = pd.DataFrame(
         [
@@ -64,6 +129,7 @@ def run_eda(competition_slug: str) -> Path:
             {"metric": "test_missing_pct", "value": float(test_df.isna().mean().mean())},
             {"metric": "train_duplicate_rows", "value": int(train_df.duplicated().sum())},
             {"metric": "test_duplicate_rows", "value": int(test_df.duplicated().sum())},
+            {"metric": "feature_count_after_drop_columns", "value": int(x_train_raw.shape[1])},
         ]
     )
     run_summary.to_csv(report_dir / "run_summary.csv", index=False)
@@ -75,5 +141,6 @@ def run_eda(competition_slug: str) -> Path:
     print(f"Test missing pct: {test_df.isna().mean().mean():.6f}")
     print(f"Train duplicate rows: {int(train_df.duplicated().sum())}")
     print(f"Test duplicate rows: {int(test_df.duplicated().sum())}")
+    print(f"Feature count after drop_columns: {int(x_train_raw.shape[1])}")
 
     return report_dir

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -115,6 +115,31 @@ def build_preprocessor(
     return preprocessor, numeric_columns, categorical_columns
 
 
+def summarize_feature_types(
+    x_train_raw: pd.DataFrame,
+    force_categorical: list[str] | None = None,
+    force_numeric: list[str] | None = None,
+    low_cardinality_int_threshold: int | None = None,
+) -> pd.DataFrame:
+    force_categorical = force_categorical or []
+    force_numeric = force_numeric or []
+
+    numeric_columns, categorical_columns = _resolve_feature_types(
+        x_train_raw=x_train_raw,
+        force_categorical=force_categorical,
+        force_numeric=force_numeric,
+        low_cardinality_int_threshold=low_cardinality_int_threshold,
+    )
+
+    return pd.DataFrame(
+        [
+            {"feature_type": "numeric", "feature_count": len(numeric_columns)},
+            {"feature_type": "categorical", "feature_count": len(categorical_columns)},
+            {"feature_type": "total", "feature_count": int(x_train_raw.shape[1])},
+        ]
+    )
+
+
 def run_preprocessing(
     competition_slug: str,
     force_categorical: list[str] | None = None,

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -25,7 +25,6 @@ def _build_model(task_type: str, random_state: int) -> tuple[str, object, dict[s
     if task_type == "binary":
         params = {
             "C": 1.0,
-            "penalty": "l2",
             "solver": "lbfgs",
             "max_iter": 2000,
             "random_state": random_state,
@@ -42,9 +41,81 @@ def _make_run_id() -> str:
 def _append_run_ledger(ledger_path: Path, row: dict[str, object]) -> None:
     ledger_df = pd.DataFrame([row])
     if ledger_path.exists():
-        ledger_df.to_csv(ledger_path, mode="a", header=False, index=False)
+        existing_df = pd.read_csv(ledger_path)
+        merged_df = pd.concat([existing_df, ledger_df], ignore_index=True, sort=False)
+        merged_df.to_csv(ledger_path, index=False)
         return
     ledger_df.to_csv(ledger_path, index=False)
+
+
+def _build_target_summary(task_type: str, y_train: pd.Series) -> dict[str, object]:
+    if task_type == "regression":
+        return {
+            "target_mean": float(y_train.mean()),
+            "target_std": float(y_train.std(ddof=0)),
+            "target_min": float(y_train.min()),
+            "target_max": float(y_train.max()),
+        }
+
+    if task_type == "binary":
+        positive_count = int(y_train.sum())
+        row_count = int(y_train.shape[0])
+        negative_count = row_count - positive_count
+        return {
+            "positive_count": positive_count,
+            "negative_count": negative_count,
+            "target_prevalence": float(positive_count / row_count),
+        }
+
+    raise ValueError(f"Unsupported task_type for target summary: {task_type}")
+
+
+def _build_diagnostic_rows(
+    task_type: str,
+    fold_index: int,
+    split_name: str,
+    y_values: pd.Series,
+) -> list[dict[str, object]]:
+    row = {
+        "task_type": task_type,
+        "fold": fold_index,
+        "split": split_name,
+        "row_count": int(y_values.shape[0]),
+        "target_mean": np.nan,
+        "target_std": np.nan,
+        "target_min": np.nan,
+        "target_max": np.nan,
+        "positive_count": np.nan,
+        "negative_count": np.nan,
+        "positive_rate": np.nan,
+    }
+
+    if task_type == "regression":
+        row.update(
+            {
+                "diagnostic_type": "target_distribution",
+                "target_mean": float(y_values.mean()),
+                "target_std": float(y_values.std(ddof=0)),
+                "target_min": float(y_values.min()),
+                "target_max": float(y_values.max()),
+            }
+        )
+        return [row]
+
+    if task_type == "binary":
+        positive_count = int(y_values.sum())
+        negative_count = int(y_values.shape[0] - positive_count)
+        row.update(
+            {
+                "diagnostic_type": "class_balance",
+                "positive_count": positive_count,
+                "negative_count": negative_count,
+                "positive_rate": float(positive_count / y_values.shape[0]),
+            }
+        )
+        return [row]
+
+    raise ValueError(f"Unsupported task_type for diagnostics: {task_type}")
 
 
 def run_training(
@@ -86,12 +157,20 @@ def run_training(
     fold_assignments = np.full(n_rows, fill_value=-1, dtype=int)
     test_predictions_per_fold: list[np.ndarray] = []
     fold_metrics: list[dict[str, object]] = []
+    run_diagnostics: list[dict[str, object]] = []
+    run_diagnostics.extend(_build_diagnostic_rows(task_type=task_type, fold_index=0, split_name="all", y_values=y_train))
 
     for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train_raw, y_train), start=1):
         x_fold_train = x_train_raw.iloc[train_idx]
         x_fold_valid = x_train_raw.iloc[valid_idx]
         y_fold_train = y_train.iloc[train_idx]
         y_fold_valid = y_train.iloc[valid_idx]
+        run_diagnostics.extend(
+            _build_diagnostic_rows(task_type=task_type, fold_index=fold_index, split_name="train", y_values=y_fold_train)
+        )
+        run_diagnostics.extend(
+            _build_diagnostic_rows(task_type=task_type, fold_index=fold_index, split_name="valid", y_values=y_fold_valid)
+        )
 
         preprocessor, _, _ = build_preprocessor(
             x_train_raw=x_fold_train,
@@ -143,14 +222,17 @@ def run_training(
         mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
 
     fold_metrics_df = pd.DataFrame(fold_metrics)
+    run_diagnostics_df = pd.DataFrame(run_diagnostics)
     cv_mean = float(fold_metrics_df["metric_value"].mean())
     cv_std = float(fold_metrics_df["metric_value"].std(ddof=0))
+    target_summary = _build_target_summary(task_type=task_type, y_train=y_train)
 
     run_id = _make_run_id()
     run_dir = Path("artifacts") / competition_slug / "train" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
 
     fold_metrics_df.to_csv(run_dir / "fold_metrics.csv", index=False)
+    run_diagnostics_df.to_csv(run_dir / "run_diagnostics.csv", index=False)
 
     cv_summary_df = pd.DataFrame(
         [
@@ -203,6 +285,14 @@ def run_training(
     }
     config_snapshot_json = json.dumps(config_snapshot, sort_keys=True)
     config_fingerprint = hashlib.sha256(config_snapshot_json.encode("utf-8")).hexdigest()[:12]
+    artifact_paths = {
+        "run_manifest": "run_manifest.json",
+        "fold_metrics": "fold_metrics.csv",
+        "cv_summary": "cv_summary.csv",
+        "run_diagnostics": "run_diagnostics.csv",
+        "oof_predictions": "oof_predictions.csv",
+        "test_predictions": "test_predictions.csv",
+    }
 
     run_manifest = {
         "run_id": run_id,
@@ -210,16 +300,12 @@ def run_training(
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
         "target_column": target_column,
+        "target_summary": target_summary,
         "train_rows": int(x_train_raw.shape[0]),
         "train_cols": int(x_train_raw.shape[1]),
         "test_rows": int(x_test_raw.shape[0]),
         "test_cols": int(x_test_raw.shape[1]),
-        "artifacts": {
-            "fold_metrics": "fold_metrics.csv",
-            "cv_summary": "cv_summary.csv",
-            "oof_predictions": "oof_predictions.csv",
-            "test_predictions": "test_predictions.csv",
-        },
+        "artifacts": artifact_paths,
     }
     (run_dir / "run_manifest.json").write_text(json.dumps(run_manifest, indent=2), encoding="utf-8")
 
@@ -236,7 +322,14 @@ def run_training(
         "cv_random_state": cv_random_state,
         "config_fingerprint": config_fingerprint,
         "artifact_dir": str(run_dir),
+        "run_manifest_path": str(run_dir / artifact_paths["run_manifest"]),
+        "fold_metrics_path": str(run_dir / artifact_paths["fold_metrics"]),
+        "cv_summary_path": str(run_dir / artifact_paths["cv_summary"]),
+        "run_diagnostics_path": str(run_dir / artifact_paths["run_diagnostics"]),
+        "oof_predictions_path": str(run_dir / artifact_paths["oof_predictions"]),
+        "test_predictions_path": str(run_dir / artifact_paths["test_predictions"]),
     }
+    ledger_row.update(target_summary)
     ledger_path = Path("artifacts") / competition_slug / "train" / "runs.csv"
     _append_run_ledger(ledger_path, ledger_row)
 


### PR DESCRIPTION
Closes #1

## Summary
- fix task-aware CV splitter construction so `cv_shuffle: false` works for both regression and binary classification
- add task-aware run diagnostics and richer run ledger metadata for later experiment work
- extend EDA outputs with missingness, categorical cardinality, and feature-type summary artifacts

## Verification
- `uv run python -m compileall main.py src`
- `uv run python main.py`
- `uv run python - <<'PY'
import sys
from pathlib import Path
sys.path.insert(0, str(Path.cwd() / "src"))
from tabular_shenanigans.train import run_training
run_training(
    competition_slug="titanic",
    task_type="binary",
    primary_metric="accuracy",
    cv_n_splits=5,
    cv_shuffle=False,
    cv_random_state=42,
)
PY`
- `uv run python - <<'PY'
import sys
from pathlib import Path
sys.path.insert(0, str(Path.cwd() / "src"))
from tabular_shenanigans.train import run_training
run_training(
    competition_slug="house-prices-advanced-regression-techniques",
    task_type="regression",
    primary_metric="rmsle",
    force_categorical=["MSSubClass", "MoSold", "YrSold"],
    drop_columns=["Id"],
    cv_n_splits=7,
    cv_shuffle=False,
    cv_random_state=42,
)
PY`