### PR TITLE
Collapse per-run metadata to a canonical manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Train baseline cross-validated models with fold-local preprocessing:
   - regression: `ElasticNet`
   - binary classification: `LogisticRegression`
-- Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
+- Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle.
 
 ## Tooling
@@ -107,9 +107,10 @@ Manual verification for each target:
 - Competition data: `data/<competition_slug>/`
 - EDA reports: `reports/<competition_slug>/`
 - Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
-  - includes `fold_metrics.csv`, `cv_summary.csv`, `run_diagnostics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `run_manifest.json`
-- Run ledger: `artifacts/<competition_slug>/train/runs.csv`
-- Submission ledger: `artifacts/<competition_slug>/train/submissions.csv`
+  - includes `fold_metrics.csv`, `run_diagnostics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `run_manifest.json`
+  - `run_manifest.json` is the canonical per-run metadata source
+- Run ledger: `artifacts/<competition_slug>/train/runs.csv` as a compact comparison/history table
+- Submission ledger: `artifacts/<competition_slug>/train/submissions.csv` as an append-only submission event table
 
 ## Current Assumptions
 - Kaggle CLI is installed, authenticated, and has access to the configured competition.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -17,7 +17,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 8. Train the baseline model:
    - regression: `ElasticNet`
    - binary classification: `LogisticRegression`
-9. Write fold metrics, CV summary, task-aware run diagnostics, OOF predictions, test predictions, and a run manifest under `artifacts/<competition_slug>/train/<run_id>/`.
+9. Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Validate predictions against `sample_submission.csv`, including exact ID content and order, write `submission.csv`, and optionally submit to Kaggle.
 
 ## Module Responsibilities
@@ -84,15 +84,15 @@ Manual verification steps for each target:
   - `run_summary.csv`
 - Training artifacts under `artifacts/<competition_slug>/train/<run_id>/`:
   - `fold_metrics.csv`
-  - `cv_summary.csv`
   - `run_diagnostics.csv`
   - `oof_predictions.csv`
   - `test_predictions.csv`
   - `run_manifest.json`
-- Training ledger at `artifacts/<competition_slug>/train/runs.csv` with task, metric, CV metadata, task-aware target summary fields, and artifact paths
+- `run_manifest.json` is the canonical per-run metadata source
+- Training ledger at `artifacts/<competition_slug>/train/runs.csv` with compact comparison fields and task-aware target summary fields
 - Submission artifact in each run dir:
   - `submission.csv`
-- Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv`
+- Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv` with submission event metadata only
 
 ## Runtime Invariants And Failure Behavior
 - One runtime config source only: `config.yaml`

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import subprocess
 from datetime import datetime, timezone
@@ -8,33 +9,72 @@ import pandas as pd
 
 from tabular_shenanigans.data import load_competition_dataset_context
 
+SUBMISSION_LEDGER_COLUMNS = [
+    "timestamp_utc",
+    "competition_slug",
+    "run_id",
+    "config_fingerprint",
+    "submission_path",
+    "submit_enabled",
+    "status",
+    "message",
+]
+
+
+def _read_submission_ledger(ledger_path: Path) -> pd.DataFrame:
+    with ledger_path.open(encoding="utf-8", newline="") as ledger_file:
+        rows = list(csv.reader(ledger_file))
+
+    if not rows:
+        return pd.DataFrame()
+
+    header = rows[0]
+    if not header:
+        return pd.DataFrame()
+
+    max_column_count = max(len(row) for row in rows[1:]) if len(rows) > 1 else len(header)
+    normalized_header = header.copy()
+    legacy_extra_columns = ["positive_label", "negative_label"]
+    while len(normalized_header) < max_column_count:
+        extra_index = len(normalized_header) - len(header)
+        if extra_index < len(legacy_extra_columns):
+            normalized_header.append(legacy_extra_columns[extra_index])
+        else:
+            normalized_header.append(f"extra_col_{extra_index - len(legacy_extra_columns) + 1}")
+
+    normalized_rows = []
+    for row in rows[1:]:
+        padded_row = row + [""] * (len(normalized_header) - len(row))
+        normalized_rows.append(dict(zip(normalized_header, padded_row)))
+    return pd.DataFrame(normalized_rows, columns=normalized_header)
+
 
 def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None:
     ledger_df = pd.DataFrame([row])
