### PR TITLE
Support non-0/1 binary labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Config-driven Python workflows for semi-automated participation in tabular Kaggl
 
 ## Development Defaults
 The repository is developed and manually verified primarily against these Playground Series competitions:
-- default classification target: `playground-series-s5e12` with `primary_metric: roc_auc`
+- default classification target: `playground-series-s6e3` with `primary_metric: roc_auc`
 - default regression target: `playground-series-s5e10` with `primary_metric: mse`
 
 ## Current Capabilities
@@ -73,13 +73,13 @@ If `id_column` or `label_column` are omitted, the pipeline infers them from `tra
 
 ## Preferred Manual Verification Targets
 Use these Playground competitions as the primary smoke tests:
-- binary classification: `playground-series-s5e12` with `task_type: binary` and `primary_metric: roc_auc`
+- binary classification: `playground-series-s6e3` with `task_type: binary` and `primary_metric: roc_auc`
 - regression: `playground-series-s5e10` with `task_type: regression` and `primary_metric: mse`
 
 Example binary config:
 
 ```yaml
-competition_slug: playground-series-s5e12
+competition_slug: playground-series-s6e3
 task_type: binary
 primary_metric: roc_auc
 ```
@@ -111,6 +111,7 @@ Manual verification for each target:
 - Kaggle CLI is installed, authenticated, and has access to the configured competition.
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
+- Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
 - `task_type` and `primary_metric` are explicitly configured for every run.
 - Runtime config comes from `config.yaml` only; there are no CLI or environment overrides.
 - The current workflow is CPU-first and optimized for iteration speed over production hardening.

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-competition_slug: playground-series-s5e12
+competition_slug: playground-series-s6e3
 task_type: binary
 primary_metric: roc_auc
 # Optional runtime settings.
@@ -6,4 +6,4 @@ primary_metric: roc_auc
 # cv_shuffle: true
 # cv_random_state: 42
 # submit_enabled: true
-# submit_message_prefix: baseline-linear
+# submit_message_prefix: s6e3-logreg-baseline

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -2,7 +2,7 @@
 
 Technical reference for the current repository design. Use GitHub issues and pull requests for active implementation tracking; this document describes the system as it exists and the contracts it is expected to preserve.
 
-The intended operating scope is Kaggle Playground Series tabular competitions. Current default development targets are `playground-series-s5e12` for binary classification with `primary_metric: roc_auc` and `playground-series-s5e10` for regression with `primary_metric: mse`.
+The intended operating scope is Kaggle Playground Series tabular competitions. Current default development targets are `playground-series-s6e3` for binary classification with `primary_metric: roc_auc` and `playground-series-s5e10` for regression with `primary_metric: mse`.
 
 ## System Flow
 1. Load and validate the repository-root `config.yaml`.
@@ -57,7 +57,7 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 Configured metrics are normalized to the internal metric names during config validation.
 
 ## Preferred Verification Targets
-- `playground-series-s5e12`: binary smoke test with `task_type: binary` and `primary_metric: roc_auc`
+- `playground-series-s6e3`: binary smoke test with `task_type: binary` and `primary_metric: roc_auc`
 - `playground-series-s5e10`: regression smoke test with `task_type: regression` and `primary_metric: mse`
 
 Manual verification steps for each target:
@@ -98,6 +98,7 @@ Manual verification steps for each target:
 - `task_type` and `primary_metric` must be present in config for every run
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
+- Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`

