### PR TITLE
Retire standalone preprocessing artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The repository is developed and manually verified primarily against these Playgr
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
-- Build preprocessing artifacts under `artifacts/<competition_slug>/preprocess/`.
 - Train baseline cross-validated models with fold-local preprocessing:
   - regression: `ElasticNet`
   - binary classification: `LogisticRegression`
@@ -42,7 +41,7 @@ The repository is developed and manually verified primarily against these Playgr
 3. Keep a project `config.yaml` at repository root with explicit `competition_slug`, `task_type`, and `primary_metric`.
 4. Run `uv run python main.py`.
 
-The current pipeline fetches competition data if needed, runs config-aware EDA, writes preprocessing artifacts, trains a baseline CV model with task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
+The current pipeline fetches competition data if needed, runs config-aware EDA, trains a baseline CV model with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
 
 ## Config Overview
 Required keys:
@@ -107,7 +106,6 @@ Manual verification for each target:
 ## Outputs
 - Competition data: `data/<competition_slug>/`
 - EDA reports: `reports/<competition_slug>/`
-- Preprocessing artifacts: `artifacts/<competition_slug>/preprocess/`
 - Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
   - includes `fold_metrics.csv`, `cv_summary.csv`, `run_diagnostics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `run_manifest.json`
 - Run ledger: `artifacts/<competition_slug>/train/runs.csv`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -11,17 +11,17 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 4. Read `train.csv`, `test.csv`, and `sample_submission.csv` from the zip as needed.
 5. Run EDA and write report CSVs under `reports/<competition_slug>/`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
-7. Build preprocessing for the selected feature types:
+7. During training, build fold-local preprocessing for the selected feature types:
    - numeric: median imputation + `StandardScaler`
    - categorical: most-frequent imputation + `OneHotEncoder`
-8. Train the baseline model with fold-local preprocessing:
+8. Train the baseline model:
    - regression: `ElasticNet`
    - binary classification: `LogisticRegression`
 9. Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Validate predictions against `sample_submission.csv`, including exact ID content and order, write `submission.csv`, and optionally submit to Kaggle.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading, data fetch, EDA, preprocessing, training, and submission.
+- `main.py`: orchestration entrypoint for config loading, data fetch, EDA, training, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, and dataset schema resolution.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
@@ -82,7 +82,6 @@ Manual verification steps for each target:
   - `target_summary.csv`
   - `feature_type_counts.csv`
   - `run_summary.csv`
-- Preprocessed feature/target CSV files under `artifacts/<competition_slug>/preprocess/`
 - Training artifacts under `artifacts/<competition_slug>/train/<run_id>/`:
   - `fold_metrics.csv`
   - `cv_summary.csv`

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ sys.path.insert(0, str(Path(__file__).parent / "src"))
 from tabular_shenanigans.config import load_config
 from tabular_shenanigans.data import fetch_competition_data
 from tabular_shenanigans.eda import run_eda
-from tabular_shenanigans.preprocess import run_preprocessing
 from tabular_shenanigans.submit import run_submission
 from tabular_shenanigans.train import run_training
 
@@ -29,16 +28,6 @@ def main() -> None:
         low_cardinality_int_threshold=config.low_cardinality_int_threshold,
     )
     print(f"EDA reports ready: {report_dir}")
-    artifact_dir = run_preprocessing(
-        competition_slug=config.competition_slug,
-        id_column=config.id_column,
-        label_column=config.label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
-    )
-    print(f"Preprocessing artifacts ready: {artifact_dir}")
     train_dir = run_training(
         competition_slug=config.competition_slug,
         task_type=config.task_type,

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -1,13 +1,9 @@
-from datetime import datetime, timezone
-from pathlib import Path
-
 import pandas as pd
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
-from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
 
 
 def _validate_column_names(config_name: str, columns: list[str], available_columns: list[str]) -> None:
@@ -150,83 +146,3 @@ def summarize_feature_types(
             {"feature_type": "total", "feature_count": int(x_train_raw.shape[1])},
         ]
     )
-
-
-def run_preprocessing(
-    competition_slug: str,
-    id_column: str | None = None,
-    label_column: str | None = None,
-    force_categorical: list[str] | None = None,
-    force_numeric: list[str] | None = None,
-    drop_columns: list[str] | None = None,
-    low_cardinality_int_threshold: int | None = None,
-) -> Path:
-    zip_path = find_competition_zip(competition_slug)
-    train_df = read_csv_from_zip(zip_path, "train.csv")
-    test_df = read_csv_from_zip(zip_path, "test.csv")
-    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
-    id_column, label_column = resolve_id_and_label_columns(
-        train_df=train_df,
-        test_df=test_df,
-        sample_submission_df=sample_submission_df,
-        configured_id_column=id_column,
-        configured_label_column=label_column,
-    )
-
-    force_categorical = force_categorical or []
-    force_numeric = force_numeric or []
-    drop_columns = drop_columns or []
-
-    x_train_raw, x_test_raw, y_train = prepare_feature_frames(
-        train_df=train_df,
-        test_df=test_df,
-        id_column=id_column,
-        label_column=label_column,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        drop_columns=drop_columns,
-    )
-
-    preprocessor, numeric_columns, categorical_columns = build_preprocessor(
-        x_train_raw=x_train_raw,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        low_cardinality_int_threshold=low_cardinality_int_threshold,
-    )
-
-    x_train_processed = preprocessor.fit_transform(x_train_raw)
-    x_test_processed = preprocessor.transform(x_test_raw)
-    feature_names = preprocessor.get_feature_names_out().tolist()
-
-    artifact_dir = Path("artifacts") / competition_slug / "preprocess"
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-
-    x_train_df = pd.DataFrame(x_train_processed, columns=feature_names)
-    x_test_df = pd.DataFrame(x_test_processed, columns=feature_names)
-
-    x_train_df.to_csv(artifact_dir / "X_train_processed.csv", index=False)
-    x_test_df.to_csv(artifact_dir / "X_test_processed.csv", index=False)
-    y_train.to_frame(name=label_column).to_csv(artifact_dir / "y_train.csv", index=False)
-
-    summary_df = pd.DataFrame(
-        [
-            {"metric": "generated_at_utc", "value": datetime.now(timezone.utc).isoformat()},
-            {"metric": "id_column", "value": id_column},
-            {"metric": "label_column", "value": label_column},
-            {"metric": "train_rows", "value": int(x_train_df.shape[0])},
-            {"metric": "train_cols", "value": int(x_train_df.shape[1])},
-            {"metric": "test_rows", "value": int(x_test_df.shape[0])},
-            {"metric": "test_cols", "value": int(x_test_df.shape[1])},
-            {"metric": "numeric_feature_count", "value": len(numeric_columns)},
-            {"metric": "categorical_feature_count", "value": len(categorical_columns)},
-            {"metric": "model_feature_count", "value": int(x_train_raw.shape[1])},
-            {"metric": "config_drop_column_count", "value": len(drop_columns)},
-            {"metric": "excluded_id_column", "value": id_column},
-        ]
-    )
-    summary_df.to_csv(artifact_dir / "preprocess_summary.csv", index=False)
-
-    print(f"Preprocessed train shape: {x_train_df.shape[0]} rows x {x_train_df.shape[1]} cols")
-    print(f"Preprocessed test shape: {x_test_df.shape[0]} rows x {x_test_df.shape[1]} cols")
-
-    return artifact_dir


### PR DESCRIPTION
## Summary
- remove the standalone preprocess stage from the default pipeline
- delete the unused `run_preprocessing()` artifact writer
- update the README and technical guide to describe training-time fold-local preprocessing only

Closes #24.

## Verification
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall main.py src`
- `PYTHONPATH=src uv run python - <<'PY'`
  smoke-tested `run_eda()`, `run_training()`, and `run_submission()` on `house-prices-advanced-regression-techniques`
  confirmed the existing `artifacts/house-prices-advanced-regression-techniques/preprocess/` directory remained unchanged
  `PY`