+    ledger_df = ledger_df.reindex(columns=SUBMISSION_LEDGER_COLUMNS)
     if ledger_path.exists():
-        ledger_df.to_csv(ledger_path, mode="a", header=False, index=False)
+        existing_df = _read_submission_ledger(ledger_path)
+        merged_df = pd.concat([existing_df, ledger_df], ignore_index=True, sort=False)
+        merged_df = merged_df.reindex(columns=SUBMISSION_LEDGER_COLUMNS)
+        merged_df.to_csv(ledger_path, index=False)
         return
     ledger_df.to_csv(ledger_path, index=False)
 
 
-def _load_run_metadata(run_dir: Path) -> tuple[str, str, str, float]:
-    manifest_path = run_dir / "run_manifest.json"
-    if not manifest_path.exists():
-        raise ValueError(f"Missing run manifest: {manifest_path}")
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    run_id = str(manifest["run_id"])
-
+def _load_legacy_cv_summary(run_dir: Path) -> dict[str, object]:
     summary_path = run_dir / "cv_summary.csv"
     if not summary_path.exists():
         raise ValueError(f"Missing CV summary: {summary_path}")
     summary_df = pd.read_csv(summary_path)
     if summary_df.shape[0] != 1:
         raise ValueError(f"Expected exactly one row in CV summary, got {summary_df.shape[0]}")
-
-    model_name = str(summary_df.loc[0, "model_name"])
-    metric_name = str(summary_df.loc[0, "metric_name"])
-    metric_mean = float(summary_df.loc[0, "metric_mean"])
-    return run_id, model_name, metric_name, metric_mean
+    return {
+        "model_name": str(summary_df.loc[0, "model_name"]),
+        "metric_name": str(summary_df.loc[0, "metric_name"]),
+        "metric_mean": float(summary_df.loc[0, "metric_mean"]),
+        "metric_std": float(summary_df.loc[0, "metric_std"]),
+        "higher_is_better": bool(summary_df.loc[0, "higher_is_better"]),
+    }
 
 
 def _load_run_manifest(run_dir: Path) -> dict[str, object]:
@@ -42,6 +82,42 @@ def _load_run_manifest(run_dir: Path) -> dict[str, object]:
     if not manifest_path.exists():
         raise ValueError(f"Missing run manifest: {manifest_path}")
     return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def _load_run_metadata(run_dir: Path) -> dict[str, object]:
