### PR TITLE
Add multi-model training artifact layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ The repository is developed and manually verified primarily against these Playgr
 - Load and validate a single repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Require explicit `task_type` and `primary_metric` in config.
-- Select one baseline model per run from config via `model_id`.
+- Select one or more baseline models per run from config via `model_ids`, with `model_id` retained as the single-model shorthand.
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
-- Train baseline cross-validated models with fold-local preprocessing:
+- Train one or more baseline cross-validated models with fold-local preprocessing:
   - regression: `elasticnet` (`ElasticNet`) or `random_forest` (`RandomForestRegressor`)
   - binary classification: `logistic_regression` (`LogisticRegression`) or `random_forest` (`RandomForestClassifier`)
-- Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
-- Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle from the selected run artifact contract.
+- Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
+- Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
 
 ## Tooling
 - Python for orchestration
@@ -54,9 +54,10 @@ Optional binary-classification key:
 - `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 
 Optional model-selection key:
-- `model_id`: baseline model preset for the configured task
-  - regression: `elasticnet` (default) or `random_forest`
-  - binary classification: `logistic_regression` (default) or `random_forest`
+- `model_ids`: ordered list of baseline model presets for the configured task
+- `model_id`: single-model shorthand retained for backward compatibility; mutually exclusive with `model_ids`
+  - regression: `elasticnet` (default), `random_forest`
+  - binary classification: `logistic_regression` (default), `random_forest`
 
 Optional submission schema keys:
 - `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
@@ -79,7 +80,7 @@ Optional submission keys:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-`model_id` is config-driven. If omitted, the workflow selects the current default baseline for the configured task: `elasticnet` for regression and `logistic_regression` for binary classification.
+`model_ids` is the preferred config-driven model interface. If both `model_id` and `model_ids` are omitted, the workflow selects the current default baseline for the configured task: `elasticnet` for regression and `logistic_regression` for binary classification. If `model_id` is provided, it resolves to a single-entry `model_ids` list.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -95,7 +96,9 @@ Example binary config:
 competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
-# model_id: random_forest
+model_ids:
+  - logistic_regression
+  - random_forest
 ```
 
 Example regression config:
@@ -104,20 +107,25 @@ Example regression config:
 competition_slug: playground-series-s5e10
 task_type: regression
 primary_metric: mse
-# model_id: random_forest
+model_ids:
+  - elasticnet
+  - random_forest
 ```
 
 Manual verification for each target:
 - confirm the competition archive includes `train.csv`, `test.csv`, and `sample_submission.csv`
 - confirm the pipeline infers `id_column` and `label_column` without overrides
-- confirm `artifacts/<competition_slug>/train/<run_id>/test_predictions.csv` is written
-- confirm `artifacts/<competition_slug>/train/<run_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
+- confirm `artifacts/<competition_slug>/train/<run_id>/model_summary.csv` is written
+- confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv` is written for each selected model
+- confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order, for the submitted model
 
 ## Outputs
 - Competition data: `data/<competition_slug>/`
 - EDA reports: `reports/<competition_slug>/`
 - Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
-  - includes `fold_metrics.csv`, `run_diagnostics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `run_manifest.json`
+  - includes `run_diagnostics.csv`, `model_summary.csv`, and `run_manifest.json`
+  - includes per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/`
+  - each model subdirectory includes `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
   - `run_manifest.json` is the canonical per-run metadata source
 - Run ledger: `artifacts/<competition_slug>/train/runs.csv` as a compact comparison/history table
 - Submission ledger: `artifacts/<competition_slug>/train/submissions.csv` as an append-only submission event table
@@ -128,8 +136,8 @@ Manual verification for each target:
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
-- Submission metadata includes the selected `model_id`.
-- Submission validation requires `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
+- Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
+- Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
 - Binary classification requires an explicit positive-class contract. If `positive_label` is omitted, the workflow only auto-resolves the positive class for labels `[0, 1]`, `[False, True]`, or `["No", "Yes"]`; other two-class label pairs fail fast.
 - `task_type` and `primary_metric` are explicitly configured for every run.

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,9 @@
 competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
+# model_ids:
+#   - logistic_regression
+#   - random_forest
 # model_id: random_forest
 # positive_label: "Yes"
 # Optional runtime settings.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -14,11 +14,12 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 7. During training, build fold-local preprocessing for the selected feature types:
    - numeric: median imputation + `StandardScaler`
    - categorical: most-frequent imputation + `OneHotEncoder`
-8. Train the configured baseline model:
+8. Train the configured baseline model or models from the resolved `model_ids` list:
    - regression: `elasticnet` (`ElasticNet`) or `random_forest` (`RandomForestRegressor`)
    - binary classification: `logistic_regression` (`LogisticRegression`) or `random_forest` (`RandomForestClassifier`)
