### PR TITLE
Add explicit positive-label contract for binary competitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Required keys:
 - `task_type`: `regression` or `binary`
 - `primary_metric`: one of `rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`
 
+Optional binary-classification key:
+- `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
+
 Optional submission schema keys:
 - `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
 - `label_column`: override for the inferred submission/target column
@@ -117,6 +120,7 @@ Manual verification for each target:
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - Submission validation requires `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
+- Binary classification requires an explicit positive-class contract. If `positive_label` is omitted, the workflow only auto-resolves the positive class for labels `[0, 1]`, `[False, True]`, or `["No", "Yes"]`; other two-class label pairs fail fast.
 - `task_type` and `primary_metric` are explicitly configured for every run.
 - Runtime config comes from `config.yaml` only; there are no CLI or environment overrides.
 - The current workflow is CPU-first and optimized for iteration speed over production hardening.

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
+# positive_label: "Yes"
 # Optional runtime settings.
 # cv_n_splits: 7
 # cv_shuffle: true

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -37,6 +37,8 @@ Input:
   - `competition_slug`
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
+- Optional binary-classification key:
+  - `positive_label` (explicit positive class for binary competitions; required unless observed labels match one of the documented safe conventions `[0, 1]`, `[False, True]`, or `["No", "Yes"]`)
 - Optional submission schema keys:
   - `id_column` (optional override for the inferred identifier column; resolved IDs are kept as metadata and excluded from modeled features)
   - `label_column` (optional override for the inferred submission/target column)
@@ -100,6 +102,7 @@ Manual verification steps for each target:
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
 - Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
+- Binary classification must have an explicit positive-class contract; when `positive_label` is omitted, the workflow only auto-resolves the positive class for `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`

--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ def main() -> None:
         competition_slug=config.competition_slug,
         task_type=config.task_type,
         primary_metric=config.primary_metric,
+        positive_label=config.positive_label,
         id_column=config.id_column,
         label_column=config.label_column,
         force_categorical=config.force_categorical,

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -17,6 +17,7 @@ class AppConfig(BaseModel):
     competition_slug: str = Field(min_length=1)
     task_type: Literal["regression", "binary"]
     primary_metric: str
+    positive_label: str | int | bool | None = None
     id_column: str | None = None
     label_column: str | None = None
     force_categorical: list[str] = Field(default_factory=list)
@@ -42,6 +43,8 @@ class AppConfig(BaseModel):
                 f"Configured primary_metric '{normalized_primary_metric}' is not valid for task_type '{self.task_type}'."
             )
         self.primary_metric = normalized_primary_metric
+        if self.task_type != "binary" and self.positive_label is not None:
+            raise ValueError("positive_label is only supported for binary task_type.")
         return self
 
 

--- a/src/tabular_shenanigans/cv.py
+++ b/src/tabular_shenanigans/cv.py
@@ -21,15 +21,42 @@ def build_splitter(task_type: str, n_splits: int, shuffle: bool, random_state: i
     raise ValueError(f"Unsupported task_type for CV splitter: {task_type}")
 
 
-def resolve_binary_labels(y_values: pd.Series) -> tuple[object, object]:
+def resolve_binary_label_pair(y_values: pd.Series) -> tuple[object, object]:
     unique_labels = pd.unique(y_values)
     if len(unique_labels) != 2:
         raise ValueError(f"Binary tasks require exactly two unique labels, got {len(unique_labels)}: {list(unique_labels)}")
+    return unique_labels[0], unique_labels[1]
 
-    ordered_labels = sorted(unique_labels.tolist())
-    negative_label = ordered_labels[0]
-    positive_label = ordered_labels[1]
-    return negative_label, positive_label
+
+def resolve_positive_label(
+    y_values: pd.Series,
+    configured_positive_label: object | None = None,
+) -> tuple[object, object, object]:
+    first_label, second_label = resolve_binary_label_pair(y_values)
+    label_pair = (first_label, second_label)
+
+    if configured_positive_label is not None:
+        if configured_positive_label not in label_pair:
+            raise ValueError(
+                "Configured positive_label does not match the observed training labels. "
+                f"Configured value: {configured_positive_label!r}; observed labels: {list(label_pair)!r}"
+            )
+        negative_label = second_label if configured_positive_label == first_label else first_label
+        return negative_label, configured_positive_label, label_pair
+
+    safe_pairs = [
+        (0, 1),
+        (False, True),
+        ("No", "Yes"),
+    ]
+    for negative_label, positive_label in safe_pairs:
+        if set(label_pair) == {negative_label, positive_label}:
+            return negative_label, positive_label, label_pair
+
+    raise ValueError(
+        "Binary competitions require an explicit positive_label unless training labels follow a documented safe "
+        f"convention. Observed labels: {list(label_pair)!r}. Supported implicit pairs: {[list(pair) for pair in safe_pairs]!r}"
+    )
 
 
 def score_predictions(
@@ -58,7 +85,8 @@ def score_predictions(
         y_pred_array = np.asarray(y_pred)
         if positive_label is None:
             raise ValueError("Binary scoring requires positive_label.")
-        negative_label, _ = resolve_binary_labels(y_true)
+        first_label, second_label = resolve_binary_label_pair(y_true)
+        negative_label = second_label if positive_label == first_label else first_label
         if primary_metric == "roc_auc":
             y_true_binary = (y_true == positive_label).astype(int).to_numpy()
             return float(roc_auc_score(y_true_binary, y_pred_array))

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -3,6 +3,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
@@ -34,6 +35,13 @@ def _load_run_metadata(run_dir: Path) -> tuple[str, str, str, float]:
     metric_name = str(summary_df.loc[0, "metric_name"])
     metric_mean = float(summary_df.loc[0, "metric_mean"])
     return run_id, model_name, metric_name, metric_mean
+
+
+def _load_run_manifest(run_dir: Path) -> dict[str, object]:
+    manifest_path = run_dir / "run_manifest.json"
+    if not manifest_path.exists():
+        raise ValueError(f"Missing run manifest: {manifest_path}")
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
 
 
 def _validate_submission_ids(
@@ -115,6 +123,22 @@ def prepare_submission_file(
             "Submission row count does not match sample_submission.csv. "
             f"Expected {sample_submission_df.shape[0]}, got {prediction_df.shape[0]}"
         )
+    manifest = _load_run_manifest(run_dir)
+    task_type = manifest.get("task_type")
+    if task_type is None:
+        config_snapshot = manifest.get("config_snapshot", {})
+        if isinstance(config_snapshot, dict):
+            task_type = config_snapshot.get("task_type")
+    if task_type == "binary":
+        prediction_values = prediction_df[resolved_label_column]
+        if not pd.api.types.is_numeric_dtype(prediction_values):
+            raise ValueError("Binary submission predictions must be numeric probabilities.")
+        if not prediction_values.map(pd.notna).all():
+            raise ValueError("Binary submission predictions contain missing values.")
+        if not np.isfinite(prediction_values.to_numpy(dtype=float)).all():
+            raise ValueError("Binary submission predictions must be finite.")
+        if ((prediction_values < 0.0) | (prediction_values > 1.0)).any():
+            raise ValueError("Binary submission predictions must be within [0, 1].")
     _validate_submission_ids(
         prediction_df=prediction_df,
         sample_submission_df=sample_submission_df,
@@ -192,6 +216,9 @@ def run_submission(
         "metric_name": metric_name,
         "metric_mean": metric_mean,
     }
+    manifest = _load_run_manifest(run_dir)
+    ledger_row["positive_label"] = manifest.get("positive_label")
+    ledger_row["negative_label"] = manifest.get("negative_label")
     ledger_path = Path("artifacts") / competition_slug / "train" / "submissions.csv"
     _append_submission_ledger(ledger_path=ledger_path, row=ledger_row)
 

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from sklearn.linear_model import ElasticNet, LogisticRegression
 
-from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_binary_labels, score_predictions
+from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
@@ -48,7 +48,13 @@ def _append_run_ledger(ledger_path: Path, row: dict[str, object]) -> None:
     ledger_df.to_csv(ledger_path, index=False)
 
 
-def _build_target_summary(task_type: str, y_train: pd.Series) -> dict[str, object]:
+def _build_target_summary(
+    task_type: str,
+    y_train: pd.Series,
+    positive_label: object | None = None,
+    negative_label: object | None = None,
+    observed_label_pair: tuple[object, object] | None = None,
+) -> dict[str, object]:
     if task_type == "regression":
         return {
             "target_mean": float(y_train.mean()),
@@ -58,11 +64,15 @@ def _build_target_summary(task_type: str, y_train: pd.Series) -> dict[str, objec
         }
 
     if task_type == "binary":
-        _, positive_label = resolve_binary_labels(y_train)
+        if positive_label is None or negative_label is None or observed_label_pair is None:
+            raise ValueError("Binary target summary requires resolved label metadata.")
         positive_count = int((y_train == positive_label).sum())
         row_count = int(y_train.shape[0])
         negative_count = row_count - positive_count
         return {
+            "observed_label_1": str(observed_label_pair[0]),
+            "observed_label_2": str(observed_label_pair[1]),
+            "negative_label": str(negative_label),
             "positive_label": str(positive_label),
             "positive_count": positive_count,
             "negative_count": negative_count,
@@ -137,6 +147,7 @@ def run_training(
     cv_n_splits: int = 7,
     cv_shuffle: bool = True,
     cv_random_state: int = 42,
+    positive_label: str | int | bool | None = None,
 ) -> Path:
     zip_path = find_competition_zip(competition_slug)
     train_df = read_csv_from_zip(zip_path, "train.csv")
@@ -159,9 +170,13 @@ def run_training(
         force_numeric=force_numeric,
         drop_columns=drop_columns,
     )
-    positive_label = None
+    observed_label_pair = None
+    negative_label = None
     if task_type == "binary":
-        _, positive_label = resolve_binary_labels(y_train)
+        negative_label, positive_label, observed_label_pair = resolve_positive_label(
+            y_values=y_train,
+            configured_positive_label=positive_label,
+        )
 
     model_name, _, model_params = _build_model(task_type, cv_random_state)
     splitter = build_splitter(
@@ -228,6 +243,8 @@ def run_training(
         if task_type == "binary":
             if positive_label is None:
                 raise ValueError("Binary training requires positive_label.")
+            if negative_label is None:
+                raise ValueError("Binary training requires negative_label.")
             positive_class_index = list(model.classes_).index(positive_label)
             fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, positive_class_index]
             fold_test_predictions = model.predict_proba(x_test_processed)[:, positive_class_index]
@@ -268,7 +285,13 @@ def run_training(
     run_diagnostics_df = pd.DataFrame(run_diagnostics)
     cv_mean = float(fold_metrics_df["metric_value"].mean())
     cv_std = float(fold_metrics_df["metric_value"].std(ddof=0))
-    target_summary = _build_target_summary(task_type=task_type, y_train=y_train)
+    target_summary = _build_target_summary(
+        task_type=task_type,
+        y_train=y_train,
+        positive_label=positive_label,
+        negative_label=negative_label,
+        observed_label_pair=observed_label_pair,
+    )
 
     run_id = _make_run_id()
     run_dir = Path("artifacts") / competition_slug / "train" / run_id
@@ -313,6 +336,7 @@ def run_training(
         "competition_slug": competition_slug,
         "task_type": task_type,
         "primary_metric": primary_metric,
+        "positive_label": positive_label,
         "id_column": id_column,
         "label_column": label_column,
         "force_categorical": force_categorical or [],
@@ -339,8 +363,14 @@ def run_training(
     run_manifest = {
         "run_id": run_id,
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "competition_slug": competition_slug,
+        "task_type": task_type,
+        "primary_metric": primary_metric,
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
+        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
+        "negative_label": negative_label,
+        "positive_label": positive_label,
         "id_column": id_column,
         "label_column": label_column,
         "target_summary": target_summary,


### PR DESCRIPTION
## Summary
- add an explicit positive_label config contract for binary runs
- remove sort-based positive-class inference from training and scoring
- persist resolved label metadata and validate binary submission probabilities

## Verification
- uv run python -m compileall main.py src
- uv run python main.py
- PYTHONPATH=src uv run python - <<'PY'
from tabular_shenanigans.train import run_training
from tabular_shenanigans.submit import run_submission
run_dir = run_training(
    competition_slug='playground-series-s6e3',
    task_type='binary',
    primary_metric='roc_auc',
    positive_label='Yes',
)
run_submission(
    competition_slug='playground-series-s6e3',
    run_dir=run_dir,
    submit_enabled=False,
)
PY
- PYTHONPATH=src uv run python - <<'PY'
import pandas as pd
from tabular_shenanigans.cv import resolve_positive_label
series = pd.Series(['approved', 'denied', 'approved', 'denied'])
try:
    resolve_positive_label(series)
except Exception as exc:
    print(type(exc).__name__)
    print(str(exc))
print(resolve_positive_label(series, configured_positive_label='approved'))
PY

Closes #18