### PR TITLE
Exclude inferred id_column from modeled features

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
+- Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Build preprocessing artifacts under `artifacts/<competition_slug>/preprocess/`.
 - Train baseline cross-validated models with fold-local preprocessing:
@@ -50,13 +51,13 @@ Required keys:
 - `primary_metric`: one of `rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`
 
 Optional submission schema keys:
-- `id_column`: override for the inferred identifier column
+- `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
 - `label_column`: override for the inferred submission/target column
 
 Optional preprocessing keys:
 - `force_categorical`: list of feature names to force into the categorical pipeline
 - `force_numeric`: list of feature names to force into the numeric pipeline
-- `drop_columns`: list of feature names to remove before preprocessing
+- `drop_columns`: additional feature names to remove before preprocessing after the ID column is already excluded by default
 - `low_cardinality_int_threshold`: integer columns at or below this unique-count threshold are treated as categorical by default
 
 Optional CV keys:
@@ -68,7 +69,7 @@ Optional submission keys:
 - `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `submit_message_prefix`: optional prefix used in auto-generated submission messages
 
-If `id_column` or `label_column` are omitted, the pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. Invalid overrides, ambiguous inference, or a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]` are hard errors.
+If `id_column` or `label_column` are omitted, the pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and submission validation, but it is not part of the model feature matrix. Invalid overrides, ambiguous inference, or a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]` are hard errors.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -113,6 +114,7 @@ Manual verification for each target:
 - Kaggle CLI is installed, authenticated, and has access to the configured competition.
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
+- The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
 - `task_type` and `primary_metric` are explicitly configured for every run.
 - Runtime config comes from `config.yaml` only; there are no CLI or environment overrides.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -10,7 +10,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 3. Download the competition zip into `data/<competition_slug>/` when it is missing.
 4. Read `train.csv`, `test.csv`, and `sample_submission.csv` from the zip as needed.
 5. Run EDA and write report CSVs under `reports/<competition_slug>/`.
-6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data.
+6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
 7. Build preprocessing for the selected feature types:
    - numeric: median imputation + `StandardScaler`
    - categorical: most-frequent imputation + `OneHotEncoder`
@@ -38,12 +38,12 @@ Input:
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
 - Optional submission schema keys:
-  - `id_column` (optional override for the inferred identifier column)
+  - `id_column` (optional override for the inferred identifier column; resolved IDs are kept as metadata and excluded from modeled features)
   - `label_column` (optional override for the inferred submission/target column)
 - Optional keys for preprocessing:
   - `force_categorical` (list of column names)
   - `force_numeric` (list of column names)
-  - `drop_columns` (list of column names)
+  - `drop_columns` (list of additional modeled-feature columns to remove after the ID column is excluded by default)
   - `low_cardinality_int_threshold` (positive integer)
 - Optional keys for CV:
   - `cv_n_splits` (integer >= 2, default 7)
@@ -101,6 +101,7 @@ Manual verification steps for each target:
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
 - Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
+- The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
@@ -123,7 +124,7 @@ Hard-error cases include:
 - Invalid `id_column` or `label_column` override -> hard error
 - Unknown columns in `force_categorical`, `force_numeric`, or `drop_columns` -> hard error
 - Any overlap between `force_categorical` and `force_numeric` -> hard error
-- No feature columns remaining after `drop_columns` -> hard error
+- No modeled feature columns remaining after excluding `id_column` and applying `drop_columns` -> hard error
 - Preprocessing fit/transform failure -> hard error
 - Unsupported task type for CV/model selection -> hard error
 - Unsupported metric for chosen task -> hard error

--- a/src/tabular_shenanigans/eda.py
+++ b/src/tabular_shenanigans/eda.py
@@ -101,6 +101,7 @@ def run_eda(
     x_train_raw, _, _ = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,
+        id_column=id_column,
         label_column=label_column,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
@@ -139,7 +140,7 @@ def run_eda(
             {"metric": "test_missing_pct", "value": float(test_df.isna().mean().mean())},
             {"metric": "train_duplicate_rows", "value": int(train_df.duplicated().sum())},
             {"metric": "test_duplicate_rows", "value": int(test_df.duplicated().sum())},
-            {"metric": "feature_count_after_drop_columns", "value": int(x_train_raw.shape[1])},
+            {"metric": "model_feature_count", "value": int(x_train_raw.shape[1])},
         ]
     )
     run_summary.to_csv(report_dir / "run_summary.csv", index=False)