-9. Write fold metrics, task-aware run diagnostics, OOF predictions, test predictions, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
-10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, write `submission.csv`, and optionally submit to Kaggle.
+9. Write run-level diagnostics, `model_summary.csv`, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
+10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
+11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading, data fetch, EDA, training, and submission.
@@ -28,8 +29,8 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 - `src/tabular_shenanigans/models.py`: single-model registry and estimator construction for supported baseline presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and sklearn preprocessing pipelines.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: config-selected model training, fold training, artifact writing, and run ledger updates.
-- `src/tabular_shenanigans/submit.py`: submission schema validation, submission message creation, Kaggle submission, and submission ledger updates.
+- `src/tabular_shenanigans/train.py`: config-selected multi-model training, shared split handling, artifact writing, and run ledger updates.
+- `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
 Input:
@@ -39,7 +40,8 @@ Input:
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
 - Optional model-selection key:
-  - `model_id` (baseline model preset for the configured task; defaults to `elasticnet` for regression and `logistic_regression` for binary classification)
+  - `model_ids` (ordered list of baseline model presets for the configured task)
+  - `model_id` (single-model shorthand; mutually exclusive with `model_ids`)
     - regression: `elasticnet`, `random_forest`
     - binary classification: `logistic_regression`, `random_forest`
 - Optional binary-classification key:
@@ -70,10 +72,11 @@ Configured metrics are normalized to the internal metric names during config val
 
 Manual verification steps for each target:
 - verify the competition assets include `train.csv`, `test.csv`, and `sample_submission.csv`
-- run the workflow from a clean repo state with explicit `task_type` and `primary_metric`
+- run the workflow from a clean repo state with explicit `task_type`, `primary_metric`, and one or more selected models
 - confirm inferred `id_column` and `label_column`
-- confirm `test_predictions.csv` is generated in the run directory
-- confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order
+- confirm `model_summary.csv` is generated in the run directory
+- confirm `test_predictions.csv` is generated in each model directory
+- confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected model directory
 
 ## Artifact Contract
 - A validated in-memory config object from Pydantic
@@ -88,22 +91,24 @@ Manual verification steps for each target:
   - `feature_type_counts.csv`
   - `run_summary.csv`
 - Training artifacts under `artifacts/<competition_slug>/train/<run_id>/`:
-  - `fold_metrics.csv`
   - `run_diagnostics.csv`
-  - `oof_predictions.csv`
-  - `test_predictions.csv`
+  - `model_summary.csv`
   - `run_manifest.json`
+  - per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/` containing:
+    - `fold_metrics.csv`
+    - `oof_predictions.csv`
+    - `test_predictions.csv`
+    - `submission.csv` when prepared or submitted
 - `run_manifest.json` is the canonical per-run metadata source
 - Training ledger at `artifacts/<competition_slug>/train/runs.csv` with compact comparison fields and task-aware target summary fields
-- Submission artifact in each run dir:
-  - `submission.csv`
 - Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv` with submission event metadata only
 
 ## Runtime Invariants And Failure Behavior
 - One runtime config source only: `config.yaml`
 - No config overrides via CLI or environment variables
 - `task_type` and `primary_metric` must be present in config for every run
-- `model_id` must resolve to a supported preset for the configured task; if omitted, the task default is used
+- `model_ids` is the preferred model-selection interface; `model_id` remains the single-model shorthand and the two keys are mutually exclusive
+- `model_ids` must resolve to one or more supported presets for the configured task; if omitted, the task default is used
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
 - Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
@@ -112,8 +117,9 @@ Manual verification steps for each target:
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
 - Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `run_manifest.json` rather than re-inferring them from raw train/test data
+- Multi-model submission must default to `best_model_id` unless a specific `model_id` is requested explicitly
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
-- `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
+- The selected model artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
@@ -128,7 +134,8 @@ Hard-error cases include:
 - Missing `task_type` or `primary_metric` -> hard error
 - Unknown/unsupported configured `primary_metric` -> hard error
 - Invalid task/metric pairing (for example `binary` + `rmse`) -> hard error
-- Invalid `model_id` for the configured task -> hard error
+- Invalid `model_id` or `model_ids` for the configured task -> hard error
+- Empty or duplicate `model_ids` -> hard error
 - Missing/invalid competition zip contents -> hard error
 - `id_column` inference not exactly one column -> hard error
 - `label_column` inference not exactly one column -> hard error
@@ -141,6 +148,7 @@ Hard-error cases include:
 - Unsupported metric for chosen task -> hard error
 - Any CV/training fit or scoring failure -> hard error
 - Fold assignment gaps in OOF generation -> hard error
+- Requested submission `model_id` not present in the run manifest -> hard error
 - Submission schema or ID mismatch against `sample_submission.csv` -> hard error
 - Kaggle submission command failure when `submit_enabled=true` -> hard error
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def main() -> None:
     config = load_config()
     print(
         "Resolved competition setup: "
-        f"task_type={config.task_type}, primary_metric={config.primary_metric}, model_id={config.model_id}"
+        f"task_type={config.task_type}, primary_metric={config.primary_metric}, model_ids={config.model_ids}"
     )
     data_dir = fetch_competition_data(config.competition_slug)
     print(f"Data ready: {data_dir}")
@@ -32,7 +32,7 @@ def main() -> None:
         competition_slug=config.competition_slug,
         task_type=config.task_type,
         primary_metric=config.primary_metric,
-        model_id=config.model_id,
+        model_ids=config.model_ids,
         positive_label=config.positive_label,
         id_column=config.id_column,
         label_column=config.label_column,

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -19,6 +19,7 @@ class AppConfig(BaseModel):
     task_type: Literal["regression", "binary"]
     primary_metric: str
     model_id: str | None = None
+    model_ids: list[str] | None = None
     positive_label: str | int | bool | None = None
     id_column: str | None = None
     label_column: str | None = None
@@ -45,14 +46,35 @@ class AppConfig(BaseModel):
                 f"Configured primary_metric '{normalized_primary_metric}' is not valid for task_type '{self.task_type}'."
             )
         self.primary_metric = normalized_primary_metric
-        resolved_model_id = self.model_id or get_default_model_id(self.task_type)
-        if not is_model_id_valid_for_task(self.task_type, resolved_model_id):
-            supported_model_ids = get_supported_model_ids(self.task_type)
+
+        if self.model_id is not None and self.model_ids is not None:
+            raise ValueError("model_id and model_ids are mutually exclusive. Use only one of them.")
+
+        if self.model_ids is not None:
+            if not self.model_ids:
+                raise ValueError("model_ids must contain at least one model_id.")
+            resolved_model_ids = self.model_ids
+        elif self.model_id is not None:
+            resolved_model_ids = [self.model_id]
+        else:
+            resolved_model_ids = [get_default_model_id(self.task_type)]
+
+        if len(set(resolved_model_ids)) != len(resolved_model_ids):
+            raise ValueError(f"model_ids must not contain duplicates: {resolved_model_ids}")
+
+        supported_model_ids = get_supported_model_ids(self.task_type)
+        invalid_model_ids = [
+            model_id for model_id in resolved_model_ids if not is_model_id_valid_for_task(self.task_type, model_id)
+        ]
+        if invalid_model_ids:
             raise ValueError(
-                f"Configured model_id '{resolved_model_id}' is not valid for task_type '{self.task_type}'. "
+                f"Configured model_ids {invalid_model_ids} are not valid for task_type '{self.task_type}'. "
                 f"Supported model_ids: {supported_model_ids}"
             )
