### PR TITLE
Add preprocessing-aware sklearn model recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ The repository is developed and manually verified primarily against these Playgr
 - Load and validate a single repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Require explicit `task_type` and `primary_metric` in config.
-- Select one or more baseline models per run from config via `model_ids`, with `model_id` retained as the single-model shorthand.
+- Select one or more baseline model recipes per run from config via `model_ids`, with `model_id` retained as the single-model shorthand.
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
-- Train one or more baseline cross-validated models with fold-local preprocessing:
-  - regression: `elasticnet` (`ElasticNet`) or `random_forest` (`RandomForestRegressor`)
-  - binary classification: `logistic_regression` (`LogisticRegression`) or `random_forest` (`RandomForestClassifier`)
+- Train one or more baseline cross-validated model recipes with fold-local, model-specific preprocessing:
+  - `onehot` preprocessing: `onehot_ridge`, `onehot_elasticnet`, `onehot_logreg`
+  - `ordinal` preprocessing: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
 - Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
 
@@ -42,7 +42,7 @@ The repository is developed and manually verified primarily against these Playgr
 3. Keep a project `config.yaml` at repository root with explicit `competition_slug`, `task_type`, and `primary_metric`.
 4. Run `uv run python main.py`.
 
-The current pipeline fetches competition data if needed, runs config-aware EDA, trains a baseline CV model with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
+The current pipeline fetches competition data if needed, runs config-aware EDA, trains one or more baseline CV model recipes with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
 
 ## Config Overview
 Required keys:
@@ -54,10 +54,11 @@ Optional binary-classification key:
 - `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 
 Optional model-selection key:
-- `model_ids`: ordered list of baseline model presets for the configured task
+- `model_ids`: ordered list of baseline model recipes for the configured task
 - `model_id`: single-model shorthand retained for backward compatibility; mutually exclusive with `model_ids`
-  - regression: `elasticnet` (default), `random_forest`
-  - binary classification: `logistic_regression` (default), `random_forest`
+  - regression: `onehot_ridge`, `onehot_elasticnet` (default), `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+  - binary classification: `onehot_logreg` (default), `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+  - compatibility aliases accepted during transition: `elasticnet`, `logistic_regression`, `random_forest`
 
 Optional submission schema keys:
 - `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
@@ -80,7 +81,7 @@ Optional submission keys:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-`model_ids` is the preferred config-driven model interface. If both `model_id` and `model_ids` are omitted, the workflow selects the current default baseline for the configured task: `elasticnet` for regression and `logistic_regression` for binary classification. If `model_id` is provided, it resolves to a single-entry `model_ids` list.
+`model_ids` is the preferred config-driven model interface. If both `model_id` and `model_ids` are omitted, the workflow selects the current default recipe for the configured task: `onehot_elasticnet` for regression and `onehot_logreg` for binary classification. If `model_id` is provided, it resolves to a single-entry `model_ids` list. Backward-compatible aliases are normalized to the canonical preprocessing-first IDs during config loading, so run artifacts always use the canonical IDs.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -97,8 +98,9 @@ competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
 model_ids:
-  - logistic_regression
-  - random_forest
+  - onehot_logreg
+  - ordinal_hgb
+  - ordinal_randomforest
 ```
 
 Example regression config:
@@ -108,8 +110,9 @@ competition_slug: playground-series-s5e10
 task_type: regression
 primary_metric: mse
 model_ids:
-  - elasticnet
-  - random_forest
+  - onehot_ridge
+  - onehot_elasticnet
+  - ordinal_hgb
 ```
 
 Manual verification for each target:
@@ -127,6 +130,7 @@ Manual verification for each target:
   - includes per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/`
   - each model subdirectory includes `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
   - `run_manifest.json` is the canonical per-run metadata source
+  - each model summary/manifest entry records the resolved `preprocessing_scheme_id`
 - Run ledger: `artifacts/<competition_slug>/train/runs.csv` as a compact comparison/history table
 - Submission ledger: `artifacts/<competition_slug>/train/submissions.csv` as an append-only submission event table
 
@@ -135,6 +139,7 @@ Manual verification for each target:
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
+- Model IDs resolve to preprocessing-aware training recipes; run artifacts record the canonical `model_id` and `preprocessing_scheme_id`.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -11,12 +11,12 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 4. Read `train.csv`, `test.csv`, and `sample_submission.csv` from the zip as needed.
 5. Run EDA and write report CSVs under `reports/<competition_slug>/`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