@@ -152,6 +153,6 @@ def run_eda(
     print(f"Test missing pct: {test_df.isna().mean().mean():.6f}")
     print(f"Train duplicate rows: {int(train_df.duplicated().sum())}")
     print(f"Test duplicate rows: {int(test_df.duplicated().sum())}")
-    print(f"Feature count after drop_columns: {int(x_train_raw.shape[1])}")
+    print(f"Modeled feature count: {int(x_train_raw.shape[1])}")
 
     return report_dir

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -46,6 +46,7 @@ def _resolve_feature_types(
 def prepare_feature_frames(
     train_df: pd.DataFrame,
     test_df: pd.DataFrame,
+    id_column: str,
     label_column: str,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
@@ -55,21 +56,24 @@ def prepare_feature_frames(
     force_numeric = force_numeric or []
     drop_columns = drop_columns or []
 
-    x_train_raw = train_df.drop(columns=[label_column])
-    y_train = train_df[label_column]
-    x_test_raw = test_df
+    available_feature_columns = train_df.drop(columns=[label_column]).columns.tolist()
+    _validate_column_names("drop_columns", drop_columns, available_feature_columns)
 
-    _validate_column_names("drop_columns", drop_columns, x_train_raw.columns.tolist())
+    excluded_feature_columns = [id_column]
+    excluded_feature_columns.extend(
+        column for column in drop_columns if column != id_column
+    )
+
+    x_train_raw = train_df.drop(columns=[label_column, *excluded_feature_columns])
+    y_train = train_df[label_column]
+    x_test_raw = test_df.drop(columns=excluded_feature_columns)
+
     _validate_column_names("force_categorical", force_categorical, x_train_raw.columns.tolist())
     _validate_column_names("force_numeric", force_numeric, x_train_raw.columns.tolist())
 
     overlap = sorted(set(force_categorical).intersection(force_numeric))
     if overlap:
         raise ValueError(f"Columns cannot be both forced categorical and forced numeric: {overlap}")
-
-    if drop_columns:
-        x_train_raw = x_train_raw.drop(columns=drop_columns)
-        x_test_raw = x_test_raw.drop(columns=drop_columns)
 
     return x_train_raw, x_test_raw, y_train
 
@@ -117,7 +121,7 @@ def build_preprocessor(
     if categorical_columns:
         transformers.append(("cat", categorical_pipeline, categorical_columns))
     if not transformers:
-        raise ValueError("No features remain after applying drop_columns.")
+        raise ValueError("No modeled features remain after excluding id_column and applying drop_columns.")
 
     preprocessor = ColumnTransformer(transformers=transformers, remainder="drop")
     return preprocessor, numeric_columns, categorical_columns
@@ -176,6 +180,7 @@ def run_preprocessing(
     x_train_raw, x_test_raw, y_train = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,
+        id_column=id_column,
         label_column=label_column,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
@@ -214,7 +219,9 @@ def run_preprocessing(
             {"metric": "test_cols", "value": int(x_test_df.shape[1])},
             {"metric": "numeric_feature_count", "value": len(numeric_columns)},
             {"metric": "categorical_feature_count", "value": len(categorical_columns)},
-            {"metric": "dropped_feature_count", "value": len(drop_columns)},
+            {"metric": "model_feature_count", "value": int(x_train_raw.shape[1])},
+            {"metric": "config_drop_column_count", "value": len(drop_columns)},
+            {"metric": "excluded_id_column", "value": id_column},
         ]
     )
     summary_df.to_csv(artifact_dir / "preprocess_summary.csv", index=False)

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -153,6 +153,7 @@ def run_training(
     x_train_raw, x_test_raw, y_train = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,
+        id_column=id_column,
         label_column=label_column,
         force_categorical=force_categorical,
         force_numeric=force_numeric,


### PR DESCRIPTION
## Summary
- exclude the resolved id column from modeled feature frames by default
- keep EDA and preprocessing summaries aligned with modeled-feature semantics
- document id_column as metadata rather than training signal

## Verification
- uv run python main.py

Closes #17