-        self.model_id = resolved_model_id
+
+        self.model_ids = resolved_model_ids
+        self.model_id = resolved_model_ids[0] if len(resolved_model_ids) == 1 else None
+
         if self.task_type != "binary" and self.positive_label is not None:
             raise ValueError("positive_label is only supported for binary task_type.")
         return self

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -122,7 +122,16 @@ def _infer_legacy_model_id(task_type: str, model_name: object | None) -> str | N
     return legacy_model_map.get((task_type, str(model_name)))
 
 
-def _resolve_manifest_model_id(manifest: dict[str, object]) -> str:
+def _load_manifest_models(manifest: dict[str, object]) -> list[dict[str, object]]:
+    manifest_models = manifest.get("models")
+    if manifest_models is None:
+        return []
+    if not isinstance(manifest_models, list) or not all(isinstance(model, dict) for model in manifest_models):
+        raise ValueError("Run manifest models must be a list of mappings.")
+    return manifest_models
+
+
+def _resolve_legacy_manifest_model_id(manifest: dict[str, object]) -> str:
     model_id = manifest.get("model_id")
     if model_id is None:
         config_snapshot = manifest.get("config_snapshot", {})
@@ -142,23 +151,88 @@ def _resolve_manifest_model_id(manifest: dict[str, object]) -> str:
     )
 
 
-def _load_submission_run_context(run_dir: Path) -> SubmissionRunContext:
+def _resolve_selected_model_id(
+    manifest: dict[str, object],
+    requested_model_id: str | None = None,
+) -> str:
+    manifest_models = _load_manifest_models(manifest)
+    if manifest_models:
+        available_model_ids = [str(model["model_id"]) for model in manifest_models]
+        if requested_model_id is not None:
+            if requested_model_id not in available_model_ids:
+                raise ValueError(
+                    f"Requested model_id '{requested_model_id}' is not present in the run manifest. "
+                    f"Available model_ids: {available_model_ids}"
+                )
+            return requested_model_id
+
+        best_model_id = manifest.get("best_model_id")
+        if best_model_id is None and len(available_model_ids) == 1:
+            return available_model_ids[0]
+        if best_model_id not in available_model_ids:
+            raise ValueError(
+                "Run manifest best_model_id must match one of the available model entries. "
+                f"Available model_ids: {available_model_ids}"
+            )
+        return str(best_model_id)
+
+    resolved_model_id = _resolve_legacy_manifest_model_id(manifest)
+    if requested_model_id is not None and requested_model_id != resolved_model_id:
+        raise ValueError(
+            f"Requested model_id '{requested_model_id}' does not match the legacy run model_id '{resolved_model_id}'."
+        )
+    return resolved_model_id
+
+
+def _load_submission_run_context(
+    run_dir: Path,
+    model_id: str | None = None,
+) -> SubmissionRunContext:
     manifest = _load_run_manifest(run_dir)
     run_id = str(manifest["run_id"])
+    selected_model_id = _resolve_selected_model_id(manifest, requested_model_id=model_id)
     return SubmissionRunContext(
         run_id=run_id,
         competition_slug=str(_require_manifest_value(manifest, "competition_slug")),
         task_type=str(_require_manifest_value(manifest, "task_type")),
-        model_id=_resolve_manifest_model_id(manifest),
+        model_id=selected_model_id,
         id_column=str(_require_manifest_value(manifest, "id_column")),
         label_column=str(_require_manifest_value(manifest, "label_column")),
         config_fingerprint=manifest.get("config_fingerprint"),
     )
 
 
-def _load_run_metadata(run_dir: Path) -> dict[str, object]:
+def _load_run_metadata(
+    run_dir: Path,
+    model_id: str | None = None,
+) -> dict[str, object]:
     manifest = _load_run_manifest(run_dir)
-    model_id = _resolve_manifest_model_id(manifest)
+    selected_model_id = _resolve_selected_model_id(manifest, requested_model_id=model_id)
+    manifest_models = _load_manifest_models(manifest)
+
+    if manifest_models:
+        selected_model = next(
+            (model for model in manifest_models if str(model["model_id"]) == selected_model_id),
+            None,
+        )
+        if selected_model is None:
+            raise ValueError(
+                f"Requested model_id '{selected_model_id}' is missing from the run manifest model entries."
+            )
+        cv_summary = selected_model.get("cv_summary")
+        if not isinstance(cv_summary, dict):
+            raise ValueError("Run manifest model cv_summary must be a mapping.")
+        return {
+            "run_id": str(manifest["run_id"]),
+            "model_id": selected_model_id,
+            "config_fingerprint": manifest.get("config_fingerprint"),
+            "model_name": str(selected_model["model_name"]),
+            "metric_name": str(cv_summary["metric_name"]),
+            "metric_mean": float(cv_summary["metric_mean"]),
+            "metric_std": float(cv_summary["metric_std"]) if cv_summary.get("metric_std") is not None else None,
+            "higher_is_better": cv_summary.get("higher_is_better"),
+        }
+
     model_name = manifest.get("model_name")
     cv_summary = manifest.get("cv_summary")
     if isinstance(cv_summary, dict):