-7. During training, build fold-local preprocessing for the selected feature types:
-   - numeric: median imputation + `StandardScaler`
-   - categorical: most-frequent imputation + `OneHotEncoder`
+7. During training, build fold-local preprocessing from the selected model recipe:
+   - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
+   - `ordinal`: numeric median imputation; categorical most-frequent imputation + `OrdinalEncoder`
 8. Train the configured baseline model or models from the resolved `model_ids` list:
-   - regression: `elasticnet` (`ElasticNet`) or `random_forest` (`RandomForestRegressor`)
-   - binary classification: `logistic_regression` (`LogisticRegression`) or `random_forest` (`RandomForestClassifier`)
+   - regression: `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+   - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
 9. Write run-level diagnostics, `model_summary.csv`, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
 11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
@@ -26,8 +26,8 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
-- `src/tabular_shenanigans/models.py`: single-model registry and estimator construction for supported baseline presets.
-- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and sklearn preprocessing pipelines.
+- `src/tabular_shenanigans/models.py`: model-recipe registry, compatibility alias resolution, and estimator construction for supported baseline presets.
+- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and scheme-specific sklearn preprocessing pipelines.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/train.py`: config-selected multi-model training, shared split handling, artifact writing, and run ledger updates.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
@@ -40,10 +40,11 @@ Input:
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
 - Optional model-selection key:
-  - `model_ids` (ordered list of baseline model presets for the configured task)
+  - `model_ids` (ordered list of baseline model recipes for the configured task)
   - `model_id` (single-model shorthand; mutually exclusive with `model_ids`)
-    - regression: `elasticnet`, `random_forest`
-    - binary classification: `logistic_regression`, `random_forest`
+    - regression: `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+    - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+    - compatibility aliases accepted during transition: `elasticnet`, `logistic_regression`, `random_forest`
 - Optional binary-classification key:
   - `positive_label` (explicit positive class for binary competitions; required unless observed labels match one of the documented safe conventions `[0, 1]`, `[False, True]`, or `["No", "Yes"]`)
 - Optional submission schema keys:
@@ -100,6 +101,7 @@ Manual verification steps for each target:
     - `test_predictions.csv`
     - `submission.csv` when prepared or submitted
 - `run_manifest.json` is the canonical per-run metadata source
+- Each model entry in `model_summary.csv` and `run_manifest.json` records the resolved `preprocessing_scheme_id`
 - Training ledger at `artifacts/<competition_slug>/train/runs.csv` with compact comparison fields and task-aware target summary fields
 - Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv` with submission event metadata only
 
@@ -109,6 +111,7 @@ Manual verification steps for each target:
 - `task_type` and `primary_metric` must be present in config for every run
 - `model_ids` is the preferred model-selection interface; `model_id` remains the single-model shorthand and the two keys are mutually exclusive
 - `model_ids` must resolve to one or more supported presets for the configured task; if omitted, the task default is used
+- Configured model IDs are normalized to canonical preprocessing-first recipe IDs during config loading
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
 - Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
@@ -165,6 +168,6 @@ Hard-error cases include:
 ## Extension Notes
 - New config keys should be added to `AppConfig` in `config.py` and documented in both this file and `README.md` when user-facing.
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
-- New model families should be introduced in `models.py` with explicit task compatibility and matching artifact outputs.
-- New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract.
+- New model families should be introduced in `models.py` with explicit task compatibility, canonical recipe IDs, and matching artifact outputs.
+- New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract or the preprocessing-first recipe naming convention.
 - New run or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -5,7 +5,12 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
-from tabular_shenanigans.models import get_default_model_id, get_supported_model_ids, is_model_id_valid_for_task
+from tabular_shenanigans.models import (
+    get_default_model_id,
+    get_supported_model_ids,
+    is_model_id_valid_for_task,
+    resolve_model_id,
+)
 
 
 class ConfigError(ValueError):
@@ -59,10 +64,7 @@ class AppConfig(BaseModel):
         else:
             resolved_model_ids = [get_default_model_id(self.task_type)]
 
-        if len(set(resolved_model_ids)) != len(resolved_model_ids):
-            raise ValueError(f"model_ids must not contain duplicates: {resolved_model_ids}")
-
-        supported_model_ids = get_supported_model_ids(self.task_type)
+        supported_model_ids = get_supported_model_ids(self.task_type, include_aliases=True)
         invalid_model_ids = [
             model_id for model_id in resolved_model_ids if not is_model_id_valid_for_task(self.task_type, model_id)
         ]
