### PR TITLE
Infer id and label columns from dataset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Config-driven Python workflows for semi-automated participation in tabular Kaggl
 - Load and validate a single repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Infer `task_type` and `primary_metric` from config or Kaggle metadata.
+- Infer Playground-style submission schema from dataset files:
+  - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
+  - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Build preprocessing artifacts under `artifacts/<competition_slug>/preprocess/`.
 - Train baseline cross-validated models with fold-local preprocessing:
@@ -40,6 +43,8 @@ Required key:
 Optional competition metadata keys:
 - `task_type`: `regression` or `binary`
 - `primary_metric`: one of `rmse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`
+- `id_column`: override for the inferred identifier column
+- `label_column`: override for the inferred submission/target column
 
 Optional preprocessing keys:
 - `force_categorical`: list of feature names to force into the categorical pipeline
@@ -56,7 +61,9 @@ Optional submission keys:
 - `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `submit_message_prefix`: optional prefix used in auto-generated submission messages
 
-If competition metadata keys are omitted, the pipeline attempts inference from Kaggle metadata. Partial or ambiguous inference fails fast and requires explicit values in `config.yaml`.
+If competition metadata keys are omitted, the pipeline attempts inference from Kaggle metadata. Partial or ambiguous task/metric inference fails fast and requires explicit values in `config.yaml`.
+
+If `id_column` or `label_column` are omitted, the pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. Invalid overrides, ambiguous inference, or a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]` are hard errors.
 
 ## Outputs
 - Competition data: `data/<competition_slug>/`
@@ -70,6 +77,6 @@ If competition metadata keys are omitted, the pipeline attempts inference from K
 ## Current Assumptions
 - Kaggle CLI is installed, authenticated, and has access to the configured competition.
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
-- A single target column can be inferred from the train/test schema difference.
+- The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - Runtime config comes from `config.yaml` only; there are no CLI or environment overrides.
 - The current workflow is CPU-first and optimized for iteration speed over production hardening.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -8,7 +8,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 3. Download the competition zip into `data/<competition_slug>/` when it is missing.
 4. Read `train.csv`, `test.csv`, and `sample_submission.csv` from the zip as needed.
 5. Run EDA and write report CSVs under `reports/<competition_slug>/`.
-6. Prepare raw feature frames from the train/test data and infer the target column from the train/test schema difference.
+6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data.
 7. Build preprocessing for the selected feature types:
    - numeric: median imputation + `StandardScaler`
    - categorical: most-frequent imputation + `OneHotEncoder`
@@ -21,7 +21,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading, data fetch, EDA, preprocessing, training, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema and loading.
-- `src/tabular_shenanigans/data.py`: Kaggle metadata lookup, competition download, zip access, and target inference.
+- `src/tabular_shenanigans/data.py`: Kaggle metadata lookup, competition download, zip access, and dataset schema resolution.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and sklearn preprocessing pipelines.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
@@ -35,6 +35,8 @@ Input:
 - Optional keys for competition metadata:
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
+  - `id_column` (optional override for the inferred identifier column)
+  - `label_column` (optional override for the inferred submission/target column)
 - Optional keys for preprocessing:
   - `force_categorical` (list of column names)
   - `force_numeric` (list of column names)