--- a/src/tabular_shenanigans/cv.py
+++ b/src/tabular_shenanigans/cv.py
@@ -21,7 +21,24 @@ def build_splitter(task_type: str, n_splits: int, shuffle: bool, random_state: i
     raise ValueError(f"Unsupported task_type for CV splitter: {task_type}")
 
 
-def score_predictions(task_type: str, primary_metric: str, y_true: pd.Series, y_pred: np.ndarray) -> float:
+def resolve_binary_labels(y_values: pd.Series) -> tuple[object, object]:
+    unique_labels = pd.unique(y_values)
+    if len(unique_labels) != 2:
+        raise ValueError(f"Binary tasks require exactly two unique labels, got {len(unique_labels)}: {list(unique_labels)}")
+
+    ordered_labels = sorted(unique_labels.tolist())
+    negative_label = ordered_labels[0]
+    positive_label = ordered_labels[1]
+    return negative_label, positive_label
+
+
+def score_predictions(
+    task_type: str,
+    primary_metric: str,
+    y_true: pd.Series,
+    y_pred: np.ndarray,
+    positive_label: object | None = None,
+) -> float:
     if task_type == "regression":
         y_true_array = y_true.to_numpy()
         y_pred_array = np.asarray(y_pred)
@@ -39,13 +56,18 @@ def score_predictions(task_type: str, primary_metric: str, y_true: pd.Series, y_
     if task_type == "binary":
         y_true_array = y_true.to_numpy()
         y_pred_array = np.asarray(y_pred)
+        if positive_label is None:
+            raise ValueError("Binary scoring requires positive_label.")
+        negative_label, _ = resolve_binary_labels(y_true)
         if primary_metric == "roc_auc":
-            return float(roc_auc_score(y_true_array, y_pred_array))
+            y_true_binary = (y_true == positive_label).astype(int).to_numpy()
+            return float(roc_auc_score(y_true_binary, y_pred_array))
         if primary_metric == "log_loss":
-            return float(log_loss(y_true_array, y_pred_array))
+            y_true_binary = (y_true == positive_label).astype(int).to_numpy()
+            return float(log_loss(y_true_binary, y_pred_array))
         if primary_metric == "accuracy":
-            labels = (y_pred_array >= 0.5).astype(int)
-            return float(accuracy_score(y_true_array, labels))
+            predicted_labels = np.where(y_pred_array >= 0.5, positive_label, negative_label)
+            return float(accuracy_score(y_true_array, predicted_labels))
         raise ValueError(f"Unsupported binary metric: {primary_metric}")
 
     raise ValueError(f"Unsupported task_type for scoring: {task_type}")

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from sklearn.linear_model import ElasticNet, LogisticRegression
 
-from tabular_shenanigans.cv import build_splitter, is_higher_better, score_predictions
+from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_binary_labels, score_predictions
 from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
@@ -58,10 +58,12 @@ def _build_target_summary(task_type: str, y_train: pd.Series) -> dict[str, objec
         }
 
     if task_type == "binary":
-        positive_count = int(y_train.sum())
+        _, positive_label = resolve_binary_labels(y_train)
+        positive_count = int((y_train == positive_label).sum())
         row_count = int(y_train.shape[0])
         negative_count = row_count - positive_count
         return {
+            "positive_label": str(positive_label),
             "positive_count": positive_count,
             "negative_count": negative_count,
             "target_prevalence": float(positive_count / row_count),
@@ -75,6 +77,7 @@ def _build_diagnostic_rows(
     fold_index: int,
     split_name: str,
     y_values: pd.Series,
+    positive_label: object | None = None,
 ) -> list[dict[str, object]]:
     row = {
         "task_type": task_type,
@@ -103,11 +106,14 @@ def _build_diagnostic_rows(
         return [row]
 
     if task_type == "binary":
-        positive_count = int(y_values.sum())
+        if positive_label is None:
+            raise ValueError("Binary diagnostics require positive_label.")
+        positive_count = int((y_values == positive_label).sum())
         negative_count = int(y_values.shape[0] - positive_count)
         row.update(
             {
                 "diagnostic_type": "class_balance",
+                "positive_label": str(positive_label),
                 "positive_count": positive_count,
                 "negative_count": negative_count,
                 "positive_rate": float(positive_count / y_values.shape[0]),
@@ -152,6 +158,9 @@ def run_training(
         force_numeric=force_numeric,
         drop_columns=drop_columns,
     )
+    positive_label = None
+    if task_type == "binary":
+        _, positive_label = resolve_binary_labels(y_train)
 
     model_name, _, model_params = _build_model(task_type, cv_random_state)
     splitter = build_splitter(
@@ -167,7 +176,15 @@ def run_training(
     test_predictions_per_fold: list[np.ndarray] = []
     fold_metrics: list[dict[str, object]] = []
     run_diagnostics: list[dict[str, object]] = []
-    run_diagnostics.extend(_build_diagnostic_rows(task_type=task_type, fold_index=0, split_name="all", y_values=y_train))
+    run_diagnostics.extend(
+        _build_diagnostic_rows(
+            task_type=task_type,
+            fold_index=0,
+            split_name="all",
+            y_values=y_train,
+            positive_label=positive_label,
+        )
+    )
 
     for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train_raw, y_train), start=1):
         x_fold_train = x_train_raw.iloc[train_idx]
@@ -175,10 +192,22 @@ def run_training(
         y_fold_train = y_train.iloc[train_idx]
         y_fold_valid = y_train.iloc[valid_idx]
         run_diagnostics.extend(
-            _build_diagnostic_rows(task_type=task_type, fold_index=fold_index, split_name="train", y_values=y_fold_train)
+            _build_diagnostic_rows(
+                task_type=task_type,
+                fold_index=fold_index,
+                split_name="train",
+                y_values=y_fold_train,
+                positive_label=positive_label,
+            )
         )
         run_diagnostics.extend(
-            _build_diagnostic_rows(task_type=task_type, fold_index=fold_index, split_name="valid", y_values=y_fold_valid)
+            _build_diagnostic_rows(
+                task_type=task_type,
+                fold_index=fold_index,
+                split_name="valid",
+                y_values=y_fold_valid,
+                positive_label=positive_label,
+            )
         )
 
         preprocessor, _, _ = build_preprocessor(
@@ -196,8 +225,11 @@ def run_training(
         model.fit(x_fold_train_processed, y_fold_train)
 
         if task_type == "binary":
-            fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, 1]
-            fold_test_predictions = model.predict_proba(x_test_processed)[:, 1]
+            if positive_label is None:
+                raise ValueError("Binary training requires positive_label.")
+            positive_class_index = list(model.classes_).index(positive_label)
+            fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, positive_class_index]
+            fold_test_predictions = model.predict_proba(x_test_processed)[:, positive_class_index]
         else:
             fold_valid_predictions = model.predict(x_fold_valid_processed)
             fold_test_predictions = model.predict(x_test_processed)
@@ -207,6 +239,7 @@ def run_training(
             primary_metric=primary_metric,
             y_true=y_fold_valid,
             y_pred=fold_valid_predictions,
+            positive_label=positive_label,
         )
 
         oof_predictions[valid_idx] = fold_valid_predictions


### PR DESCRIPTION
## Summary
- support binary labels such as Yes/No throughout diagnostics, scoring, and predict_proba handling
- switch the default binary smoke target to playground-series-s6e3
- document the widened binary-label contract

## Verification
- ran Resolved competition setup: task_type=binary, primary_metric=roc_auc
Data ready: data/playground-series-s6e3
Train shape: 594194 rows x 21 cols
Test shape: 254655 rows x 20 cols
ID column: id
Label column: Churn
Train missing pct: 0.000000
Test missing pct: 0.000000
Train duplicate rows: 0
Test duplicate rows: 0
Feature count after drop_columns: 20
EDA reports ready: reports/playground-series-s6e3
Preprocessed train shape: 594194 rows x 46 cols
Preprocessed test shape: 254655 rows x 46 cols
Preprocessing artifacts ready: artifacts/playground-series-s6e3/preprocess
Training model: LogisticRegression
CV roc_auc: mean=0.907950, std=0.001215
Training artifacts ready: artifacts/playground-series-s6e3/train/20260306T183450Z
Submission dry-run mode: validation complete, Kaggle submit skipped.
Submission file ready: artifacts/playground-series-s6e3/train/20260306T183450Z/submission.csv (prepared) for 
- observed CV roc_auc 0.907950 and prepared submission artifacts
- reran with  and successfully submitted to Kaggle

Closes #12