### PR TITLE
Restore s5e12 as binary dev default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Config-driven Python workflows for semi-automated participation in tabular Kaggl
 
 ## Development Defaults
 The repository is developed and manually verified primarily against these Playground Series competitions:
-- default classification target: `playground-series-s6e3` with `primary_metric: roc_auc`
+- default classification development target: `playground-series-s5e12` with `primary_metric: roc_auc`
+- classification production target: `playground-series-s6e3` with `primary_metric: roc_auc`
 - default regression target: `playground-series-s5e10` with `primary_metric: mse`
 
 ## Current Capabilities
@@ -73,13 +74,14 @@ If `id_column` or `label_column` are omitted, the pipeline infers them from `tra
 
 ## Preferred Manual Verification Targets
 Use these Playground competitions as the primary smoke tests:
-- binary classification: `playground-series-s6e3` with `task_type: binary` and `primary_metric: roc_auc`
+- binary classification (dev): `playground-series-s5e12` with `task_type: binary` and `primary_metric: roc_auc`
+- binary classification (prod target): `playground-series-s6e3` with `task_type: binary` and `primary_metric: roc_auc`
 - regression: `playground-series-s5e10` with `task_type: regression` and `primary_metric: mse`
 
 Example binary config:
 
 ```yaml
-competition_slug: playground-series-s6e3
+competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-competition_slug: playground-series-s6e3
+competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
 # Optional runtime settings.
@@ -6,4 +6,4 @@ primary_metric: roc_auc
 # cv_shuffle: true
 # cv_random_state: 42
 # submit_enabled: true
-# submit_message_prefix: s6e3-logreg-baseline
+# submit_message_prefix: s5e12-logreg-baseline

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -2,7 +2,7 @@
 
 Technical reference for the current repository design. Use GitHub issues and pull requests for active implementation tracking; this document describes the system as it exists and the contracts it is expected to preserve.
 
-The intended operating scope is Kaggle Playground Series tabular competitions. Current default development targets are `playground-series-s6e3` for binary classification with `primary_metric: roc_auc` and `playground-series-s5e10` for regression with `primary_metric: mse`.
+The intended operating scope is Kaggle Playground Series tabular competitions. Current default development targets are `playground-series-s5e12` for binary classification with `primary_metric: roc_auc` and `playground-series-s5e10` for regression with `primary_metric: mse`. The current binary production target is `playground-series-s6e3` with `primary_metric: roc_auc`.
 
 ## System Flow
 1. Load and validate the repository-root `config.yaml`.
@@ -57,7 +57,8 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 Configured metrics are normalized to the internal metric names during config validation.
 
 ## Preferred Verification Targets
-- `playground-series-s6e3`: binary smoke test with `task_type: binary` and `primary_metric: roc_auc`
+- `playground-series-s5e12`: binary development smoke test with `task_type: binary` and `primary_metric: roc_auc`
+- `playground-series-s6e3`: binary production-target smoke test with `task_type: binary` and `primary_metric: roc_auc`
 - `playground-series-s5e10`: regression smoke test with `task_type: regression` and `primary_metric: mse`
 
 Manual verification steps for each target:


### PR DESCRIPTION
## Summary
- restore `playground-series-s5e12` as the default binary development target
- keep `playground-series-s6e3` documented as the binary production target
- update the repo-root default config and verification docs to match

Closes #19