### PR TITLE
Make submission artifact-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The repository is developed and manually verified primarily against these Playgr
   - regression: `ElasticNet`
   - binary classification: `LogisticRegression`
 - Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
-- Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle.
+- Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle from the selected run artifact contract.
 
 ## Tooling
 - Python for orchestration
@@ -71,7 +71,7 @@ Optional submission keys:
 - `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `submit_message_prefix`: optional prefix used in auto-generated submission messages
 
-If `id_column` or `label_column` are omitted, the pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and submission validation, but it is not part of the model feature matrix. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
+If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -117,6 +117,7 @@ Manual verification for each target:
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
+- Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission validation requires `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
 - Binary classification requires an explicit positive-class contract. If `positive_label` is omitted, the workflow only auto-resolves the positive class for labels `[0, 1]`, `[False, True]`, or `["No", "Yes"]`; other two-class label pairs fail fast.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -18,12 +18,12 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
    - regression: `ElasticNet`
    - binary classification: `LogisticRegression`
 9. Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
-10. Validate predictions against `sample_submission.csv`, including exact ID content and order, write `submission.csv`, and optionally submit to Kaggle.
+10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, write `submission.csv`, and optionally submit to Kaggle.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading, data fetch, EDA, training, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
-- `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, and dataset schema resolution.
+- `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and sklearn preprocessing pipelines.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
@@ -105,6 +105,7 @@ Manual verification steps for each target:
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
+- Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `run_manifest.json` rather than re-inferring them from raw train/test data
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
 - `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets

--- a/main.py
+++ b/main.py
@@ -45,12 +45,9 @@ def main() -> None:
     )
     print(f"Training artifacts ready: {train_dir}")
     submission_path, submission_status = run_submission(
-        competition_slug=config.competition_slug,
         run_dir=train_dir,
         submit_enabled=config.submit_enabled,
         submit_message_prefix=config.submit_message_prefix,
-        id_column=config.id_column,
-        label_column=config.label_column,
     )
     print(f"Submission file ready: {submission_path} ({submission_status})")
 

--- a/src/tabular_shenanigans/data.py
+++ b/src/tabular_shenanigans/data.py
@@ -72,6 +72,25 @@ def read_csv_from_zip(zip_path: Path, member_name: str) -> pd.DataFrame:
             return pd.read_csv(f)
 
 
+def load_sample_submission_template(competition_slug: str) -> pd.DataFrame:
+    zip_path = find_competition_zip(competition_slug)
+    return read_csv_from_zip(zip_path, "sample_submission.csv")
+
+
+def validate_sample_submission_schema(
+    sample_submission_df: pd.DataFrame,
+    id_column: str,
+    label_column: str,
+) -> None:
+    expected_submission_columns = [id_column, label_column]
+    sample_submission_columns = sample_submission_df.columns.tolist()
+    if sample_submission_columns != expected_submission_columns:
+        raise ValueError(
+            "sample_submission.csv must match the resolved schema exactly. "
+            f"Expected columns {expected_submission_columns}, got {sample_submission_columns}"
+        )
+
+
 @dataclass(frozen=True)
 class CompetitionDatasetContext:
     train_df: pd.DataFrame
@@ -137,12 +156,11 @@ def resolve_id_and_label_columns(
             )
         label_column = label_candidates[0]
 
-    expected_submission_columns = [id_column, label_column]
-    if sample_submission_columns != expected_submission_columns:
-        raise ValueError(
-            "sample_submission.csv must match the resolved schema exactly. "
-            f"Expected columns {expected_submission_columns}, got {sample_submission_columns}"
-        )
+    validate_sample_submission_schema(
+        sample_submission_df=sample_submission_df,
+        id_column=id_column,
+        label_column=label_column,
+    )
 
     return id_column, label_column
 
@@ -155,7 +173,7 @@ def load_competition_dataset_context(
     zip_path = find_competition_zip(competition_slug)
     train_df = read_csv_from_zip(zip_path, "train.csv")
     test_df = read_csv_from_zip(zip_path, "test.csv")
-    sample_submission_df = read_csv_from_zip(zip_path, "sample_submission.csv")
+    sample_submission_df = load_sample_submission_template(competition_slug)
     id_column, label_column = resolve_id_and_label_columns(
         train_df=train_df,
         test_df=test_df,

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -1,13 +1,14 @@
 import csv
 import json
 import subprocess
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
-from tabular_shenanigans.data import load_competition_dataset_context
+from tabular_shenanigans.data import load_sample_submission_template, validate_sample_submission_schema
 
 SUBMISSION_LEDGER_COLUMNS = [
     "timestamp_utc",
@@ -19,6 +20,16 @@ SUBMISSION_LEDGER_COLUMNS = [
     "status",
     "message",
 ]
+
+
+@dataclass(frozen=True)
+class SubmissionRunContext:
+    run_id: str
+    competition_slug: str
+    task_type: str
+    id_column: str
+    label_column: str
+    config_fingerprint: str | None
 
 
 def _read_submission_ledger(ledger_path: Path) -> pd.DataFrame:
@@ -82,6 +93,35 @@ def _load_run_manifest(run_dir: Path) -> dict[str, object]:
     if not manifest_path.exists():
         raise ValueError(f"Missing run manifest: {manifest_path}")
     return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def _require_manifest_value(manifest: dict[str, object], field_name: str) -> object:
+    field_value = manifest.get(field_name)
+    if field_value is not None:
+        return field_value
+
+    config_snapshot = manifest.get("config_snapshot", {})
+    if isinstance(config_snapshot, dict):
+        field_value = config_snapshot.get(field_name)
+    if field_value is None:
+        raise ValueError(
+            f"Run manifest is missing required submission field '{field_name}'. "
+            "Submission requires a manifest-backed artifact contract."
+        )
+    return field_value
+
+
+def _load_submission_run_context(run_dir: Path) -> SubmissionRunContext:
+    manifest = _load_run_manifest(run_dir)
+    run_id = str(manifest["run_id"])
+    return SubmissionRunContext(
+        run_id=run_id,
+        competition_slug=str(_require_manifest_value(manifest, "competition_slug")),
+        task_type=str(_require_manifest_value(manifest, "task_type")),
+        id_column=str(_require_manifest_value(manifest, "id_column")),
+        label_column=str(_require_manifest_value(manifest, "label_column")),
+        config_fingerprint=manifest.get("config_fingerprint"),
+    )
 
 
 def _load_run_metadata(run_dir: Path) -> dict[str, object]:
@@ -164,26 +204,22 @@ def _validate_submission_ids(
 
 
 def prepare_submission_file(
-    competition_slug: str,
     run_dir: Path,
-    id_column: str | None = None,
-    label_column: str | None = None,
 ) -> Path:
     prediction_path = run_dir / "test_predictions.csv"
     if not prediction_path.exists():
         raise ValueError(f"Missing test predictions file: {prediction_path}")
 
     prediction_df = pd.read_csv(prediction_path)
-    dataset_context = load_competition_dataset_context(
-        competition_slug=competition_slug,
-        configured_id_column=id_column,
-        configured_label_column=label_column,
+    run_context = _load_submission_run_context(run_dir)
+    sample_submission_df = load_sample_submission_template(run_context.competition_slug)
+    validate_sample_submission_schema(
+        sample_submission_df=sample_submission_df,
+        id_column=run_context.id_column,
+        label_column=run_context.label_column,
     )
-    sample_submission_df = dataset_context.sample_submission_df
-    resolved_id_column = dataset_context.id_column
-    resolved_label_column = dataset_context.label_column
 
-    expected_columns = [resolved_id_column, resolved_label_column]
+    expected_columns = [run_context.id_column, run_context.label_column]
     actual_columns = prediction_df.columns.tolist()
 
     if actual_columns != expected_columns:
@@ -196,14 +232,8 @@ def prepare_submission_file(
             "Submission row count does not match sample_submission.csv. "
             f"Expected {sample_submission_df.shape[0]}, got {prediction_df.shape[0]}"
         )
-    manifest = _load_run_manifest(run_dir)
-    task_type = manifest.get("task_type")
-    if task_type is None:
-        config_snapshot = manifest.get("config_snapshot", {})
-        if isinstance(config_snapshot, dict):
-            task_type = config_snapshot.get("task_type")
-    if task_type == "binary":
-        prediction_values = prediction_df[resolved_label_column]
+    if run_context.task_type == "binary":
+        prediction_values = prediction_df[run_context.label_column]
         if not pd.api.types.is_numeric_dtype(prediction_values):
             raise ValueError("Binary submission predictions must be numeric probabilities.")
         if not prediction_values.map(pd.notna).all():
@@ -215,7 +245,7 @@ def prepare_submission_file(
     _validate_submission_ids(
         prediction_df=prediction_df,
         sample_submission_df=sample_submission_df,
-        id_column=resolved_id_column,
+        id_column=run_context.id_column,
     )
 
     submission_path = run_dir / "submission.csv"
@@ -235,21 +265,13 @@ def build_submission_message(run_dir: Path, submit_message_prefix: str | None = 
 
 
 def run_submission(
-    competition_slug: str,
     run_dir: Path,
     submit_enabled: bool,
     submit_message_prefix: str | None = None,
-    id_column: str | None = None,
-    label_column: str | None = None,
 ) -> tuple[Path, str]:
-    submission_path = prepare_submission_file(
-        competition_slug=competition_slug,
-        run_dir=run_dir,
-        id_column=id_column,
-        label_column=label_column,
-    )
+    run_context = _load_submission_run_context(run_dir)
+    submission_path = prepare_submission_file(run_dir=run_dir)
     message = build_submission_message(run_dir=run_dir, submit_message_prefix=submit_message_prefix)
-    run_metadata = _load_run_metadata(run_dir)
 
     if submit_enabled:
         completed = subprocess.run(
@@ -258,7 +280,7 @@ def run_submission(
                 "competitions",
                 "submit",
                 "-c",
-                competition_slug,
+                run_context.competition_slug,
                 "-f",
                 str(submission_path),
                 "-m",
@@ -279,15 +301,15 @@ def run_submission(
 
     ledger_row = {
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-        "competition_slug": competition_slug,
-        "run_id": run_metadata["run_id"],
-        "config_fingerprint": run_metadata["config_fingerprint"],
+        "competition_slug": run_context.competition_slug,
+        "run_id": run_context.run_id,
+        "config_fingerprint": run_context.config_fingerprint,
         "submission_path": str(submission_path),
         "submit_enabled": submit_enabled,
         "status": status,
         "message": message,
     }
-    ledger_path = Path("artifacts") / competition_slug / "train" / "submissions.csv"
+    ledger_path = Path("artifacts") / run_context.competition_slug / "train" / "submissions.csv"
     _append_submission_ledger(ledger_path=ledger_path, row=ledger_row)
 
     return submission_path, status


### PR DESCRIPTION
## Summary
- make submission load competition slug, task type, and schema from run_manifest.json
- limit submit-time dataset access to sample_submission.csv only
- update docs and the main entrypoint to match the artifact-driven submit contract

Closes #27

## Verification
- uv run python -m compileall main.py src
- uv run python - <<'PY'
  import json
  import os
  import sys
  import tempfile
  import zipfile
  from pathlib import Path

  repo_root = Path("/Users/hs/dev/TabularShenanigans")
  temp_root = Path(tempfile.mkdtemp(prefix="issue27-"))
  competition_slug = "mock-comp"
  run_id = "20260308T000000Z"

  sample_dir = temp_root / "data" / competition_slug
  sample_dir.mkdir(parents=True, exist_ok=True)
  zip_path = sample_dir / "mock.zip"
  with zipfile.ZipFile(zip_path, "w") as archive:
      archive.writestr("sample_submission.csv", "id,target\\n1,0\\n2,0\\n")

  run_dir = temp_root / "artifacts" / competition_slug / "train" / run_id
  run_dir.mkdir(parents=True, exist_ok=True)
  (run_dir / "run_manifest.json").write_text(json.dumps({
      "run_id": run_id,
      "competition_slug": competition_slug,
      "task_type": "binary",
      "id_column": "id",
      "label_column": "target",
      "config_fingerprint": "abc123def456",
      "model_name": "LogisticRegression",
      "cv_summary": {
          "metric_name": "roc_auc",
          "metric_mean": 0.5,
          "metric_std": 0.0,
          "higher_is_better": True,
      },
  }, indent=2), encoding="utf-8")
  (run_dir / "test_predictions.csv").write_text("id,target\\n1,0.2\\n2,0.8\\n", encoding="utf-8")

  os.chdir(temp_root)
  sys.path.insert(0, str(repo_root / "src"))

  from tabular_shenanigans.submit import run_submission

  run_submission(run_dir=run_dir, submit_enabled=False, submit_message_prefix="artifact-check")
  PY