+    manifest = _load_run_manifest(run_dir)
+    model_name = manifest.get("model_name")
+    cv_summary = manifest.get("cv_summary")
+    if isinstance(cv_summary, dict):
+        metric_name = cv_summary.get("metric_name")
+        metric_mean = cv_summary.get("metric_mean")
+        metric_std = cv_summary.get("metric_std")
+        higher_is_better = cv_summary.get("higher_is_better")
+        if model_name is not None and metric_name is not None and metric_mean is not None:
+            return {
+                "run_id": str(manifest["run_id"]),
+                "config_fingerprint": manifest.get("config_fingerprint"),
+                "model_name": str(model_name),
+                "metric_name": str(metric_name),
+                "metric_mean": float(metric_mean),
+                "metric_std": float(metric_std) if metric_std is not None else None,
+                "higher_is_better": higher_is_better,
+            }
+
+    config_snapshot = manifest.get("config_snapshot", {})
+    if model_name is None and isinstance(config_snapshot, dict):
+        model_name = config_snapshot.get("model_name")
+    legacy_summary = _load_legacy_cv_summary(run_dir)
+    resolved_model_name = model_name if model_name is not None else legacy_summary["model_name"]
+    return {
+        "run_id": str(manifest["run_id"]),
+        "config_fingerprint": manifest.get("config_fingerprint"),
+        "model_name": str(resolved_model_name),
+        "metric_name": str(legacy_summary["metric_name"]),
+        "metric_mean": float(legacy_summary["metric_mean"]),
+        "metric_std": float(legacy_summary["metric_std"]),
+        "higher_is_better": legacy_summary["higher_is_better"],
+    }
 
 
 def _validate_submission_ids(
@@ -148,13 +224,13 @@ def prepare_submission_file(
 
 
 def build_submission_message(run_dir: Path, submit_message_prefix: str | None = None) -> str:
-    run_id, model_name, metric_name, metric_mean = _load_run_metadata(run_dir)
+    run_metadata = _load_run_metadata(run_dir)
     message_parts = []
     if submit_message_prefix:
         message_parts.append(submit_message_prefix.strip())
-    message_parts.append(f"run={run_id}")
-    message_parts.append(f"model={model_name}")
-    message_parts.append(f"{metric_name}={metric_mean:.6f}")
+    message_parts.append(f"run={run_metadata['run_id']}")
+    message_parts.append(f"model={run_metadata['model_name']}")
+    message_parts.append(f"{run_metadata['metric_name']}={run_metadata['metric_mean']:.6f}")
     return " | ".join(message_parts)
 
 
@@ -173,7 +249,7 @@ def run_submission(
         label_column=label_column,
     )
     message = build_submission_message(run_dir=run_dir, submit_message_prefix=submit_message_prefix)
-    run_id, model_name, metric_name, metric_mean = _load_run_metadata(run_dir)
+    run_metadata = _load_run_metadata(run_dir)
 
     if submit_enabled:
         completed = subprocess.run(
@@ -204,18 +280,13 @@ def run_submission(
     ledger_row = {
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
         "competition_slug": competition_slug,
-        "run_id": run_id,
+        "run_id": run_metadata["run_id"],
+        "config_fingerprint": run_metadata["config_fingerprint"],
         "submission_path": str(submission_path),
         "submit_enabled": submit_enabled,
         "status": status,
         "message": message,
-        "model_name": model_name,
-        "metric_name": metric_name,
-        "metric_mean": metric_mean,
     }
-    manifest = _load_run_manifest(run_dir)
-    ledger_row["positive_label"] = manifest.get("positive_label")
-    ledger_row["negative_label"] = manifest.get("negative_label")
     ledger_path = Path("artifacts") / competition_slug / "train" / "submissions.csv"
     _append_submission_ledger(ledger_path=ledger_path, row=ledger_row)
 

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -11,6 +11,33 @@ from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_pos
 from tabular_shenanigans.data import load_competition_dataset_context
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
+RUN_LEDGER_COLUMNS = [
+    "run_id",
+    "timestamp_utc",
+    "competition_slug",
+    "task_type",
+    "primary_metric",
+    "model_name",
+    "cv_mean",
+    "cv_std",
+    "higher_is_better",
+    "cv_n_splits",
+    "cv_shuffle",
+    "cv_random_state",
+    "config_fingerprint",
+    "target_mean",
+    "target_std",
+    "target_min",
+    "target_max",
+    "positive_count",
+    "negative_count",
+    "target_prevalence",
+    "positive_label",
+    "observed_label_1",
+    "observed_label_2",
+    "negative_label",
+]
+
 
 def _build_model(task_type: str, random_state: int) -> tuple[str, object, dict[str, object]]:
     if task_type == "regression":
@@ -40,9 +67,11 @@ def _make_run_id() -> str:
 
 def _append_run_ledger(ledger_path: Path, row: dict[str, object]) -> None:
     ledger_df = pd.DataFrame([row])
+    ledger_df = ledger_df.reindex(columns=RUN_LEDGER_COLUMNS)
     if ledger_path.exists():
         existing_df = pd.read_csv(ledger_path)
         merged_df = pd.concat([existing_df, ledger_df], ignore_index=True, sort=False)
+        merged_df = merged_df.reindex(columns=RUN_LEDGER_COLUMNS)
         merged_df.to_csv(ledger_path, index=False)
         return
     ledger_df.to_csv(ledger_path, index=False)
@@ -132,6 +161,89 @@ def _build_diagnostic_rows(
         return [row]
 
     raise ValueError(f"Unsupported task_type for diagnostics: {task_type}")
+
+
+def _build_run_manifest(
+    run_id: str,
+    generated_at_utc: str,
+    competition_slug: str,
+    task_type: str,
+    primary_metric: str,
+    config_fingerprint: str,
+    config_snapshot: dict[str, object],
+    model_name: str,
+    model_params: dict[str, object],
+    cv_mean: float,
+    cv_std: float,
+    observed_label_pair: tuple[object, object] | None,
+    negative_label: object | None,
+    positive_label: object | None,
+    id_column: str,
+    label_column: str,
+    target_summary: dict[str, object],
+    train_rows: int,
+    train_cols: int,
+    test_rows: int,
+    test_cols: int,
+) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "generated_at_utc": generated_at_utc,
+        "competition_slug": competition_slug,
+        "task_type": task_type,
+        "primary_metric": primary_metric,
+        "config_fingerprint": config_fingerprint,
+        "config_snapshot": config_snapshot,
+        "model_name": model_name,
+        "model_params": model_params,
+        "cv_summary": {
+            "metric_name": primary_metric,
+            "metric_mean": cv_mean,
+            "metric_std": cv_std,
+            "higher_is_better": is_higher_better(primary_metric),
+        },
+        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
+        "negative_label": negative_label,
+        "positive_label": positive_label,
+        "id_column": id_column,
+        "label_column": label_column,
+        "target_summary": target_summary,
+        "train_rows": train_rows,
+        "train_cols": train_cols,
+        "test_rows": test_rows,
+        "test_cols": test_cols,
+    }
+
+
+def _build_run_ledger_row(
+    run_manifest: dict[str, object],
+    cv_n_splits: int,
+    cv_shuffle: bool,
+    cv_random_state: int,
+) -> dict[str, object]:
+    cv_summary = run_manifest["cv_summary"]
+    if not isinstance(cv_summary, dict):
+        raise ValueError("Run manifest cv_summary must be a mapping.")
+
+    ledger_row = {
+        "run_id": run_manifest["run_id"],
+        "timestamp_utc": run_manifest["generated_at_utc"],
+        "competition_slug": run_manifest["competition_slug"],
+        "task_type": run_manifest["task_type"],
+        "primary_metric": run_manifest["primary_metric"],
+        "model_name": run_manifest["model_name"],
+        "cv_mean": cv_summary["metric_mean"],
+        "cv_std": cv_summary["metric_std"],
+        "higher_is_better": cv_summary["higher_is_better"],
+        "cv_n_splits": cv_n_splits,
+        "cv_shuffle": cv_shuffle,
+        "cv_random_state": cv_random_state,
+        "config_fingerprint": run_manifest["config_fingerprint"],
+    }
+    target_summary = run_manifest.get("target_summary", {})
+    if isinstance(target_summary, dict):
+        ledger_row.update(target_summary)
+    return ledger_row
 
 
 def run_training(
@@ -298,19 +410,6 @@ def run_training(
     fold_metrics_df.to_csv(run_dir / "fold_metrics.csv", index=False)
     run_diagnostics_df.to_csv(run_dir / "run_diagnostics.csv", index=False)
 
-    cv_summary_df = pd.DataFrame(
-        [
-            {
-                "model_name": model_name,
-                "metric_name": primary_metric,
-                "metric_mean": cv_mean,
-                "metric_std": cv_std,
-                "higher_is_better": is_higher_better(primary_metric),
-            }
-        ]
-    )
-    cv_summary_df.to_csv(run_dir / "cv_summary.csv", index=False)
-
     oof_df = pd.DataFrame(
         {
             "row_idx": np.arange(n_rows, dtype=int),
@@ -344,63 +443,47 @@ def run_training(
         "cv_n_splits": cv_n_splits,
         "cv_shuffle": cv_shuffle,
         "cv_random_state": cv_random_state,
+    }
+    fingerprint_payload = {
+        "config_snapshot": config_snapshot,
         "model_name": model_name,
         "model_params": model_params,
     }
-    config_snapshot_json = json.dumps(config_snapshot, sort_keys=True)
+    config_snapshot_json = json.dumps(fingerprint_payload, sort_keys=True)
     config_fingerprint = hashlib.sha256(config_snapshot_json.encode("utf-8")).hexdigest()[:12]
-    artifact_paths = {
-        "run_manifest": "run_manifest.json",
-        "fold_metrics": "fold_metrics.csv",
-        "cv_summary": "cv_summary.csv",
-        "run_diagnostics": "run_diagnostics.csv",
-        "oof_predictions": "oof_predictions.csv",
-        "test_predictions": "test_predictions.csv",
-    }
 
-    run_manifest = {
-        "run_id": run_id,
-        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-        "competition_slug": competition_slug,
-        "task_type": task_type,
-        "primary_metric": primary_metric,
-        "config_fingerprint": config_fingerprint,
-        "config_snapshot": config_snapshot,
-        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
-        "negative_label": negative_label,
-        "positive_label": positive_label,
-        "id_column": id_column,
-        "label_column": label_column,
-        "target_summary": target_summary,
-        "train_rows": int(x_train_raw.shape[0]),
-        "train_cols": int(x_train_raw.shape[1]),
-        "test_rows": int(x_test_raw.shape[0]),
-        "test_cols": int(x_test_raw.shape[1]),
-        "artifacts": artifact_paths,
-    }
+    generated_at_utc = datetime.now(timezone.utc).isoformat()
+    run_manifest = _build_run_manifest(
+        run_id=run_id,
+        generated_at_utc=generated_at_utc,
+        competition_slug=competition_slug,
+        task_type=task_type,
+        primary_metric=primary_metric,
+        config_fingerprint=config_fingerprint,
+        config_snapshot=config_snapshot,
+        model_name=model_name,
+        model_params=model_params,
+        cv_mean=cv_mean,
+        cv_std=cv_std,
+        observed_label_pair=observed_label_pair,
+        negative_label=negative_label,
+        positive_label=positive_label,
+        id_column=id_column,
+        label_column=label_column,
+        target_summary=target_summary,
+        train_rows=int(x_train_raw.shape[0]),
+        train_cols=int(x_train_raw.shape[1]),
+        test_rows=int(x_test_raw.shape[0]),
+        test_cols=int(x_test_raw.shape[1]),
+    )
     (run_dir / "run_manifest.json").write_text(json.dumps(run_manifest, indent=2), encoding="utf-8")
 
-    ledger_row = {
-        "run_id": run_id,
-        "timestamp_utc": run_manifest["generated_at_utc"],
-        "competition_slug": competition_slug,
-        "task_type": task_type,
-        "primary_metric": primary_metric,
-        "model_name": model_name,
-        "cv_mean": cv_mean,
-        "cv_std": cv_std,
-        "cv_n_splits": cv_n_splits,
-        "cv_random_state": cv_random_state,
-        "config_fingerprint": config_fingerprint,
-        "artifact_dir": str(run_dir),
-        "run_manifest_path": str(run_dir / artifact_paths["run_manifest"]),
-        "fold_metrics_path": str(run_dir / artifact_paths["fold_metrics"]),
-        "cv_summary_path": str(run_dir / artifact_paths["cv_summary"]),
-        "run_diagnostics_path": str(run_dir / artifact_paths["run_diagnostics"]),
-        "oof_predictions_path": str(run_dir / artifact_paths["oof_predictions"]),
-        "test_predictions_path": str(run_dir / artifact_paths["test_predictions"]),
-    }
-    ledger_row.update(target_summary)
+    ledger_row = _build_run_ledger_row(
+        run_manifest=run_manifest,
+        cv_n_splits=cv_n_splits,
+        cv_shuffle=cv_shuffle,
+        cv_random_state=cv_random_state,
+    )
     ledger_path = Path("artifacts") / competition_slug / "train" / "runs.csv"
     _append_run_ledger(ledger_path, ledger_row)
 


### PR DESCRIPTION
## Summary
- make `run_manifest.json` the canonical per-run metadata source
- remove `cv_summary.csv` from new runs and move CV summary into the manifest
- slim `runs.csv` and `submissions.csv` to compact comparison/event schemas
- normalize legacy malformed `submissions.csv` rows on the next write

Closes #26.

## Verification
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall main.py src`
- `PYTHONPATH=src uv run python - <<'PY'`
  smoke-tested `run_training()` and `run_submission()` on `house-prices-advanced-regression-techniques`
  confirmed new runs do not write `cv_summary.csv`
  confirmed `run_manifest.json` contains the canonical CV summary fields
  confirmed `runs.csv` and `submissions.csv` rewrite to the slim `#26` schemas
  `PY`
