### PR TITLE
Add explicit model selection and random forest baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ The repository is developed and manually verified primarily against these Playgr
 - Load and validate a single repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Require explicit `task_type` and `primary_metric` in config.
+- Select one baseline model per run from config via `model_id`.
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Train baseline cross-validated models with fold-local preprocessing:
-  - regression: `ElasticNet`
-  - binary classification: `LogisticRegression`
+  - regression: `elasticnet` (`ElasticNet`) or `random_forest` (`RandomForestRegressor`)
+  - binary classification: `logistic_regression` (`LogisticRegression`) or `random_forest` (`RandomForestClassifier`)
 - Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle from the selected run artifact contract.
 
@@ -52,6 +53,11 @@ Required keys:
 Optional binary-classification key:
 - `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 
+Optional model-selection key:
+- `model_id`: baseline model preset for the configured task
+  - regression: `elasticnet` (default) or `random_forest`
+  - binary classification: `logistic_regression` (default) or `random_forest`
+
 Optional submission schema keys:
 - `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
 - `label_column`: override for the inferred submission/target column
@@ -73,6 +79,8 @@ Optional submission keys:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
+`model_id` is config-driven. If omitted, the workflow selects the current default baseline for the configured task: `elasticnet` for regression and `logistic_regression` for binary classification.
+
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
 ## Preferred Manual Verification Targets
@@ -87,6 +95,7 @@ Example binary config:
 competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
+# model_id: random_forest
 ```
 
 Example regression config:
@@ -95,6 +104,7 @@ Example regression config:
 competition_slug: playground-series-s5e10
 task_type: regression
 primary_metric: mse
+# model_id: random_forest
 ```
 
 Manual verification for each target:
