### PR TITLE
Validate submission IDs against sample submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The repository is developed and manually verified primarily against these Playgr
   - regression: `ElasticNet`
   - binary classification: `LogisticRegression`
 - Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
-- Validate predictions against `sample_submission.csv` and optionally submit to Kaggle.
+- Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle.
 
 ## Tooling
 - Python for orchestration
@@ -69,7 +69,7 @@ Optional submission keys:
 - `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `submit_message_prefix`: optional prefix used in auto-generated submission messages
 
-If `id_column` or `label_column` are omitted, the pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and submission validation, but it is not part of the model feature matrix. Invalid overrides, ambiguous inference, or a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]` are hard errors.
+If `id_column` or `label_column` are omitted, the pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and submission validation, but it is not part of the model feature matrix. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -99,7 +99,7 @@ Manual verification for each target:
 - confirm the competition archive includes `train.csv`, `test.csv`, and `sample_submission.csv`
 - confirm the pipeline infers `id_column` and `label_column` without overrides
 - confirm `artifacts/<competition_slug>/train/<run_id>/test_predictions.csv` is written
-- confirm `artifacts/<competition_slug>/train/<run_id>/submission.csv` is written and validated against `sample_submission.csv`
+- confirm `artifacts/<competition_slug>/train/<run_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
 
 ## Outputs
 - Competition data: `data/<competition_slug>/`
@@ -115,6 +115,7 @@ Manual verification for each target:
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
+- Submission validation requires `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
 - `task_type` and `primary_metric` are explicitly configured for every run.
 - Runtime config comes from `config.yaml` only; there are no CLI or environment overrides.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -18,7 +18,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
    - regression: `ElasticNet`
    - binary classification: `LogisticRegression`
 9. Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
-10. Validate predictions against `sample_submission.csv`, write `submission.csv`, and optionally submit to Kaggle.
+10. Validate predictions against `sample_submission.csv`, including exact ID content and order, write `submission.csv`, and optionally submit to Kaggle.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading, data fetch, EDA, preprocessing, training, and submission.
@@ -66,7 +66,7 @@ Manual verification steps for each target:
 - run the workflow from a clean repo state with explicit `task_type` and `primary_metric`
 - confirm inferred `id_column` and `label_column`
 - confirm `test_predictions.csv` is generated in the run directory
-- confirm `submission.csv` validates against `sample_submission.csv`
+- confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order
 
 ## Artifact Contract
 - A validated in-memory config object from Pydantic
@@ -104,10 +104,11 @@ Manual verification steps for each target:
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
+- `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
-- Submission output must match the schema and row count of `sample_submission.csv`
+- Submission output must match the schema, row count, and ID ordering/content of `sample_submission.csv`
 - Fail fast is the default behavior; errors are surfaced directly with minimal wrapping
 
 Hard-error cases include:
@@ -130,7 +131,7 @@ Hard-error cases include:
 - Unsupported metric for chosen task -> hard error
 - Any CV/training fit or scoring failure -> hard error
 - Fold assignment gaps in OOF generation -> hard error
-- Submission schema mismatch against `sample_submission.csv` -> hard error
+- Submission schema or ID mismatch against `sample_submission.csv` -> hard error
 - Kaggle submission command failure when `submit_enabled=true` -> hard error
 
 ## Design Guardrails

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -36,6 +36,49 @@ def _load_run_metadata(run_dir: Path) -> tuple[str, str, str, float]:
     return run_id, model_name, metric_name, metric_mean
 
 
+def _validate_submission_ids(
+    prediction_df: pd.DataFrame,
+    sample_submission_df: pd.DataFrame,
+    id_column: str,
+) -> None:
+    prediction_ids = prediction_df[id_column]
+    sample_ids = sample_submission_df[id_column]
+
+    if prediction_ids.duplicated().any():
+        duplicate_ids = prediction_ids[prediction_ids.duplicated(keep=False)].unique().tolist()
+        raise ValueError(
+            "Submission ID column contains duplicate values in test_predictions.csv. "
+            f"Duplicate IDs: {duplicate_ids[:10]}"
+        )
+
+    if sample_ids.duplicated().any():
+        duplicate_ids = sample_ids[sample_ids.duplicated(keep=False)].unique().tolist()
+        raise ValueError(
+            "sample_submission.csv ID column contains duplicate values. "
+            f"Duplicate IDs: {duplicate_ids[:10]}"
+        )
+
+    prediction_id_list = prediction_ids.tolist()
+    sample_id_list = sample_ids.tolist()
+    if prediction_id_list == sample_id_list:
+        return
+
+    prediction_id_set = set(prediction_id_list)
+    sample_id_set = set(sample_id_list)
+    if prediction_id_set == sample_id_set:
+        raise ValueError(
+            "Submission ID order does not match sample_submission.csv. "
+            "IDs contain the same values but appear in a different order."
+        )
+
+    missing_ids = sorted(sample_id_set - prediction_id_set)
+    extra_ids = sorted(prediction_id_set - sample_id_set)
+    raise ValueError(
+        "Submission ID values do not match sample_submission.csv. "
+        f"Missing IDs: {missing_ids[:10]}; extra IDs: {extra_ids[:10]}"
+    )
+
+
 def prepare_submission_file(
     competition_slug: str,
     run_dir: Path,
@@ -72,6 +115,11 @@ def prepare_submission_file(
             "Submission row count does not match sample_submission.csv. "
             f"Expected {sample_submission_df.shape[0]}, got {prediction_df.shape[0]}"
         )
+    _validate_submission_ids(
+        prediction_df=prediction_df,
+        sample_submission_df=sample_submission_df,
+        id_column=resolved_id_column,
+    )
 
     submission_path = run_dir / "submission.csv"
     prediction_df.to_csv(submission_path, index=False)


### PR DESCRIPTION
## Summary
- validate submission IDs against sample_submission.csv values and order
- fail fast for duplicate IDs, shuffled IDs, and missing or extra IDs
- document the stricter submission validation contract

## Verification
- PYTHONPATH=src uv run python - <<'PY'
from pathlib import Path
from tabular_shenanigans.submit import prepare_submission_file
run_dir = Path('artifacts/playground-series-s5e12/train/20260308T100254Z')
print(prepare_submission_file(competition_slug='playground-series-s5e12', run_dir=run_dir))
PY
- manually verified that a temporary reversed test_predictions.csv copy fails with an ID order mismatch error

Closes #11