### PR TITLE
Add shared competition dataset loader

### DIFF
--- a/src/tabular_shenanigans/data.py
+++ b/src/tabular_shenanigans/data.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from pathlib import Path
 import subprocess
 import zipfile
@@ -71,6 +72,15 @@ def read_csv_from_zip(zip_path: Path, member_name: str) -> pd.DataFrame:
             return pd.read_csv(f)
 
 
+@dataclass(frozen=True)
+class CompetitionDatasetContext:
+    train_df: pd.DataFrame
+    test_df: pd.DataFrame
+    sample_submission_df: pd.DataFrame
+    id_column: str
+    label_column: str
+
+
 def resolve_id_and_label_columns(
     train_df: pd.DataFrame,
     test_df: pd.DataFrame,
@@ -135,3 +145,28 @@ def resolve_id_and_label_columns(
         )
 
     return id_column, label_column
+
+
+def load_competition_dataset_context(
+    competition_slug: str,
+    configured_id_column: str | None = None,
+    configured_label_column: str | None = None,
+) -> CompetitionDatasetContext:
+    zip_path = find_competition_zip(competition_slug)
+    train_df = read_csv_from_zip(zip_path, "train.csv")
+    test_df = read_csv_from_zip(zip_path, "test.csv")
+    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
+    id_column, label_column = resolve_id_and_label_columns(
+        train_df=train_df,
+        test_df=test_df,
+        sample_submission_df=sample_submission_df,
+        configured_id_column=configured_id_column,
+        configured_label_column=configured_label_column,
+    )
+    return CompetitionDatasetContext(
+        train_df=train_df,
+        test_df=test_df,
+        sample_submission_df=sample_submission_df,
+        id_column=id_column,
+        label_column=label_column,
+    )

--- a/src/tabular_shenanigans/eda.py
+++ b/src/tabular_shenanigans/eda.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
-from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
+from tabular_shenanigans.data import load_competition_dataset_context
 from tabular_shenanigans.preprocess import prepare_feature_frames, summarize_feature_types
 
 
@@ -87,17 +87,16 @@ def run_eda(
     drop_columns: list[str] | None = None,
     low_cardinality_int_threshold: int | None = None,
 ) -> Path:
-    zip_path = find_competition_zip(competition_slug)
-    train_df = read_csv_from_zip(zip_path, "train.csv")
-    test_df = read_csv_from_zip(zip_path, "test.csv")
-    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
-    id_column, label_column = resolve_id_and_label_columns(
-        train_df=train_df,
-        test_df=test_df,
-        sample_submission_df=sample_submission_df,
+    dataset_context = load_competition_dataset_context(
+        competition_slug=competition_slug,
         configured_id_column=id_column,
         configured_label_column=label_column,
     )
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+
     x_train_raw, _, _ = prepare_feature_frames(
         train_df=train_df,
         test_df=test_df,

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
+from tabular_shenanigans.data import load_competition_dataset_context
 
 
 def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None:
@@ -98,17 +98,14 @@ def prepare_submission_file(
         raise ValueError(f"Missing test predictions file: {prediction_path}")
 
     prediction_df = pd.read_csv(prediction_path)
-    zip_path = find_competition_zip(competition_slug)
-    train_df = read_csv_from_zip(zip_path, "train.csv")
-    test_df = read_csv_from_zip(zip_path, "test.csv")
-    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
-    resolved_id_column, resolved_label_column = resolve_id_and_label_columns(
-        train_df=train_df,
-        test_df=test_df,
-        sample_submission_df=sample_submission_df,
+    dataset_context = load_competition_dataset_context(
+        competition_slug=competition_slug,
         configured_id_column=id_column,
         configured_label_column=label_column,
     )
+    sample_submission_df = dataset_context.sample_submission_df
+    resolved_id_column = dataset_context.id_column
+    resolved_label_column = dataset_context.label_column
 
     expected_columns = [resolved_id_column, resolved_label_column]
     actual_columns = prediction_df.columns.tolist()

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sklearn.linear_model import ElasticNet, LogisticRegression
 
 from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_positive_label, score_predictions
-from tabular_shenanigans.data import find_competition_zip, read_csv_from_zip, resolve_id_and_label_columns
+from tabular_shenanigans.data import load_competition_dataset_context
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
 
@@ -149,17 +149,15 @@ def run_training(
     cv_random_state: int = 42,
     positive_label: str | int | bool | None = None,
 ) -> Path:
-    zip_path = find_competition_zip(competition_slug)
-    train_df = read_csv_from_zip(zip_path, "train.csv")
-    test_df = read_csv_from_zip(zip_path, "test.csv")
-    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
-    id_column, label_column = resolve_id_and_label_columns(
-        train_df=train_df,
-        test_df=test_df,
-        sample_submission_df=sample_submission_df,
+    dataset_context = load_competition_dataset_context(
+        competition_slug=competition_slug,
         configured_id_column=id_column,
         configured_label_column=label_column,
     )
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
 
     x_train_raw, x_test_raw, y_train = prepare_feature_frames(
         train_df=train_df,


### PR DESCRIPTION
## Summary
- add a small shared dataset-context helper in `data.py`
- reuse that helper from EDA, training, and submission
- keep schema inference and validation behavior unchanged while removing the repeated loader block from the call sites

Closes #25.

## Verification
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall main.py src`
- `PYTHONPATH=src uv run python - <<'PY'`
  smoke-tested `run_eda()`, `run_training()`, and `run_submission()` on `house-prices-advanced-regression-techniques`
  `PY`