@@ -118,6 +128,7 @@ Manual verification for each target:
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
+- Submission metadata includes the selected `model_id`.
 - Submission validation requires `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
 - Binary classification requires an explicit positive-class contract. If `positive_label` is omitted, the workflow only auto-resolves the positive class for labels `[0, 1]`, `[False, True]`, or `["No", "Yes"]`; other two-class label pairs fail fast.

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
+# model_id: random_forest
 # positive_label: "Yes"
 # Optional runtime settings.
 # cv_n_splits: 7

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -14,9 +14,9 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 7. During training, build fold-local preprocessing for the selected feature types:
    - numeric: median imputation + `StandardScaler`
    - categorical: most-frequent imputation + `OneHotEncoder`
-8. Train the baseline model:
-   - regression: `ElasticNet`
-   - binary classification: `LogisticRegression`
+8. Train the configured baseline model:
+   - regression: `elasticnet` (`ElasticNet`) or `random_forest` (`RandomForestRegressor`)
+   - binary classification: `logistic_regression` (`LogisticRegression`) or `random_forest` (`RandomForestClassifier`)
 9. Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, write `submission.csv`, and optionally submit to Kaggle.
 
@@ -25,9 +25,10 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
+- `src/tabular_shenanigans/models.py`: single-model registry and estimator construction for supported baseline presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and sklearn preprocessing pipelines.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: baseline model selection, fold training, artifact writing, and run ledger updates.
+- `src/tabular_shenanigans/train.py`: config-selected model training, fold training, artifact writing, and run ledger updates.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
@@ -37,6 +38,10 @@ Input:
   - `competition_slug`
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
+- Optional model-selection key:
+  - `model_id` (baseline model preset for the configured task; defaults to `elasticnet` for regression and `logistic_regression` for binary classification)
+    - regression: `elasticnet`, `random_forest`
+    - binary classification: `logistic_regression`, `random_forest`
 - Optional binary-classification key:
   - `positive_label` (explicit positive class for binary competitions; required unless observed labels match one of the documented safe conventions `[0, 1]`, `[False, True]`, or `["No", "Yes"]`)
 - Optional submission schema keys:
@@ -98,6 +103,7 @@ Manual verification steps for each target:
 - One runtime config source only: `config.yaml`
 - No config overrides via CLI or environment variables
 - `task_type` and `primary_metric` must be present in config for every run
+- `model_id` must resolve to a supported preset for the configured task; if omitted, the task default is used
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
 - Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
@@ -122,6 +128,7 @@ Hard-error cases include:
 - Missing `task_type` or `primary_metric` -> hard error
 - Unknown/unsupported configured `primary_metric` -> hard error
 - Invalid task/metric pairing (for example `binary` + `rmse`) -> hard error
+- Invalid `model_id` for the configured task -> hard error
 - Missing/invalid competition zip contents -> hard error
 - `id_column` inference not exactly one column -> hard error
 - `label_column` inference not exactly one column -> hard error
@@ -150,6 +157,6 @@ Hard-error cases include:
 ## Extension Notes
 - New config keys should be added to `AppConfig` in `config.py` and documented in both this file and `README.md` when user-facing.
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
-- New model families should be introduced in `train.py` with explicit task compatibility and matching artifact outputs.
+- New model families should be introduced in `models.py` with explicit task compatibility and matching artifact outputs.
 - New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract.
 - New run or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def main() -> None:
     config = load_config()
     print(
         "Resolved competition setup: "
-        f"task_type={config.task_type}, primary_metric={config.primary_metric}"
+        f"task_type={config.task_type}, primary_metric={config.primary_metric}, model_id={config.model_id}"
     )
     data_dir = fetch_competition_data(config.competition_slug)
     print(f"Data ready: {data_dir}")
@@ -32,6 +32,7 @@ def main() -> None:
         competition_slug=config.competition_slug,
         task_type=config.task_type,
         primary_metric=config.primary_metric,
+        model_id=config.model_id,
         positive_label=config.positive_label,
         id_column=config.id_column,
         label_column=config.label_column,

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -5,6 +5,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
+from tabular_shenanigans.models import get_default_model_id, get_supported_model_ids, is_model_id_valid_for_task
 
 
 class ConfigError(ValueError):
@@ -17,6 +18,7 @@ class AppConfig(BaseModel):
     competition_slug: str = Field(min_length=1)
     task_type: Literal["regression", "binary"]
     primary_metric: str
+    model_id: str | None = None
     positive_label: str | int | bool | None = None
     id_column: str | None = None
     label_column: str | None = None
@@ -43,6 +45,14 @@ class AppConfig(BaseModel):
                 f"Configured primary_metric '{normalized_primary_metric}' is not valid for task_type '{self.task_type}'."
             )
         self.primary_metric = normalized_primary_metric
+        resolved_model_id = self.model_id or get_default_model_id(self.task_type)
+        if not is_model_id_valid_for_task(self.task_type, resolved_model_id):
+            supported_model_ids = get_supported_model_ids(self.task_type)
+            raise ValueError(
+                f"Configured model_id '{resolved_model_id}' is not valid for task_type '{self.task_type}'. "
+                f"Supported model_ids: {supported_model_ids}"
+            )
+        self.model_id = resolved_model_id
         if self.task_type != "binary" and self.positive_label is not None:
             raise ValueError("positive_label is only supported for binary task_type.")
         return self

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.linear_model import ElasticNet, LogisticRegression
+
+ModelBuilder = Callable[[int], tuple[object, dict[str, object]]]
+
+
+@dataclass(frozen=True)
+class ModelDefinition:
+    model_id: str
+    model_name: str
+    builder: ModelBuilder
+
+
+def _build_elasticnet(random_state: int) -> tuple[ElasticNet, dict[str, object]]:
+    del random_state
+    return ElasticNet(), {}
+
+
+def _build_random_forest_regressor(random_state: int) -> tuple[RandomForestRegressor, dict[str, object]]:
+    params = {"random_state": random_state}
+    return RandomForestRegressor(**params), params
+
+
+def _build_logistic_regression(random_state: int) -> tuple[LogisticRegression, dict[str, object]]:
+    del random_state
+    return LogisticRegression(), {}
+
+
+def _build_random_forest_classifier(random_state: int) -> tuple[RandomForestClassifier, dict[str, object]]:
+    params = {"random_state": random_state}
+    return RandomForestClassifier(**params), params
+
+
+DEFAULT_MODEL_ID_BY_TASK = {
+    "regression": "elasticnet",
+    "binary": "logistic_regression",
+}
+
+MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
+    "regression": {
+        "elasticnet": ModelDefinition(
+            model_id="elasticnet",
+            model_name="ElasticNet",
+            builder=_build_elasticnet,
+        ),
+        "random_forest": ModelDefinition(
+            model_id="random_forest",
+            model_name="RandomForestRegressor",
+            builder=_build_random_forest_regressor,
+        ),
+    },
+    "binary": {
+        "logistic_regression": ModelDefinition(
+            model_id="logistic_regression",
+            model_name="LogisticRegression",
+            builder=_build_logistic_regression,
+        ),
+        "random_forest": ModelDefinition(
+            model_id="random_forest",
+            model_name="RandomForestClassifier",
+            builder=_build_random_forest_classifier,
+        ),
+    },
+}
+
+
+def get_default_model_id(task_type: str) -> str:
+    try:
+        return DEFAULT_MODEL_ID_BY_TASK[task_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
+
+
+def get_supported_model_ids(task_type: str) -> list[str]:
+    try:
+        return sorted(MODEL_REGISTRY[task_type])
+    except KeyError as exc:
+        raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
+
+
+def is_model_id_valid_for_task(task_type: str, model_id: str) -> bool:
+    try:
+        return model_id in MODEL_REGISTRY[task_type]
+    except KeyError:
+        return False
+
+
+def build_model(
+    task_type: str,
+    model_id: str,
+    random_state: int,
+) -> tuple[str, str, object, dict[str, object]]:
+    if not is_model_id_valid_for_task(task_type, model_id):
+        supported_model_ids = get_supported_model_ids(task_type)
+        raise ValueError(
+            f"Configured model_id '{model_id}' is not valid for task_type '{task_type}'. "
+            f"Supported model_ids: {supported_model_ids}"
+        )
+
+    model_definition = MODEL_REGISTRY[task_type][model_id]
+    estimator, explicit_params = model_definition.builder(random_state)
+    return model_definition.model_id, model_definition.model_name, estimator, explicit_params

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -14,6 +14,8 @@ SUBMISSION_LEDGER_COLUMNS = [
     "timestamp_utc",
     "competition_slug",
     "run_id",
+    "model_id",
+    "model_name",
     "config_fingerprint",
     "submission_path",
     "submit_enabled",
@@ -27,6 +29,7 @@ class SubmissionRunContext:
     run_id: str
     competition_slug: str
     task_type: str
+    model_id: str
     id_column: str
     label_column: str
     config_fingerprint: str | None
@@ -111,6 +114,34 @@ def _require_manifest_value(manifest: dict[str, object], field_name: str) -> obj
     return field_value
 
 
+def _infer_legacy_model_id(task_type: str, model_name: object | None) -> str | None:
+    legacy_model_map = {
+        ("regression", "ElasticNet"): "elasticnet",
+        ("binary", "LogisticRegression"): "logistic_regression",
+    }
+    return legacy_model_map.get((task_type, str(model_name)))
+
+
+def _resolve_manifest_model_id(manifest: dict[str, object]) -> str:
+    model_id = manifest.get("model_id")
+    if model_id is None:
+        config_snapshot = manifest.get("config_snapshot", {})
+        if isinstance(config_snapshot, dict):
+            model_id = config_snapshot.get("model_id")
+    if model_id is not None:
+        return str(model_id)
+
+    task_type = str(_require_manifest_value(manifest, "task_type"))
+    legacy_model_id = _infer_legacy_model_id(task_type, manifest.get("model_name"))
+    if legacy_model_id is not None:
+        return legacy_model_id
+
+    raise ValueError(
+        "Run manifest is missing required submission field 'model_id'. "
+        "Submission requires a manifest-backed model selection contract."
+    )
+
+
 def _load_submission_run_context(run_dir: Path) -> SubmissionRunContext:
     manifest = _load_run_manifest(run_dir)
     run_id = str(manifest["run_id"])
@@ -118,6 +149,7 @@ def _load_submission_run_context(run_dir: Path) -> SubmissionRunContext:
         run_id=run_id,
         competition_slug=str(_require_manifest_value(manifest, "competition_slug")),
         task_type=str(_require_manifest_value(manifest, "task_type")),
+        model_id=_resolve_manifest_model_id(manifest),
         id_column=str(_require_manifest_value(manifest, "id_column")),
         label_column=str(_require_manifest_value(manifest, "label_column")),
         config_fingerprint=manifest.get("config_fingerprint"),
@@ -126,6 +158,7 @@ def _load_submission_run_context(run_dir: Path) -> SubmissionRunContext:
 
 def _load_run_metadata(run_dir: Path) -> dict[str, object]:
     manifest = _load_run_manifest(run_dir)
+    model_id = _resolve_manifest_model_id(manifest)
     model_name = manifest.get("model_name")
     cv_summary = manifest.get("cv_summary")
     if isinstance(cv_summary, dict):
@@ -136,6 +169,7 @@ def _load_run_metadata(run_dir: Path) -> dict[str, object]:
         if model_name is not None and metric_name is not None and metric_mean is not None:
             return {
                 "run_id": str(manifest["run_id"]),
+                "model_id": model_id,
                 "config_fingerprint": manifest.get("config_fingerprint"),
                 "model_name": str(model_name),
                 "metric_name": str(metric_name),
@@ -151,6 +185,7 @@ def _load_run_metadata(run_dir: Path) -> dict[str, object]:
     resolved_model_name = model_name if model_name is not None else legacy_summary["model_name"]
     return {
         "run_id": str(manifest["run_id"]),
+        "model_id": model_id,
         "config_fingerprint": manifest.get("config_fingerprint"),
         "model_name": str(resolved_model_name),
         "metric_name": str(legacy_summary["metric_name"]),
@@ -259,7 +294,7 @@ def build_submission_message(run_dir: Path, submit_message_prefix: str | None = 
     if submit_message_prefix:
         message_parts.append(submit_message_prefix.strip())
     message_parts.append(f"run={run_metadata['run_id']}")
-    message_parts.append(f"model={run_metadata['model_name']}")
+    message_parts.append(f"model={run_metadata['model_id']}")
     message_parts.append(f"{run_metadata['metric_name']}={run_metadata['metric_mean']:.6f}")
     return " | ".join(message_parts)
 
@@ -270,6 +305,7 @@ def run_submission(
     submit_message_prefix: str | None = None,
 ) -> tuple[Path, str]:
     run_context = _load_submission_run_context(run_dir)
+    run_metadata = _load_run_metadata(run_dir)
     submission_path = prepare_submission_file(run_dir=run_dir)
     message = build_submission_message(run_dir=run_dir, submit_message_prefix=submit_message_prefix)
 
@@ -303,6 +339,8 @@ def run_submission(
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
         "competition_slug": run_context.competition_slug,
         "run_id": run_context.run_id,
+        "model_id": run_context.model_id,
+        "model_name": run_metadata["model_name"],
         "config_fingerprint": run_context.config_fingerprint,
         "submission_path": str(submission_path),
         "submit_enabled": submit_enabled,

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from sklearn.linear_model import ElasticNet, LogisticRegression
 
 from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import load_competition_dataset_context
+from tabular_shenanigans.models import build_model
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
 RUN_LEDGER_COLUMNS = [
@@ -17,6 +17,7 @@ RUN_LEDGER_COLUMNS = [
     "competition_slug",
     "task_type",
     "primary_metric",
+    "model_id",
     "model_name",
     "cv_mean",
     "cv_std",
@@ -39,26 +40,16 @@ RUN_LEDGER_COLUMNS = [
 ]
 
 
-def _build_model(task_type: str, random_state: int) -> tuple[str, object, dict[str, object]]:
-    if task_type == "regression":
-        params = {
-            "alpha": 0.001,
-            "l1_ratio": 0.5,
-            "max_iter": 10000,
-            "random_state": random_state,
-        }
-        return "ElasticNet", ElasticNet(**params), params
-
-    if task_type == "binary":
-        params = {
-            "C": 1.0,
-            "solver": "lbfgs",
-            "max_iter": 2000,
-            "random_state": random_state,
-        }
-        return "LogisticRegression", LogisticRegression(**params), params
-
-    raise ValueError(f"Unsupported task_type for baseline model: {task_type}")
+def _json_ready(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
 
 
 def _make_run_id() -> str:
@@ -171,6 +162,7 @@ def _build_run_manifest(
     primary_metric: str,
     config_fingerprint: str,
     config_snapshot: dict[str, object],
+    model_id: str,
     model_name: str,
     model_params: dict[str, object],
     cv_mean: float,
@@ -194,6 +186,7 @@ def _build_run_manifest(
         "primary_metric": primary_metric,
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
+        "model_id": model_id,
         "model_name": model_name,
         "model_params": model_params,
         "cv_summary": {
@@ -231,6 +224,7 @@ def _build_run_ledger_row(
         "competition_slug": run_manifest["competition_slug"],
         "task_type": run_manifest["task_type"],
         "primary_metric": run_manifest["primary_metric"],
+        "model_id": run_manifest["model_id"],
         "model_name": run_manifest["model_name"],
         "cv_mean": cv_summary["metric_mean"],
         "cv_std": cv_summary["metric_std"],
@@ -250,6 +244,7 @@ def run_training(
     competition_slug: str,
     task_type: str,
     primary_metric: str,
+    model_id: str,
     id_column: str | None = None,
     label_column: str | None = None,
     force_categorical: list[str] | None = None,
@@ -288,7 +283,7 @@ def run_training(
             configured_positive_label=positive_label,
         )
 
-    model_name, _, model_params = _build_model(task_type, cv_random_state)
+    model_id, model_name, _, model_params = build_model(task_type, model_id, cv_random_state)
     splitter = build_splitter(
         task_type=task_type,
         n_splits=cv_n_splits,
@@ -347,7 +342,7 @@ def run_training(
         x_fold_valid_processed = preprocessor.transform(x_fold_valid)
         x_test_processed = preprocessor.transform(x_test_raw)
 
-        _, model, _ = _build_model(task_type, cv_random_state)
+        _, _, model, _ = build_model(task_type, model_id, cv_random_state)
         model.fit(x_fold_train_processed, y_fold_train)
 
         if task_type == "binary":
@@ -375,6 +370,7 @@ def run_training(
         test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
         fold_metrics.append(
             {
+                "model_id": model_id,
                 "model_name": model_name,
                 "fold": fold_index,
                 "metric_name": primary_metric,
@@ -416,6 +412,7 @@ def run_training(
             "y_true": y_train.to_numpy(),
             "y_pred": oof_predictions,
             "fold": fold_assignments,
+            "model_id": model_id,
             "model_name": model_name,
         }
     )
@@ -433,6 +430,7 @@ def run_training(
         "competition_slug": competition_slug,
         "task_type": task_type,
         "primary_metric": primary_metric,
+        "model_id": model_id,
         "positive_label": positive_label,
         "id_column": id_column,
         "label_column": label_column,
@@ -449,7 +447,7 @@ def run_training(
         "model_name": model_name,
         "model_params": model_params,
     }
-    config_snapshot_json = json.dumps(fingerprint_payload, sort_keys=True)
+    config_snapshot_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
     config_fingerprint = hashlib.sha256(config_snapshot_json.encode("utf-8")).hexdigest()[:12]
 
     generated_at_utc = datetime.now(timezone.utc).isoformat()
@@ -461,6 +459,7 @@ def run_training(
         primary_metric=primary_metric,
         config_fingerprint=config_fingerprint,
         config_snapshot=config_snapshot,
+        model_id=model_id,
         model_name=model_name,
         model_params=model_params,
         cv_mean=cv_mean,
@@ -476,7 +475,8 @@ def run_training(
         test_rows=int(x_test_raw.shape[0]),
         test_cols=int(x_test_raw.shape[1]),
     )
-    (run_dir / "run_manifest.json").write_text(json.dumps(run_manifest, indent=2), encoding="utf-8")
+    run_manifest_json = json.dumps(_json_ready(run_manifest), indent=2)
+    (run_dir / "run_manifest.json").write_text(run_manifest_json, encoding="utf-8")
 
     ledger_row = _build_run_ledger_row(
         run_manifest=run_manifest,
@@ -487,7 +487,7 @@ def run_training(
     ledger_path = Path("artifacts") / competition_slug / "train" / "runs.csv"
     _append_run_ledger(ledger_path, ledger_row)
 
-    print(f"Training model: {model_name}")
+    print(f"Training model: {model_id} ({model_name})")
     print(f"CV {primary_metric}: mean={cv_mean:.6f}, std={cv_std:.6f}")
 
     return run_dir


### PR DESCRIPTION
## Summary
- add explicit single-model selection via `model_id` with task-specific defaults
- replace hard-coded task-based model construction with a small registry in `models.py`
- add `random_forest` presets for regression and binary tasks
- record `model_id` in manifests and ledgers and update docs for the new config contract

Closes #32.

## Verification
- `uv run python -m compileall main.py src`
- `uv run python - <<'PY'`
  created local mock regression and binary competition zips
  verified `AppConfig` defaults `model_id` to `elasticnet` and `logistic_regression`
  ran `run_training()` + `run_submission()` with `elasticnet`, `logistic_regression`, and `random_forest` on both task types
  confirmed `run_manifest.json`, `runs.csv`, and `submissions.csv` record `model_id`
  `PY`