@@ -72,8 +74,12 @@ class AppConfig(BaseModel):
                 f"Supported model_ids: {supported_model_ids}"
             )
 
-        self.model_ids = resolved_model_ids
-        self.model_id = resolved_model_ids[0] if len(resolved_model_ids) == 1 else None
+        canonical_model_ids = [resolve_model_id(self.task_type, model_id) for model_id in resolved_model_ids]
+        if len(set(canonical_model_ids)) != len(canonical_model_ids):
+            raise ValueError(f"model_ids must not contain duplicates after alias resolution: {canonical_model_ids}")
+
+        self.model_ids = canonical_model_ids
+        self.model_id = canonical_model_ids[0] if len(canonical_model_ids) == 1 else None
 
         if self.task_type != "binary" and self.positive_label is not None:
             raise ValueError("positive_label is only supported for binary task_type.")

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -1,8 +1,15 @@
 from dataclasses import dataclass
 from typing import Callable
 
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.linear_model import ElasticNet, LogisticRegression
+from sklearn.ensemble import (
+    ExtraTreesClassifier,
+    ExtraTreesRegressor,
+    HistGradientBoostingClassifier,
+    HistGradientBoostingRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
+from sklearn.linear_model import ElasticNet, LogisticRegression, Ridge
 
 ModelBuilder = Callable[[int], tuple[object, dict[str, object]]]
 
@@ -11,7 +18,13 @@ ModelBuilder = Callable[[int], tuple[object, dict[str, object]]]
 class ModelDefinition:
     model_id: str
     model_name: str
+    preprocessing_scheme_id: str
     builder: ModelBuilder
+
+
+def _build_ridge(random_state: int) -> tuple[Ridge, dict[str, object]]:
+    del random_state
+    return Ridge(), {}
 
 
 def _build_elasticnet(random_state: int) -> tuple[ElasticNet, dict[str, object]]:
@@ -20,51 +33,145 @@ def _build_elasticnet(random_state: int) -> tuple[ElasticNet, dict[str, object]]
 
 
 def _build_random_forest_regressor(random_state: int) -> tuple[RandomForestRegressor, dict[str, object]]:
-    params = {"random_state": random_state}
+    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
     return RandomForestRegressor(**params), params
 
 
-def _build_logistic_regression(random_state: int) -> tuple[LogisticRegression, dict[str, object]]:
+def _build_extra_trees_regressor(random_state: int) -> tuple[ExtraTreesRegressor, dict[str, object]]:
+    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
+    return ExtraTreesRegressor(**params), params
+
+
+def _build_hist_gradient_boosting_regressor(
+    random_state: int,
+) -> tuple[HistGradientBoostingRegressor, dict[str, object]]:
+    params = {
+        "early_stopping": False,
+        "learning_rate": 0.05,
+        "max_iter": 300,
+        "random_state": random_state,
+    }
+    return HistGradientBoostingRegressor(**params), params
+
+
+def _build_logreg(random_state: int) -> tuple[LogisticRegression, dict[str, object]]:
     del random_state
-    return LogisticRegression(), {}
+    params = {"max_iter": 1000}
+    return LogisticRegression(**params), params
 
 
 def _build_random_forest_classifier(random_state: int) -> tuple[RandomForestClassifier, dict[str, object]]:
-    params = {"random_state": random_state}
+    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
     return RandomForestClassifier(**params), params
 
 
+def _build_extra_trees_classifier(random_state: int) -> tuple[ExtraTreesClassifier, dict[str, object]]:
+    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
+    return ExtraTreesClassifier(**params), params
+
+
+def _build_hist_gradient_boosting_classifier(
+    random_state: int,
+) -> tuple[HistGradientBoostingClassifier, dict[str, object]]:
+    params = {
+        "early_stopping": False,
+        "learning_rate": 0.05,
+        "max_iter": 300,
+        "random_state": random_state,
+    }
+    return HistGradientBoostingClassifier(**params), params
+
+
 DEFAULT_MODEL_ID_BY_TASK = {
-    "regression": "elasticnet",
-    "binary": "logistic_regression",
+    "regression": "onehot_elasticnet",
+    "binary": "onehot_logreg",
 }
 
 MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
     "regression": {
-        "elasticnet": ModelDefinition(
-            model_id="elasticnet",
+        "onehot_ridge": ModelDefinition(
+            model_id="onehot_ridge",
+            model_name="Ridge",
+            preprocessing_scheme_id="onehot",
+            builder=_build_ridge,
+        ),
+        "onehot_elasticnet": ModelDefinition(
+            model_id="onehot_elasticnet",
             model_name="ElasticNet",
+            preprocessing_scheme_id="onehot",
             builder=_build_elasticnet,
         ),
-        "random_forest": ModelDefinition(
-            model_id="random_forest",
+        "ordinal_randomforest": ModelDefinition(
+            model_id="ordinal_randomforest",
             model_name="RandomForestRegressor",
+            preprocessing_scheme_id="ordinal",
             builder=_build_random_forest_regressor,
+        ),
+        "ordinal_extratrees": ModelDefinition(
+            model_id="ordinal_extratrees",
+            model_name="ExtraTreesRegressor",
+            preprocessing_scheme_id="ordinal",
+            builder=_build_extra_trees_regressor,
+        ),
+        "ordinal_hgb": ModelDefinition(
+            model_id="ordinal_hgb",
+            model_name="HistGradientBoostingRegressor",
+            preprocessing_scheme_id="ordinal",
+            builder=_build_hist_gradient_boosting_regressor,
         ),
     },
     "binary": {
-        "logistic_regression": ModelDefinition(
-            model_id="logistic_regression",
+        "onehot_logreg": ModelDefinition(
+            model_id="onehot_logreg",
             model_name="LogisticRegression",
-            builder=_build_logistic_regression,
+            preprocessing_scheme_id="onehot",
+            builder=_build_logreg,
         ),
-        "random_forest": ModelDefinition(
-            model_id="random_forest",
+        "ordinal_randomforest": ModelDefinition(
+            model_id="ordinal_randomforest",
             model_name="RandomForestClassifier",
+            preprocessing_scheme_id="ordinal",
             builder=_build_random_forest_classifier,
+        ),
+        "ordinal_extratrees": ModelDefinition(
+            model_id="ordinal_extratrees",
+            model_name="ExtraTreesClassifier",
+            preprocessing_scheme_id="ordinal",
+            builder=_build_extra_trees_classifier,
+        ),
+        "ordinal_hgb": ModelDefinition(
+            model_id="ordinal_hgb",
+            model_name="HistGradientBoostingClassifier",
+            preprocessing_scheme_id="ordinal",
+            builder=_build_hist_gradient_boosting_classifier,
         ),
     },
 }
+
+MODEL_ID_ALIASES: dict[str, dict[str, str]] = {
+    "regression": {
+        "elasticnet": "onehot_elasticnet",
+        "random_forest": "ordinal_randomforest",
+    },
+    "binary": {
+        "logistic_regression": "onehot_logreg",
+        "random_forest": "ordinal_randomforest",
+    },
+}
+
+
+def _get_task_model_registry(task_type: str) -> dict[str, ModelDefinition]:
+    try:
+        return MODEL_REGISTRY[task_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
+
+
+def _get_task_model_aliases(task_type: str) -> dict[str, str]:
+    try:
+        return MODEL_ID_ALIASES[task_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
 
 
 def get_default_model_id(task_type: str) -> str:
@@ -74,17 +181,39 @@ def get_default_model_id(task_type: str) -> str:
         raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
 
 
-def get_supported_model_ids(task_type: str) -> list[str]:
-    try:
-        return sorted(MODEL_REGISTRY[task_type])
-    except KeyError as exc:
-        raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
+def get_supported_model_ids(task_type: str, include_aliases: bool = False) -> list[str]:
+    supported_model_ids = sorted(_get_task_model_registry(task_type))
+    if not include_aliases:
+        return supported_model_ids
+    return sorted(supported_model_ids + list(_get_task_model_aliases(task_type)))
+
+
+def resolve_model_id(task_type: str, model_id: str) -> str:
+    task_registry = _get_task_model_registry(task_type)
+    if model_id in task_registry:
+        return model_id
+
+    task_aliases = _get_task_model_aliases(task_type)
+    if model_id in task_aliases:
+        return task_aliases[model_id]
+
+    supported_model_ids = get_supported_model_ids(task_type, include_aliases=True)
+    raise ValueError(
+        f"Configured model_id '{model_id}' is not valid for task_type '{task_type}'. "
+        f"Supported model_ids: {supported_model_ids}"
+    )
+
+
+def get_model_definition(task_type: str, model_id: str) -> ModelDefinition:
+    resolved_model_id = resolve_model_id(task_type, model_id)
+    return _get_task_model_registry(task_type)[resolved_model_id]
 
 
 def is_model_id_valid_for_task(task_type: str, model_id: str) -> bool:
     try:
-        return model_id in MODEL_REGISTRY[task_type]
-    except KeyError:
+        resolve_model_id(task_type, model_id)
+        return True
+    except ValueError:
         return False
 
 
@@ -92,14 +221,7 @@ def build_model(
     task_type: str,
     model_id: str,
     random_state: int,
-) -> tuple[str, str, object, dict[str, object]]:
-    if not is_model_id_valid_for_task(task_type, model_id):
-        supported_model_ids = get_supported_model_ids(task_type)
-        raise ValueError(
-            f"Configured model_id '{model_id}' is not valid for task_type '{task_type}'. "
-            f"Supported model_ids: {supported_model_ids}"
-        )
-
-    model_definition = MODEL_REGISTRY[task_type][model_id]
+) -> tuple[ModelDefinition, object, dict[str, object]]:
+    model_definition = get_model_definition(task_type, model_id)
     estimator, explicit_params = model_definition.builder(random_state)
-    return model_definition.model_id, model_definition.model_name, estimator, explicit_params
+    return model_definition, estimator, explicit_params

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -1,15 +1,30 @@
+from dataclasses import dataclass
+from typing import Callable
+
 import pandas as pd
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.preprocessing import FunctionTransformer, OneHotEncoder, OrdinalEncoder, StandardScaler
+
+PreprocessorBuilder = Callable[[list[str], list[str]], ColumnTransformer]
+
+
+@dataclass(frozen=True)
+class PreprocessingDefinition:
+    scheme_id: str
+    scheme_name: str
+    builder: PreprocessorBuilder
 
 
 def _validate_column_names(config_name: str, columns: list[str], available_columns: list[str]) -> None:
     missing_columns = [column for column in columns if column not in available_columns]
     if missing_columns:
         raise ValueError(f"{config_name} has unknown columns: {missing_columns}")
+
+
+def _coerce_object(frame: pd.DataFrame) -> pd.DataFrame:
+    return frame.astype(object)
 
 
 def _resolve_feature_types(
@@ -74,7 +89,92 @@ def prepare_feature_frames(
     return x_train_raw, x_test_raw, y_train
 
 
+def _build_linear_onehot_preprocessor(
+    numeric_columns: list[str],
+    categorical_columns: list[str],
+) -> ColumnTransformer:
+    numeric_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+        ]
+    )
+
+    categorical_pipeline = Pipeline(
+        steps=[
+            ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
+            ("imputer", SimpleImputer(strategy="most_frequent")),
+            ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
+        ]
+    )
+
+    transformers = []
+    if numeric_columns:
+        transformers.append(("num", numeric_pipeline, numeric_columns))
+    if categorical_columns:
+        transformers.append(("cat", categorical_pipeline, categorical_columns))
+    return ColumnTransformer(transformers=transformers, remainder="drop")
+
+
+def _build_ordinal_preprocessor(
+    numeric_columns: list[str],
+    categorical_columns: list[str],
+) -> ColumnTransformer:
+    numeric_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+        ]
+    )
+
+    categorical_pipeline = Pipeline(
+        steps=[
+            ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
+            ("imputer", SimpleImputer(strategy="most_frequent")),
+            (
+                "ordinal",
+                OrdinalEncoder(
+                    handle_unknown="use_encoded_value",
+                    unknown_value=-1,
+                    encoded_missing_value=-1,
+                ),
+            ),
+        ]
+    )
+
+    transformers = []
+    if numeric_columns:
+        transformers.append(("num", numeric_pipeline, numeric_columns))
+    if categorical_columns:
+        transformers.append(("cat", categorical_pipeline, categorical_columns))
+    return ColumnTransformer(transformers=transformers, remainder="drop")
+
+
+PREPROCESSING_REGISTRY = {
+    "onehot": PreprocessingDefinition(
+        scheme_id="onehot",
+        scheme_name="OneHotLinear",
+        builder=_build_linear_onehot_preprocessor,
+    ),
+    "ordinal": PreprocessingDefinition(
+        scheme_id="ordinal",
+        scheme_name="OrdinalTree",
+        builder=_build_ordinal_preprocessor,
+    ),
+}
+
+
+def get_preprocessing_definition(scheme_id: str) -> PreprocessingDefinition:
+    try:
+        return PREPROCESSING_REGISTRY[scheme_id]
+    except KeyError as exc:
+        supported_scheme_ids = sorted(PREPROCESSING_REGISTRY)
+        raise ValueError(
+            f"Unsupported preprocessing scheme '{scheme_id}'. Supported values: {supported_scheme_ids}"
+        ) from exc
+
+
 def build_preprocessor(
+    scheme_id: str,
     x_train_raw: pd.DataFrame,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
@@ -90,36 +190,11 @@ def build_preprocessor(
         low_cardinality_int_threshold=low_cardinality_int_threshold,
     )
 
-    numeric_pipeline = Pipeline(
-        steps=[
-            ("imputer", SimpleImputer(strategy="median")),
-            ("scaler", StandardScaler()),
-        ]
-    )
-
-    categorical_pipeline = Pipeline(
-        steps=[
-            (
-                "coerce_object",
-                FunctionTransformer(
-                    lambda frame: frame.astype(object),
-                    feature_names_out="one-to-one",
-                ),
-            ),
-            ("imputer", SimpleImputer(strategy="most_frequent")),
-            ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
-        ]
-    )
-
-    transformers = []
-    if numeric_columns:
-        transformers.append(("num", numeric_pipeline, numeric_columns))
-    if categorical_columns:
-        transformers.append(("cat", categorical_pipeline, categorical_columns))
-    if not transformers:
+    if not numeric_columns and not categorical_columns:
         raise ValueError("No modeled features remain after excluding id_column and applying drop_columns.")
 
-    preprocessor = ColumnTransformer(transformers=transformers, remainder="drop")
+    preprocessing_definition = get_preprocessing_definition(scheme_id)
+    preprocessor = preprocessing_definition.builder(numeric_columns, categorical_columns)
     return preprocessor, numeric_columns, categorical_columns
 
 

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -117,14 +117,28 @@ def _require_manifest_value(manifest: dict[str, object], field_name: str) -> obj
 def _infer_legacy_model_id(task_type: str, model_name: object | None) -> str | None:
     resolved_model_name = str(model_name).strip()
     legacy_model_map = {
-        ("regression", "ElasticNet"): "elasticnet",
-        ("regression", "RandomForestRegressor"): "random_forest",
-        ("binary", "LogisticRegression"): "logistic_regression",
-        ("binary", "RandomForestClassifier"): "random_forest",
-        ("regression", "elasticnet"): "elasticnet",
-        ("regression", "random_forest"): "random_forest",
-        ("binary", "logistic_regression"): "logistic_regression",
-        ("binary", "random_forest"): "random_forest",
+        ("regression", "Ridge"): "onehot_ridge",
+        ("regression", "ElasticNet"): "onehot_elasticnet",
+        ("regression", "RandomForestRegressor"): "ordinal_randomforest",
+        ("regression", "ExtraTreesRegressor"): "ordinal_extratrees",
+        ("regression", "HistGradientBoostingRegressor"): "ordinal_hgb",
+        ("binary", "LogisticRegression"): "onehot_logreg",
+        ("binary", "RandomForestClassifier"): "ordinal_randomforest",
+        ("binary", "ExtraTreesClassifier"): "ordinal_extratrees",
+        ("binary", "HistGradientBoostingClassifier"): "ordinal_hgb",
+        ("regression", "onehot_ridge"): "onehot_ridge",
+        ("regression", "onehot_elasticnet"): "onehot_elasticnet",
+        ("regression", "ordinal_randomforest"): "ordinal_randomforest",
+        ("regression", "ordinal_extratrees"): "ordinal_extratrees",
+        ("regression", "ordinal_hgb"): "ordinal_hgb",
+        ("binary", "onehot_logreg"): "onehot_logreg",
+        ("binary", "ordinal_randomforest"): "ordinal_randomforest",
+        ("binary", "ordinal_extratrees"): "ordinal_extratrees",
+        ("binary", "ordinal_hgb"): "ordinal_hgb",
+        ("regression", "elasticnet"): "onehot_elasticnet",
+        ("regression", "random_forest"): "ordinal_randomforest",
+        ("binary", "logistic_regression"): "onehot_logreg",
+        ("binary", "random_forest"): "ordinal_randomforest",
     }
     return legacy_model_map.get((task_type, resolved_model_name))
 

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -262,7 +262,10 @@ def _train_single_model(
     positive_label: object | None,
     negative_label: object | None,
 ) -> dict[str, object]:
-    resolved_model_id, model_name, _, model_params = build_model(task_type, model_id, cv_random_state)
+    model_definition, _, model_params = build_model(task_type, model_id, cv_random_state)
+    resolved_model_id = model_definition.model_id
+    model_name = model_definition.model_name
+    preprocessing_scheme_id = model_definition.preprocessing_scheme_id
 
     oof_predictions = np.zeros(x_train_raw.shape[0], dtype=float)
     test_predictions_per_fold: list[np.ndarray] = []
@@ -275,6 +278,7 @@ def _train_single_model(
         y_fold_valid = y_train.iloc[valid_idx]
 
         preprocessor, _, _ = build_preprocessor(
+            scheme_id=preprocessing_scheme_id,
             x_train_raw=x_fold_train,
             force_categorical=force_categorical,
             force_numeric=force_numeric,
@@ -284,7 +288,7 @@ def _train_single_model(
         x_fold_valid_processed = preprocessor.transform(x_fold_valid)
         x_test_processed = preprocessor.transform(x_test_raw)
 
-        _, _, model, _ = build_model(task_type, resolved_model_id, cv_random_state)
+        _, model, _ = build_model(task_type, resolved_model_id, cv_random_state)
         model.fit(x_fold_train_processed, y_fold_train)
 
         if task_type == "binary":
@@ -353,6 +357,7 @@ def _train_single_model(
         "competition_slug": competition_slug,
         "model_id": resolved_model_id,
         "model_name": model_name,
+        "preprocessing_scheme_id": preprocessing_scheme_id,
         "model_params": model_params,
         "cv_mean": float(fold_metrics_df["metric_value"].mean()),
         "cv_std": float(fold_metrics_df["metric_value"].std(ddof=0)),
@@ -391,6 +396,7 @@ def _build_model_summary_rows(
             {
                 "model_id": result["model_id"],
                 "model_name": result["model_name"],
+                "preprocessing_scheme_id": result["preprocessing_scheme_id"],
                 "metric_name": primary_metric,
                 "cv_mean": result["cv_mean"],
                 "cv_std": result["cv_std"],
@@ -451,6 +457,7 @@ def _build_run_manifest(
         single_model = models[0]
         run_manifest["model_id"] = single_model["model_id"]
         run_manifest["model_name"] = single_model["model_name"]
+        run_manifest["preprocessing_scheme_id"] = single_model["preprocessing_scheme_id"]
         run_manifest["model_params"] = single_model["model_params"]
         run_manifest["cv_summary"] = single_model["cv_summary"]
 
@@ -600,6 +607,7 @@ def run_training(
         model_results.append(model_result)
         print(
             f"Training model: {model_result['model_id']} ({model_result['model_name']}) | "
+            f"preprocessing={model_result['preprocessing_scheme_id']} | "
             f"CV {primary_metric}: mean={model_result['cv_mean']:.6f}, std={model_result['cv_std']:.6f}"
         )
 
@@ -615,6 +623,7 @@ def run_training(
             {
                 "model_id": result["model_id"],
                 "model_name": result["model_name"],
+                "preprocessing_scheme_id": result["preprocessing_scheme_id"],
                 "model_params": result["model_params"],
                 "cv_summary": {
                     "metric_name": primary_metric,


### PR DESCRIPTION
Closes #3

## Summary
- make preprocessing part of each model recipe and normalize configs to canonical preprocessing-first model IDs
- add the expanded sklearn recipe set for regression and binary classification with compatibility aliases for existing configs
- record `preprocessing_scheme_id` in model artifacts and update docs to match the new recipe contract

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/*.py`
- `PYTHONPATH=src .venv/bin/python -c "from tabular_shenanigans.config import load_config; config = load_config(); print(config.model_id); print(config.model_ids)"`
- synthetic binary smoke run covering `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, and `ordinal_hgb` with dry-run submission validation
- synthetic regression smoke run covering `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, and `ordinal_hgb` with dry-run submission validation
- real binary run on `playground-series-s5e12` with `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, and `ordinal_hgb`, plus dry-run submission validation
- real regression run on `house-prices-advanced-regression-techniques` with `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, and `ordinal_hgb`, plus dry-run submission validation