@@ -169,7 +243,7 @@ def _load_run_metadata(run_dir: Path) -> dict[str, object]:
         if model_name is not None and metric_name is not None and metric_mean is not None:
             return {
                 "run_id": str(manifest["run_id"]),
-                "model_id": model_id,
+                "model_id": selected_model_id,
                 "config_fingerprint": manifest.get("config_fingerprint"),
                 "model_name": str(model_name),
                 "metric_name": str(metric_name),
@@ -185,7 +259,7 @@ def _load_run_metadata(run_dir: Path) -> dict[str, object]:
     resolved_model_name = model_name if model_name is not None else legacy_summary["model_name"]
     return {
         "run_id": str(manifest["run_id"]),
-        "model_id": model_id,
+        "model_id": selected_model_id,
         "config_fingerprint": manifest.get("config_fingerprint"),
         "model_name": str(resolved_model_name),
         "metric_name": str(legacy_summary["metric_name"]),
@@ -193,6 +267,26 @@ def _load_run_metadata(run_dir: Path) -> dict[str, object]:
         "metric_std": float(legacy_summary["metric_std"]),
         "higher_is_better": legacy_summary["higher_is_better"],
     }
+
+
+def _resolve_prediction_path(
+    run_dir: Path,
+    model_id: str,
+) -> Path:
+    manifest = _load_run_manifest(run_dir)
+    manifest_models = _load_manifest_models(manifest)
+    model_prediction_path = run_dir / model_id / "test_predictions.csv"
+    if model_prediction_path.exists():
+        return model_prediction_path
+
+    legacy_prediction_path = run_dir / "test_predictions.csv"
+    if not manifest_models and legacy_prediction_path.exists():
+        return legacy_prediction_path
+
+    raise ValueError(
+        "Missing test predictions file for submission. "
+        f"Checked {model_prediction_path} and {legacy_prediction_path}"
+    )
 
 
 def _validate_submission_ids(
@@ -240,13 +334,11 @@ def _validate_submission_ids(
 
 def prepare_submission_file(
     run_dir: Path,
+    model_id: str | None = None,
 ) -> Path:
-    prediction_path = run_dir / "test_predictions.csv"
-    if not prediction_path.exists():
-        raise ValueError(f"Missing test predictions file: {prediction_path}")
-
+    run_context = _load_submission_run_context(run_dir=run_dir, model_id=model_id)
+    prediction_path = _resolve_prediction_path(run_dir=run_dir, model_id=run_context.model_id)
     prediction_df = pd.read_csv(prediction_path)
-    run_context = _load_submission_run_context(run_dir)
     sample_submission_df = load_sample_submission_template(run_context.competition_slug)
     validate_sample_submission_schema(
         sample_submission_df=sample_submission_df,
@@ -283,13 +375,17 @@ def prepare_submission_file(
         id_column=run_context.id_column,
     )
 
-    submission_path = run_dir / "submission.csv"
+    submission_path = prediction_path.parent / "submission.csv"
     prediction_df.to_csv(submission_path, index=False)
     return submission_path
 
 
-def build_submission_message(run_dir: Path, submit_message_prefix: str | None = None) -> str:
-    run_metadata = _load_run_metadata(run_dir)
+def build_submission_message(
+    run_dir: Path,
+    submit_message_prefix: str | None = None,
+    model_id: str | None = None,
+) -> str:
+    run_metadata = _load_run_metadata(run_dir=run_dir, model_id=model_id)
     message_parts = []
     if submit_message_prefix:
         message_parts.append(submit_message_prefix.strip())
@@ -303,11 +399,16 @@ def run_submission(
     run_dir: Path,
     submit_enabled: bool,
     submit_message_prefix: str | None = None,
+    model_id: str | None = None,
 ) -> tuple[Path, str]:
-    run_context = _load_submission_run_context(run_dir)
-    run_metadata = _load_run_metadata(run_dir)
-    submission_path = prepare_submission_file(run_dir=run_dir)
-    message = build_submission_message(run_dir=run_dir, submit_message_prefix=submit_message_prefix)
+    run_context = _load_submission_run_context(run_dir=run_dir, model_id=model_id)
+    run_metadata = _load_run_metadata(run_dir=run_dir, model_id=model_id)
+    submission_path = prepare_submission_file(run_dir=run_dir, model_id=model_id)
+    message = build_submission_message(
+        run_dir=run_dir,
+        submit_message_prefix=submit_message_prefix,
+        model_id=model_id,
+    )
 
     if submit_enabled:
         completed = subprocess.run(

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -17,11 +17,12 @@ RUN_LEDGER_COLUMNS = [
     "competition_slug",
     "task_type",
     "primary_metric",
-    "model_id",
-    "model_name",
+    "best_model_id",
+    "best_model_name",
     "cv_mean",
     "cv_std",
     "higher_is_better",
+    "model_count",
     "cv_n_splits",
     "cv_shuffle",
     "cv_random_state",
@@ -56,11 +57,25 @@ def _make_run_id() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
+def _read_run_ledger(ledger_path: Path) -> pd.DataFrame:
+    ledger_df = pd.read_csv(ledger_path)
+    if "best_model_id" not in ledger_df.columns:
+        legacy_model_id = ledger_df["model_id"] if "model_id" in ledger_df.columns else pd.Series("", index=ledger_df.index)
+        ledger_df["best_model_id"] = legacy_model_id
+    if "best_model_name" not in ledger_df.columns:
+        legacy_model_name = (
+            ledger_df["model_name"] if "model_name" in ledger_df.columns else pd.Series("", index=ledger_df.index)
+        )
+        ledger_df["best_model_name"] = legacy_model_name
+    if "model_count" not in ledger_df.columns:
+        ledger_df["model_count"] = 1
+    return ledger_df.reindex(columns=RUN_LEDGER_COLUMNS)
+
+
 def _append_run_ledger(ledger_path: Path, row: dict[str, object]) -> None:
-    ledger_df = pd.DataFrame([row])
-    ledger_df = ledger_df.reindex(columns=RUN_LEDGER_COLUMNS)
+    ledger_df = pd.DataFrame([row]).reindex(columns=RUN_LEDGER_COLUMNS)
     if ledger_path.exists():
-        existing_df = pd.read_csv(ledger_path)
+        existing_df = _read_run_ledger(ledger_path)
         merged_df = pd.concat([existing_df, ledger_df], ignore_index=True, sort=False)
         merged_df = merged_df.reindex(columns=RUN_LEDGER_COLUMNS)
         merged_df.to_csv(ledger_path, index=False)
@@ -154,6 +169,239 @@ def _build_diagnostic_rows(
     raise ValueError(f"Unsupported task_type for diagnostics: {task_type}")
 
 
+def _materialize_split_indices(
+    task_type: str,
+    x_train_raw: pd.DataFrame,
+    y_train: pd.Series,
+    n_splits: int,
+    shuffle: bool,
+    random_state: int,
+) -> list[tuple[int, np.ndarray, np.ndarray]]:
+    splitter = build_splitter(
+        task_type=task_type,
+        n_splits=n_splits,
+        shuffle=shuffle,
+        random_state=random_state,
+    )
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]] = []
+    for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train_raw, y_train), start=1):
+        split_indices.append((fold_index, train_idx, valid_idx))
+    return split_indices
+
+
+def _build_fold_assignments(
+    row_count: int,
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
+) -> np.ndarray:
+    fold_assignments = np.full(row_count, fill_value=-1, dtype=int)
+    for fold_index, _, valid_idx in split_indices:
+        if (fold_assignments[valid_idx] >= 0).any():
+            raise ValueError("Fold assignment failed: at least one training row received multiple validation folds.")
+        fold_assignments[valid_idx] = fold_index
+    if (fold_assignments < 0).any():
+        raise ValueError("Fold assignment failed: at least one training row did not receive a validation fold.")
+    return fold_assignments
+
+
+def _build_run_diagnostics(
+    task_type: str,
+    y_train: pd.Series,
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
+    positive_label: object | None = None,
+) -> pd.DataFrame:
+    run_diagnostics: list[dict[str, object]] = []
+    run_diagnostics.extend(
+        _build_diagnostic_rows(
+            task_type=task_type,
+            fold_index=0,
+            split_name="all",
+            y_values=y_train,
+            positive_label=positive_label,
+        )
+    )
+    for fold_index, train_idx, valid_idx in split_indices:
+        run_diagnostics.extend(
+            _build_diagnostic_rows(
+                task_type=task_type,
+                fold_index=fold_index,
+                split_name="train",
+                y_values=y_train.iloc[train_idx],
+                positive_label=positive_label,
+            )
+        )
+        run_diagnostics.extend(
+            _build_diagnostic_rows(
+                task_type=task_type,
+                fold_index=fold_index,
+                split_name="valid",
+                y_values=y_train.iloc[valid_idx],
+                positive_label=positive_label,
+            )
+        )
+    return pd.DataFrame(run_diagnostics)
+
+
+def _train_single_model(
+    competition_slug: str,
+    task_type: str,
+    primary_metric: str,
+    model_id: str,
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+    y_train: pd.Series,
+    test_ids: pd.Series,
+    id_column: str,
+    label_column: str,
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
+    fold_assignments: np.ndarray,
+    run_dir: Path,
+    force_categorical: list[str] | None,
+    force_numeric: list[str] | None,
+    low_cardinality_int_threshold: int | None,
+    cv_random_state: int,
+    positive_label: object | None,
+    negative_label: object | None,
+) -> dict[str, object]:
+    resolved_model_id, model_name, _, model_params = build_model(task_type, model_id, cv_random_state)
+
+    oof_predictions = np.zeros(x_train_raw.shape[0], dtype=float)
+    test_predictions_per_fold: list[np.ndarray] = []
+    fold_metrics: list[dict[str, object]] = []
+
+    for fold_index, train_idx, valid_idx in split_indices:
+        x_fold_train = x_train_raw.iloc[train_idx]
+        x_fold_valid = x_train_raw.iloc[valid_idx]
+        y_fold_train = y_train.iloc[train_idx]
+        y_fold_valid = y_train.iloc[valid_idx]
+
+        preprocessor, _, _ = build_preprocessor(
+            x_train_raw=x_fold_train,
+            force_categorical=force_categorical,
+            force_numeric=force_numeric,
+            low_cardinality_int_threshold=low_cardinality_int_threshold,
+        )
+        x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
+        x_fold_valid_processed = preprocessor.transform(x_fold_valid)
+        x_test_processed = preprocessor.transform(x_test_raw)
+
+        _, _, model, _ = build_model(task_type, resolved_model_id, cv_random_state)
+        model.fit(x_fold_train_processed, y_fold_train)
+
+        if task_type == "binary":
+            if positive_label is None or negative_label is None:
+                raise ValueError("Binary training requires resolved class metadata.")
+            positive_class_index = list(model.classes_).index(positive_label)
+            fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, positive_class_index]
+            fold_test_predictions = model.predict_proba(x_test_processed)[:, positive_class_index]
+        else:
+            fold_valid_predictions = model.predict(x_fold_valid_processed)
+            fold_test_predictions = model.predict(x_test_processed)
+
+        fold_score = score_predictions(
+            task_type=task_type,
+            primary_metric=primary_metric,
+            y_true=y_fold_valid,
+            y_pred=fold_valid_predictions,
+            positive_label=positive_label,
+        )
+
+        oof_predictions[valid_idx] = fold_valid_predictions
+        test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
+        fold_metrics.append(
+            {
+                "model_id": resolved_model_id,
+                "model_name": model_name,
+                "fold": fold_index,
+                "metric_name": primary_metric,
+                "metric_value": fold_score,
+                "train_rows": int(len(train_idx)),
+                "valid_rows": int(len(valid_idx)),
+            }
+        )
+
+    mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
+    if task_type == "regression" and primary_metric == "rmsle":
+        mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
+
+    model_dir = run_dir / resolved_model_id
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    fold_metrics_df = pd.DataFrame(fold_metrics)
+    fold_metrics_df.to_csv(model_dir / "fold_metrics.csv", index=False)
+
+    oof_df = pd.DataFrame(
+        {
+            "row_idx": np.arange(x_train_raw.shape[0], dtype=int),
+            "y_true": y_train.to_numpy(),
+            "y_pred": oof_predictions,
+            "fold": fold_assignments,
+            "model_id": resolved_model_id,
+            "model_name": model_name,
+        }
+    )
+    oof_df.to_csv(model_dir / "oof_predictions.csv", index=False)
+
+    test_predictions_df = pd.DataFrame(
+        {
+            id_column: test_ids.to_numpy(),
+            label_column: mean_test_predictions,
+        }
+    )
+    test_predictions_df.to_csv(model_dir / "test_predictions.csv", index=False)
+
+    return {
+        "competition_slug": competition_slug,
+        "model_id": resolved_model_id,
+        "model_name": model_name,
+        "model_params": model_params,
+        "cv_mean": float(fold_metrics_df["metric_value"].mean()),
+        "cv_std": float(fold_metrics_df["metric_value"].std(ddof=0)),
+        "higher_is_better": is_higher_better(primary_metric),
+    }
+
+
+def _rank_model_results(
+    model_results: list[dict[str, object]],
+    configured_model_ids: list[str],
+) -> list[dict[str, object]]:
+    model_order = {model_id: index for index, model_id in enumerate(configured_model_ids)}
+
+    sorted_results = sorted(
+        model_results,
+        key=lambda result: (
+            -float(result["cv_mean"]) if bool(result["higher_is_better"]) else float(result["cv_mean"]),
+            model_order[str(result["model_id"])],
+        ),
+    )
+
+    for rank, result in enumerate(sorted_results, start=1):
+        result["rank"] = rank
+        result["is_best_model"] = rank == 1
+
+    return sorted_results
+
+
+def _build_model_summary_rows(
+    ranked_model_results: list[dict[str, object]],
+    primary_metric: str,
+) -> list[dict[str, object]]:
+    summary_rows: list[dict[str, object]] = []
+    for result in ranked_model_results:
+        summary_rows.append(
+            {
+                "model_id": result["model_id"],
+                "model_name": result["model_name"],
+                "metric_name": primary_metric,
+                "cv_mean": result["cv_mean"],
+                "cv_std": result["cv_std"],
+                "higher_is_better": result["higher_is_better"],
+                "rank": result["rank"],
+                "is_best_model": result["is_best_model"],
+            }
+        )
+    return summary_rows
+
+
 def _build_run_manifest(
     run_id: str,
     generated_at_utc: str,
@@ -162,11 +410,9 @@ def _build_run_manifest(
     primary_metric: str,
     config_fingerprint: str,
     config_snapshot: dict[str, object],
-    model_id: str,
-    model_name: str,
-    model_params: dict[str, object],
-    cv_mean: float,
-    cv_std: float,
+    model_ids: list[str],
+    best_model_id: str,
+    models: list[dict[str, object]],
     observed_label_pair: tuple[object, object] | None,
     negative_label: object | None,
     positive_label: object | None,
@@ -178,7 +424,7 @@ def _build_run_manifest(
     test_rows: int,
     test_cols: int,
 ) -> dict[str, object]:
-    return {
+    run_manifest = {
         "run_id": run_id,
         "generated_at_utc": generated_at_utc,
         "competition_slug": competition_slug,
@@ -186,15 +432,9 @@ def _build_run_manifest(
         "primary_metric": primary_metric,
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
-        "model_id": model_id,
-        "model_name": model_name,
-        "model_params": model_params,
-        "cv_summary": {
-            "metric_name": primary_metric,
-            "metric_mean": cv_mean,
-            "metric_std": cv_std,
-            "higher_is_better": is_higher_better(primary_metric),
-        },
+        "model_ids": model_ids,
+        "best_model_id": best_model_id,
+        "models": models,
         "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
         "negative_label": negative_label,
         "positive_label": positive_label,
@@ -207,6 +447,15 @@ def _build_run_manifest(
         "test_cols": test_cols,
     }
 
+    if len(models) == 1:
+        single_model = models[0]
+        run_manifest["model_id"] = single_model["model_id"]
+        run_manifest["model_name"] = single_model["model_name"]
+        run_manifest["model_params"] = single_model["model_params"]
+        run_manifest["cv_summary"] = single_model["cv_summary"]
+
+    return run_manifest
+
 
 def _build_run_ledger_row(
     run_manifest: dict[str, object],
@@ -214,9 +463,21 @@ def _build_run_ledger_row(
     cv_shuffle: bool,
     cv_random_state: int,
 ) -> dict[str, object]:
-    cv_summary = run_manifest["cv_summary"]
+    models = run_manifest.get("models")
+    if not isinstance(models, list) or not models:
+        raise ValueError("Run manifest models must be a non-empty list.")
+
+    best_model_id = run_manifest.get("best_model_id")
+    best_model = next(
+        (model for model in models if isinstance(model, dict) and model.get("model_id") == best_model_id),
+        None,
+    )
+    if best_model is None:
+        raise ValueError("Run manifest best_model_id must match one of the model entries.")
+
+    cv_summary = best_model.get("cv_summary")
     if not isinstance(cv_summary, dict):
-        raise ValueError("Run manifest cv_summary must be a mapping.")
+        raise ValueError("Run manifest model cv_summary must be a mapping.")
 
     ledger_row = {
         "run_id": run_manifest["run_id"],
@@ -224,11 +485,12 @@ def _build_run_ledger_row(
         "competition_slug": run_manifest["competition_slug"],
         "task_type": run_manifest["task_type"],
         "primary_metric": run_manifest["primary_metric"],
-        "model_id": run_manifest["model_id"],
-        "model_name": run_manifest["model_name"],
+        "best_model_id": best_model["model_id"],
+        "best_model_name": best_model["model_name"],
         "cv_mean": cv_summary["metric_mean"],
         "cv_std": cv_summary["metric_std"],
         "higher_is_better": cv_summary["higher_is_better"],
+        "model_count": len(models),
         "cv_n_splits": cv_n_splits,
         "cv_shuffle": cv_shuffle,
         "cv_random_state": cv_random_state,
@@ -244,7 +506,7 @@ def run_training(
     competition_slug: str,
     task_type: str,
     primary_metric: str,
-    model_id: str,
+    model_ids: list[str],
     id_column: str | None = None,
     label_column: str | None = None,
     force_categorical: list[str] | None = None,
@@ -275,6 +537,7 @@ def run_training(
         force_numeric=force_numeric,
         drop_columns=drop_columns,
     )
+
     observed_label_pair = None
     negative_label = None
     if task_type == "binary":
@@ -283,114 +546,21 @@ def run_training(
             configured_positive_label=positive_label,
         )
 
-    model_id, model_name, _, model_params = build_model(task_type, model_id, cv_random_state)
-    splitter = build_splitter(
+    split_indices = _materialize_split_indices(
         task_type=task_type,
+        x_train_raw=x_train_raw,
+        y_train=y_train,
         n_splits=cv_n_splits,
         shuffle=cv_shuffle,
         random_state=cv_random_state,
     )
-
-    n_rows = x_train_raw.shape[0]
-    oof_predictions = np.zeros(n_rows, dtype=float)
-    fold_assignments = np.full(n_rows, fill_value=-1, dtype=int)
-    test_predictions_per_fold: list[np.ndarray] = []
-    fold_metrics: list[dict[str, object]] = []
-    run_diagnostics: list[dict[str, object]] = []
-    run_diagnostics.extend(
-        _build_diagnostic_rows(
-            task_type=task_type,
-            fold_index=0,
-            split_name="all",
-            y_values=y_train,
-            positive_label=positive_label,
-        )
+    fold_assignments = _build_fold_assignments(x_train_raw.shape[0], split_indices)
+    run_diagnostics_df = _build_run_diagnostics(
+        task_type=task_type,
+        y_train=y_train,
+        split_indices=split_indices,
+        positive_label=positive_label,
     )
-
-    for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train_raw, y_train), start=1):
-        x_fold_train = x_train_raw.iloc[train_idx]
-        x_fold_valid = x_train_raw.iloc[valid_idx]
-        y_fold_train = y_train.iloc[train_idx]
-        y_fold_valid = y_train.iloc[valid_idx]
-        run_diagnostics.extend(
-            _build_diagnostic_rows(
-                task_type=task_type,
-                fold_index=fold_index,
-                split_name="train",
-                y_values=y_fold_train,
-                positive_label=positive_label,
-            )
-        )
-        run_diagnostics.extend(
-            _build_diagnostic_rows(
-                task_type=task_type,
-                fold_index=fold_index,
-                split_name="valid",
-                y_values=y_fold_valid,
-                positive_label=positive_label,
-            )
-        )
-
-        preprocessor, _, _ = build_preprocessor(
-            x_train_raw=x_fold_train,
-            force_categorical=force_categorical,
-            force_numeric=force_numeric,
-            low_cardinality_int_threshold=low_cardinality_int_threshold,
-        )
-
-        x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
-        x_fold_valid_processed = preprocessor.transform(x_fold_valid)
-        x_test_processed = preprocessor.transform(x_test_raw)
-
-        _, _, model, _ = build_model(task_type, model_id, cv_random_state)
-        model.fit(x_fold_train_processed, y_fold_train)
-
-        if task_type == "binary":
-            if positive_label is None:
-                raise ValueError("Binary training requires positive_label.")
-            if negative_label is None:
-                raise ValueError("Binary training requires negative_label.")
-            positive_class_index = list(model.classes_).index(positive_label)
-            fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, positive_class_index]
-            fold_test_predictions = model.predict_proba(x_test_processed)[:, positive_class_index]
-        else:
-            fold_valid_predictions = model.predict(x_fold_valid_processed)
-            fold_test_predictions = model.predict(x_test_processed)
-
-        fold_score = score_predictions(
-            task_type=task_type,
-            primary_metric=primary_metric,
-            y_true=y_fold_valid,
-            y_pred=fold_valid_predictions,
-            positive_label=positive_label,
-        )
-
-        oof_predictions[valid_idx] = fold_valid_predictions
-        fold_assignments[valid_idx] = fold_index
-        test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
-        fold_metrics.append(
-            {
-                "model_id": model_id,
-                "model_name": model_name,
-                "fold": fold_index,
-                "metric_name": primary_metric,
-                "metric_value": fold_score,
-                "train_rows": int(len(train_idx)),
-                "valid_rows": int(len(valid_idx)),
-            }
-        )
-
-    if (fold_assignments < 0).any():
-        raise ValueError("Fold assignment failed: at least one training row did not receive a validation fold.")
-
-    mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
-    if task_type == "regression" and primary_metric == "rmsle":
-        mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
-
-    fold_metrics_df = pd.DataFrame(fold_metrics)
-    run_diagnostics_df = pd.DataFrame(run_diagnostics)
-    cv_mean = float(fold_metrics_df["metric_value"].mean())
-    cv_std = float(fold_metrics_df["metric_value"].std(ddof=0))
     target_summary = _build_target_summary(
         task_type=task_type,
         y_train=y_train,
@@ -402,35 +572,69 @@ def run_training(
     run_id = _make_run_id()
     run_dir = Path("artifacts") / competition_slug / "train" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
-
-    fold_metrics_df.to_csv(run_dir / "fold_metrics.csv", index=False)
     run_diagnostics_df.to_csv(run_dir / "run_diagnostics.csv", index=False)
 
-    oof_df = pd.DataFrame(
-        {
-            "row_idx": np.arange(n_rows, dtype=int),
-            "y_true": y_train.to_numpy(),
-            "y_pred": oof_predictions,
-            "fold": fold_assignments,
-            "model_id": model_id,
-            "model_name": model_name,
-        }
-    )
-    oof_df.to_csv(run_dir / "oof_predictions.csv", index=False)
+    model_results: list[dict[str, object]] = []
+    for configured_model_id in model_ids:
+        model_result = _train_single_model(
+            competition_slug=competition_slug,
+            task_type=task_type,
+            primary_metric=primary_metric,
+            model_id=configured_model_id,
+            x_train_raw=x_train_raw,
+            x_test_raw=x_test_raw,
+            y_train=y_train,
+            test_ids=test_df[id_column],
+            id_column=id_column,
+            label_column=label_column,
+            split_indices=split_indices,
+            fold_assignments=fold_assignments,
+            run_dir=run_dir,
+            force_categorical=force_categorical,
+            force_numeric=force_numeric,
+            low_cardinality_int_threshold=low_cardinality_int_threshold,
+            cv_random_state=cv_random_state,
+            positive_label=positive_label,
+            negative_label=negative_label,
+        )
+        model_results.append(model_result)
+        print(
+            f"Training model: {model_result['model_id']} ({model_result['model_name']}) | "
+            f"CV {primary_metric}: mean={model_result['cv_mean']:.6f}, std={model_result['cv_std']:.6f}"
+        )
 
-    test_predictions_df = pd.DataFrame(
-        {
-            id_column: test_df[id_column].to_numpy(),
-            label_column: mean_test_predictions,
-        }
-    )
-    test_predictions_df.to_csv(run_dir / "test_predictions.csv", index=False)
+    ranked_model_results = _rank_model_results(model_results, model_ids)
+    model_summary_rows = _build_model_summary_rows(ranked_model_results, primary_metric)
+    model_summary_df = pd.DataFrame(model_summary_rows)
+    model_summary_df.to_csv(run_dir / "model_summary.csv", index=False)
+
+    best_model_result = ranked_model_results[0]
+    model_entries = []
+    for result in model_results:
+        model_entries.append(
+            {
+                "model_id": result["model_id"],
+                "model_name": result["model_name"],
+                "model_params": result["model_params"],
+                "cv_summary": {
+                    "metric_name": primary_metric,
+                    "metric_mean": result["cv_mean"],
+                    "metric_std": result["cv_std"],
+                    "higher_is_better": result["higher_is_better"],
+                },
+                "rank": next(row["rank"] for row in model_summary_rows if row["model_id"] == result["model_id"]),
+                "is_best_model": next(
+                    row["is_best_model"] for row in model_summary_rows if row["model_id"] == result["model_id"]
+                ),
+            }
+        )
 
     config_snapshot = {
         "competition_slug": competition_slug,
         "task_type": task_type,
         "primary_metric": primary_metric,
-        "model_id": model_id,
+        "model_id": model_ids[0] if len(model_ids) == 1 else None,
+        "model_ids": model_ids,
         "positive_label": positive_label,
         "id_column": id_column,
         "label_column": label_column,
@@ -444,8 +648,13 @@ def run_training(
     }
     fingerprint_payload = {
         "config_snapshot": config_snapshot,
-        "model_name": model_name,
-        "model_params": model_params,
+        "models": [
+            {
+                "model_id": result["model_id"],
+                "model_params": result["model_params"],
+            }
+            for result in model_results
+        ],
     }
     config_snapshot_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
     config_fingerprint = hashlib.sha256(config_snapshot_json.encode("utf-8")).hexdigest()[:12]
@@ -459,11 +668,9 @@ def run_training(
         primary_metric=primary_metric,
         config_fingerprint=config_fingerprint,
         config_snapshot=config_snapshot,
-        model_id=model_id,
-        model_name=model_name,
-        model_params=model_params,
-        cv_mean=cv_mean,
-        cv_std=cv_std,
+        model_ids=model_ids,
+        best_model_id=str(best_model_result["model_id"]),
+        models=model_entries,
         observed_label_pair=observed_label_pair,
         negative_label=negative_label,
         positive_label=positive_label,
@@ -487,7 +694,9 @@ def run_training(
     ledger_path = Path("artifacts") / competition_slug / "train" / "runs.csv"
     _append_run_ledger(ledger_path, ledger_row)
 
-    print(f"Training model: {model_id} ({model_name})")
-    print(f"CV {primary_metric}: mean={cv_mean:.6f}, std={cv_std:.6f}")
+    print(
+        f"Best model: {best_model_result['model_id']} ({best_model_result['model_name']}) | "
+        f"CV {primary_metric}: mean={best_model_result['cv_mean']:.6f}, std={best_model_result['cv_std']:.6f}"
+    )
 
     return run_dir


### PR DESCRIPTION
## Summary
- add `model_ids` as the public multi-model config interface while retaining `model_id` as the single-model shorthand
- refactor training to share one split plan across selected models and write per-model artifacts under `<run_id>/<model_id>/`
- add run-root `model_summary.csv`, extend `run_manifest.json` with model entries and `best_model_id`, and slim `runs.csv` to best-model summary fields
- make submission default to the run `best_model_id` while allowing explicit model selection and preserving legacy single-model compatibility
- update the README, technical guide, and sample config for the multi-model contract

Closes #2.

## Verification
- `uv run python -m compileall main.py src`
- `uv run python - <<'PY'`
  created local mock regression and binary competition zips
  verified `AppConfig` resolves `model_ids` for both multi-model and single-model configs
  ran `run_training()` on regression and binary tasks with `elasticnet`/`logistic_regression` plus `random_forest`
  confirmed run-root `model_summary.csv` and per-model `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`
  confirmed `run_submission()` defaults to `best_model_id` and can also target an explicit `model_id`
  confirmed legacy root-level submission artifacts still work for older single-model runs
  `PY`
- `uv run python - <<'PY'`
  smoke-tested a new single-model run using `model_id: random_forest`
  confirmed the new single-model layout writes artifacts under `<run_id>/random_forest/`
  `PY`