@@ -80,7 +82,9 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 - No config overrides via CLI or environment variables
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
-- Target inference must resolve to exactly one column
+- `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
+- `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
+- `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Metric resolution must produce a supported metric compatible with the resolved task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
@@ -97,7 +101,9 @@ Hard-error cases include:
 - Partial task/metric inference from Kaggle metadata -> hard error
 - Invalid task/metric pairing (for example `binary` + `rmse`) -> hard error
 - Missing/invalid competition zip contents -> hard error
-- Target inference not exactly one column -> hard error
+- `id_column` inference not exactly one column -> hard error
+- `label_column` inference not exactly one column -> hard error
+- Invalid `id_column` or `label_column` override -> hard error
 - Unknown columns in `force_categorical`, `force_numeric`, or `drop_columns` -> hard error
 - Any overlap between `force_categorical` and `force_numeric` -> hard error
 - No feature columns remaining after `drop_columns` -> hard error

--- a/main.py
+++ b/main.py
@@ -26,6 +26,8 @@ def main() -> None:
     print(f"Data ready: {data_dir}")
     report_dir = run_eda(
         competition_slug=config.competition_slug,
+        id_column=config.id_column,
+        label_column=config.label_column,
         force_categorical=config.force_categorical,
         force_numeric=config.force_numeric,
         drop_columns=config.drop_columns,
@@ -34,6 +36,8 @@ def main() -> None:
     print(f"EDA reports ready: {report_dir}")
     artifact_dir = run_preprocessing(
         competition_slug=config.competition_slug,
+        id_column=config.id_column,
+        label_column=config.label_column,
         force_categorical=config.force_categorical,
         force_numeric=config.force_numeric,
         drop_columns=config.drop_columns,
@@ -44,6 +48,8 @@ def main() -> None:
         competition_slug=config.competition_slug,
         task_type=task_type,
         primary_metric=primary_metric,
+        id_column=config.id_column,
+        label_column=config.label_column,
         force_categorical=config.force_categorical,
         force_numeric=config.force_numeric,
         drop_columns=config.drop_columns,
@@ -58,6 +64,8 @@ def main() -> None:
         run_dir=train_dir,
         submit_enabled=config.submit_enabled,
         submit_message_prefix=config.submit_message_prefix,
+        id_column=config.id_column,
+        label_column=config.label_column,
     )
     print(f"Submission file ready: {submission_path} ({submission_status})")
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -15,6 +15,8 @@ class AppConfig(BaseModel):
     competition_slug: str = Field(min_length=1)
     task_type: Literal["regression", "binary"] | None = None
     primary_metric: str | None = None
+    id_column: str | None = None
+    label_column: str | None = None
     force_categorical: list[str] = Field(default_factory=list)
     force_numeric: list[str] = Field(default_factory=list)
     drop_columns: list[str] = Field(default_factory=list)

--- a/src/tabular_shenanigans/data.py
+++ b/src/tabular_shenanigans/data.py
@@ -14,8 +14,6 @@ SUPPORTED_PRIMARY_METRICS = {
     "log loss": "log_loss",
     "accuracy": "accuracy",
 }
-
-
 def normalize_primary_metric(metric_name: str) -> str | None:
     normalized_name = metric_name.strip().lower()
     if normalized_name in SUPPORTED_PRIMARY_METRICS.values():
@@ -162,8 +160,67 @@ def read_csv_from_zip(zip_path: Path, member_name: str) -> pd.DataFrame:
             return pd.read_csv(f)
 
 
-def infer_target_column(train_df: pd.DataFrame, test_df: pd.DataFrame) -> str:
-    candidate_columns = [col for col in train_df.columns if col not in test_df.columns]
-    if len(candidate_columns) != 1:
-        raise ValueError(f"Could not infer a single target column. Candidates: {candidate_columns}")
-    return candidate_columns[0]
+def resolve_id_and_label_columns(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    sample_submission_df: pd.DataFrame,
+    configured_id_column: str | None = None,
+    configured_label_column: str | None = None,
+) -> tuple[str, str]:
+    train_columns = train_df.columns.tolist()
+    test_columns = test_df.columns.tolist()
+    sample_submission_columns = sample_submission_df.columns.tolist()
+
+    id_candidates = [
+        column
+        for column in train_columns
+        if column in test_columns and column in sample_submission_columns
+    ]
+    label_candidates = [
+        column
+        for column in train_columns
+        if column not in test_columns and column in sample_submission_columns
+    ]
+
+    if configured_id_column is not None:
+        if configured_id_column not in id_candidates:
+            raise ValueError(
+                f"Configured id_column '{configured_id_column}' is invalid. "
+                "Expected a column present in train.csv, test.csv, and sample_submission.csv. "
+                f"Candidates: {id_candidates}"
+            )
+        id_column = configured_id_column
+    else:
+        if len(id_candidates) != 1:
+            raise ValueError(
+                "Could not infer a single id_column. "
+                "Columns present in train.csv, test.csv, and sample_submission.csv: "
+                f"{id_candidates}"
+            )
+        id_column = id_candidates[0]
+
+    if configured_label_column is not None:
+        if configured_label_column not in label_candidates:
+            raise ValueError(
+                f"Configured label_column '{configured_label_column}' is invalid. "
+                "Expected a column present in train.csv and sample_submission.csv but not test.csv. "
+                f"Candidates: {label_candidates}"
+            )
+        label_column = configured_label_column
+    else:
+        if len(label_candidates) != 1:
+            raise ValueError(
+                "Could not infer a single label_column. "
+                "Columns present in train.csv and sample_submission.csv but not test.csv: "
+                f"{label_candidates}"
+            )
+        label_column = label_candidates[0]
+
+    expected_submission_columns = [id_column, label_column]
+    if sample_submission_columns != expected_submission_columns:
+        raise ValueError(
+            "sample_submission.csv must match the resolved schema exactly. "
+            f"Expected columns {expected_submission_columns}, got {sample_submission_columns}"
+        )
+
+    return id_column, label_column

--- a/src/tabular_shenanigans/eda.py
+++ b/src/tabular_shenanigans/eda.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
-from tabular_shenanigans.data import find_competition_zip, infer_target_column, read_csv_from_zip
+from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 from tabular_shenanigans.preprocess import prepare_feature_frames, summarize_feature_types
 
 
@@ -80,6 +80,8 @@ def _target_summary(train_df: pd.DataFrame, target_column: str) -> pd.DataFrame:
 
 def run_eda(
     competition_slug: str,
+    id_column: str | None = None,
+    label_column: str | None = None,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
     drop_columns: list[str] | None = None,
@@ -88,11 +90,18 @@ def run_eda(
     zip_path = find_competition_zip(competition_slug)
     train_df = read_csv_from_zip(zip_path, "train.csv")
     test_df = read_csv_from_zip(zip_path, "test.csv")
-    target_column = infer_target_column(train_df, test_df)
+    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
+    id_column, label_column = resolve_id_and_label_columns(
+        train_df=train_df,
+        test_df=test_df,
+        sample_submission_df=sample_submission_df,
+        configured_id_column=id_column,
+        configured_label_column=label_column,
+    )
     x_train_raw, _, _ = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,
-        target_column=target_column,
+        label_column=label_column,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
         drop_columns=drop_columns,
@@ -108,7 +117,7 @@ def run_eda(
         report_dir / "categorical_cardinality_summary.csv",
         index=False,
     )
-    _target_summary(train_df, target_column).to_csv(report_dir / "target_summary.csv", index=False)
+    _target_summary(train_df, label_column).to_csv(report_dir / "target_summary.csv", index=False)
     feature_type_counts = summarize_feature_types(
         x_train_raw=x_train_raw,
         force_categorical=force_categorical,
@@ -124,7 +133,8 @@ def run_eda(
             {"metric": "train_cols", "value": int(train_df.shape[1])},
             {"metric": "test_rows", "value": int(test_df.shape[0])},
             {"metric": "test_cols", "value": int(test_df.shape[1])},
-            {"metric": "target_column", "value": target_column},
+            {"metric": "id_column", "value": id_column},
+            {"metric": "label_column", "value": label_column},
             {"metric": "train_missing_pct", "value": float(train_df.isna().mean().mean())},
             {"metric": "test_missing_pct", "value": float(test_df.isna().mean().mean())},
             {"metric": "train_duplicate_rows", "value": int(train_df.duplicated().sum())},
@@ -136,7 +146,8 @@ def run_eda(
 
     print(f"Train shape: {train_df.shape[0]} rows x {train_df.shape[1]} cols")
     print(f"Test shape: {test_df.shape[0]} rows x {test_df.shape[1]} cols")
-    print(f"Target column: {target_column}")
+    print(f"ID column: {id_column}")
+    print(f"Label column: {label_column}")
     print(f"Train missing pct: {train_df.isna().mean().mean():.6f}")
     print(f"Test missing pct: {test_df.isna().mean().mean():.6f}")
     print(f"Train duplicate rows: {int(train_df.duplicated().sum())}")

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -6,7 +6,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
-from tabular_shenanigans.data import find_competition_zip, infer_target_column, read_csv_from_zip
+from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 
 
 def _validate_column_names(config_name: str, columns: list[str], available_columns: list[str]) -> None:
@@ -45,7 +45,7 @@ def _resolve_feature_types(
 def prepare_feature_frames(
     train_df: pd.DataFrame,
     test_df: pd.DataFrame,
-    target_column: str,
+    label_column: str,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
     drop_columns: list[str] | None = None,
@@ -54,8 +54,8 @@ def prepare_feature_frames(
     force_numeric = force_numeric or []
     drop_columns = drop_columns or []
 
-    x_train_raw = train_df.drop(columns=[target_column])
-    y_train = train_df[target_column]
+    x_train_raw = train_df.drop(columns=[label_column])
+    y_train = train_df[label_column]
     x_test_raw = test_df
 
     _validate_column_names("drop_columns", drop_columns, x_train_raw.columns.tolist())
@@ -142,6 +142,8 @@ def summarize_feature_types(
 
 def run_preprocessing(
     competition_slug: str,
+    id_column: str | None = None,
+    label_column: str | None = None,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
     drop_columns: list[str] | None = None,
@@ -150,7 +152,14 @@ def run_preprocessing(
     zip_path = find_competition_zip(competition_slug)
     train_df = read_csv_from_zip(zip_path, "train.csv")
     test_df = read_csv_from_zip(zip_path, "test.csv")
-    target_column = infer_target_column(train_df, test_df)
+    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
+    id_column, label_column = resolve_id_and_label_columns(
+        train_df=train_df,
+        test_df=test_df,
+        sample_submission_df=sample_submission_df,
+        configured_id_column=id_column,
+        configured_label_column=label_column,
+    )
 
     force_categorical = force_categorical or []
     force_numeric = force_numeric or []
@@ -159,7 +168,7 @@ def run_preprocessing(
     x_train_raw, x_test_raw, y_train = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,
-        target_column=target_column,
+        label_column=label_column,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
         drop_columns=drop_columns,
@@ -184,12 +193,13 @@ def run_preprocessing(
 
     x_train_df.to_csv(artifact_dir / "X_train_processed.csv", index=False)
     x_test_df.to_csv(artifact_dir / "X_test_processed.csv", index=False)
-    y_train.to_frame(name=target_column).to_csv(artifact_dir / "y_train.csv", index=False)
+    y_train.to_frame(name=label_column).to_csv(artifact_dir / "y_train.csv", index=False)
 
     summary_df = pd.DataFrame(
         [
             {"metric": "generated_at_utc", "value": datetime.now(timezone.utc).isoformat()},
-            {"metric": "target_column", "value": target_column},
+            {"metric": "id_column", "value": id_column},
+            {"metric": "label_column", "value": label_column},
             {"metric": "train_rows", "value": int(x_train_df.shape[0])},
             {"metric": "train_cols", "value": int(x_train_df.shape[1])},
             {"metric": "test_rows", "value": int(x_test_df.shape[0])},

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip
+from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 
 
 def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None:
@@ -36,16 +36,30 @@ def _load_run_metadata(run_dir: Path) -> tuple[str, str, str, float]:
     return run_id, model_name, metric_name, metric_mean
 
 
-def prepare_submission_file(competition_slug: str, run_dir: Path) -> Path:
+def prepare_submission_file(
+    competition_slug: str,
+    run_dir: Path,
+    id_column: str | None = None,
+    label_column: str | None = None,
+) -> Path:
     prediction_path = run_dir / "test_predictions.csv"
     if not prediction_path.exists():
         raise ValueError(f"Missing test predictions file: {prediction_path}")
 
     prediction_df = pd.read_csv(prediction_path)
     zip_path = find_competition_zip(competition_slug)
+    train_df = read_csv_from_zip(zip_path, "train.csv")
+    test_df = read_csv_from_zip(zip_path, "test.csv")
     sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
+    resolved_id_column, resolved_label_column = resolve_id_and_label_columns(
+        train_df=train_df,
+        test_df=test_df,
+        sample_submission_df=sample_submission_df,
+        configured_id_column=id_column,
+        configured_label_column=label_column,
+    )
 
-    expected_columns = sample_submission_df.columns.tolist()
+    expected_columns = [resolved_id_column, resolved_label_column]
     actual_columns = prediction_df.columns.tolist()
 
     if actual_columns != expected_columns:
@@ -80,8 +94,15 @@ def run_submission(
     run_dir: Path,
     submit_enabled: bool,
     submit_message_prefix: str | None = None,
+    id_column: str | None = None,
+    label_column: str | None = None,
 ) -> tuple[Path, str]:
-    submission_path = prepare_submission_file(competition_slug=competition_slug, run_dir=run_dir)
+    submission_path = prepare_submission_file(
+        competition_slug=competition_slug,
+        run_dir=run_dir,
+        id_column=id_column,
+        label_column=label_column,
+    )
     message = build_submission_message(run_dir=run_dir, submit_message_prefix=submit_message_prefix)
     run_id, model_name, metric_name, metric_mean = _load_run_metadata(run_dir)
 

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sklearn.linear_model import ElasticNet, LogisticRegression
 
 from tabular_shenanigans.cv import build_splitter, is_higher_better, score_predictions
-from tabular_shenanigans.data import find_competition_zip, infer_target_column, read_csv_from_zip
+from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
 
@@ -122,6 +122,8 @@ def run_training(
     competition_slug: str,
     task_type: str,
     primary_metric: str,
+    id_column: str | None = None,
+    label_column: str | None = None,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
     drop_columns: list[str] | None = None,
@@ -133,12 +135,19 @@ def run_training(
     zip_path = find_competition_zip(competition_slug)
     train_df = read_csv_from_zip(zip_path, "train.csv")
     test_df = read_csv_from_zip(zip_path, "test.csv")
-    target_column = infer_target_column(train_df, test_df)
+    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
+    id_column, label_column = resolve_id_and_label_columns(
+        train_df=train_df,
+        test_df=test_df,
+        sample_submission_df=sample_submission_df,
+        configured_id_column=id_column,
+        configured_label_column=label_column,
+    )
 
     x_train_raw, x_test_raw, y_train = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,
-        target_column=target_column,
+        label_column=label_column,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
         drop_columns=drop_columns,
@@ -258,21 +267,20 @@ def run_training(
     )
     oof_df.to_csv(run_dir / "oof_predictions.csv", index=False)
 
-    if "Id" in test_df.columns:
-        test_predictions_df = pd.DataFrame(
-            {
-                "Id": test_df["Id"].to_numpy(),
-                target_column: mean_test_predictions,
-            }
-        )
-    else:
-        test_predictions_df = pd.DataFrame({target_column: mean_test_predictions})
+    test_predictions_df = pd.DataFrame(
+        {
+            id_column: test_df[id_column].to_numpy(),
+            label_column: mean_test_predictions,
+        }
+    )
     test_predictions_df.to_csv(run_dir / "test_predictions.csv", index=False)
 
     config_snapshot = {
         "competition_slug": competition_slug,
         "task_type": task_type,
         "primary_metric": primary_metric,
+        "id_column": id_column,
+        "label_column": label_column,
         "force_categorical": force_categorical or [],
         "force_numeric": force_numeric or [],
         "drop_columns": drop_columns or [],
@@ -299,7 +307,8 @@ def run_training(
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
-        "target_column": target_column,
+        "id_column": id_column,
+        "label_column": label_column,
         "target_summary": target_summary,
         "train_rows": int(x_train_raw.shape[0]),
         "train_cols": int(x_train_raw.shape[1]),


### PR DESCRIPTION
## Summary
- infer `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`
- add optional config overrides for both columns and validate them against dataset files
- remove the hardcoded `Id` assumption from training outputs and submission validation

## Verification
- `uv run python main.py`
- `uv run python -c "import sys; sys.path.insert(0, 'src'); from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns; z=find_competition_zip('house-prices-advanced-regression-techniques'); train=read_csv_from_zip(z,'train.csv'); test=read_csv_from_zip(z,'test.csv'); sample=read_csv_from_zip(z,'sample_submission.csv'); print(resolve_id_and_label_columns(train,test,sample)); print(resolve_id_and_label_columns(train,test,sample, configured_id_column='Id', configured_label_column='SalePrice'))"`
- `uv run python -c "import sys; sys.path.insert(0, 'src'); from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns; z=find_competition_zip('house-prices-advanced-regression-techniques'); train=read_csv_from_zip(z,'train.csv'); test=read_csv_from_zip(z,'test.csv'); sample=read_csv_from_zip(z,'sample_submission.csv'); resolve_id_and_label_columns(train,test,sample, configured_id_column='PassengerId')"` (expected failure)

## Notes
- left local `config.yaml` changes out of this PR
- split Playground-series verification and example alignment into #9
