### PR TITLE
Support accuracy-scored binary competitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The repository is developed and manually verified primarily against these Playgr
   - `ordinal` preprocessing: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `ordinal_xgboost`
   - `native` preprocessing: `native_catboost`
 - Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
-- Validate predictions against `sample_submission.csv`, including exact ID content and order, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
+- Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
 
 ## Tooling
 - Python for orchestration
@@ -103,6 +103,10 @@ Optional submission keys:
 - `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `submit_message_prefix`: optional prefix used in auto-generated submission messages
 
+Binary prediction artifact contract:
+- `roc_auc` and `log_loss`: `test_predictions.csv` and `submission.csv` contain positive-class probabilities in `[0, 1]`
+- `accuracy`: `test_predictions.csv` and `submission.csv` contain predicted class labels from the observed binary label set
+
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
 `model_ids` is the preferred config-driven model interface. If both `model_id` and `model_ids` are omitted, the workflow selects the current default recipe for the configured task: `onehot_elasticnet` for regression and `onehot_logreg` for binary classification. If `model_id` is provided, it resolves to a single-entry `model_ids` list. Backward-compatible aliases are normalized to the canonical preprocessing-first IDs during config loading, so run artifacts always use the canonical IDs.
@@ -126,6 +130,7 @@ Manual verification for each target:
 - confirm `artifacts/<competition_slug>/train/<run_id>/model_summary.csv` is written
 - confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv` is written for each selected model
 - confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order, for the submitted model
+- confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
 ## Outputs
 - Competition data: `data/<competition_slug>/`
@@ -148,7 +153,9 @@ Manual verification for each target:
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
-- Binary classification supports any two-class labels accepted by scikit-learn; probability outputs are aligned to the resolved positive class.
+- Binary classification supports any two-class labels accepted by scikit-learn.
+- For binary `roc_auc` and `log_loss`, prediction artifacts use probabilities aligned to the resolved positive class.
+- For binary `accuracy`, prediction artifacts use class labels from the observed binary label set.
 - Binary classification requires an explicit positive-class contract. If `positive_label` is omitted, the workflow only auto-resolves the positive class for labels `[0, 1]`, `[False, True]`, or `["No", "Yes"]`; other two-class label pairs fail fast.
 - `task_type` and `primary_metric` are explicitly configured for every run.
 - Runtime config comes from local repository-root `config.yaml` only; tracked example files are just starting points, and there are no CLI or environment overrides.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -20,7 +20,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
    - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
 9. Write run-level diagnostics, `model_summary.csv`, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
-11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
+11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading, data fetch, EDA, training, and submission.
@@ -66,6 +66,10 @@ Input:
   - `submit_enabled` (boolean, default false)
   - `submit_message_prefix` (string, optional)
 
+Binary prediction artifact contract:
+- `roc_auc` and `log_loss` write positive-class probabilities to `test_predictions.csv` and `submission.csv`
+- `accuracy` writes predicted class labels to `test_predictions.csv` and `submission.csv`
+
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
 LightGBM, CatBoost, and XGBoost require the optional booster dependencies installed via `uv sync --extra boosters`.
@@ -83,6 +87,7 @@ Manual verification steps for each target:
 - confirm `model_summary.csv` is generated in the run directory
 - confirm `test_predictions.csv` is generated in each model directory
 - confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected model directory
+- confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
 ## Artifact Contract
 - A validated in-memory config object from Pydantic
@@ -121,7 +126,10 @@ Manual verification steps for each target:
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
-- Binary classification supports any two-class target labels; the positive class is resolved from the training target and used consistently for diagnostics, scoring, and probability extraction
+- Binary classification supports any two-class target labels
+- The positive class is resolved from the training target and used consistently for diagnostics and scoring
+- Binary `roc_auc` and `log_loss` artifacts use positive-class probabilities
+- Binary `accuracy` artifacts use class labels from the observed binary label pair
 - Binary classification must have an explicit positive-class contract; when `positive_label` is omitted, the workflow only auto-resolves the positive class for `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
@@ -160,6 +168,8 @@ Hard-error cases include:
 - Fold assignment gaps in OOF generation -> hard error
 - Requested submission `model_id` not present in the run manifest -> hard error
 - Submission schema or ID mismatch against `sample_submission.csv` -> hard error
+- Binary probability artifact outside `[0, 1]` for `roc_auc` or `log_loss` -> hard error
+- Binary label artifact containing values outside the observed label pair for `accuracy` -> hard error
 - Kaggle submission command failure when `submit_enabled=true` -> hard error
 
 ## Design Guardrails

--- a/src/tabular_shenanigans/data.py
+++ b/src/tabular_shenanigans/data.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 import subprocess
+from typing import Literal
 import zipfile
 
 import pandas as pd
@@ -16,6 +17,10 @@ SUPPORTED_PRIMARY_METRICS = {
     "accuracy": "accuracy",
 }
 
+BINARY_PROBABILITY_METRICS = {"roc_auc", "log_loss"}
+BINARY_LABEL_METRICS = {"accuracy"}
+BinaryPredictionKind = Literal["probability", "label"]
+
 
 def normalize_primary_metric(metric_name: str) -> str | None:
     normalized_name = metric_name.strip().lower()
@@ -26,12 +31,21 @@ def normalize_primary_metric(metric_name: str) -> str | None:
 
 def is_metric_valid_for_task(task_type: str, primary_metric: str) -> bool:
     regression_metrics = {"rmse", "mse", "rmsle", "mae"}
-    binary_metrics = {"roc_auc", "log_loss", "accuracy"}
+    binary_metrics = BINARY_PROBABILITY_METRICS | BINARY_LABEL_METRICS
     if task_type == "regression":
         return primary_metric in regression_metrics
     if task_type == "binary":
         return primary_metric in binary_metrics
     return False
+
+
+def get_binary_prediction_kind(primary_metric: str) -> BinaryPredictionKind:
+    normalized_primary_metric = normalize_primary_metric(primary_metric)
+    if normalized_primary_metric in BINARY_PROBABILITY_METRICS:
+        return "probability"
+    if normalized_primary_metric in BINARY_LABEL_METRICS:
+        return "label"
+    raise ValueError(f"Unsupported binary primary_metric for prediction handling: {primary_metric}")
 
 
 def fetch_competition_data(competition_slug: str) -> Path:

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from tabular_shenanigans.data import load_sample_submission_template, validate_sample_submission_schema
+from tabular_shenanigans.data import get_binary_prediction_kind, load_sample_submission_template, validate_sample_submission_schema
 
 SUBMISSION_LEDGER_COLUMNS = [
     "timestamp_utc",
@@ -29,9 +29,11 @@ class SubmissionRunContext:
     run_id: str
     competition_slug: str
     task_type: str
+    primary_metric: str
     model_id: str
     id_column: str
     label_column: str
+    observed_label_pair: tuple[object, object] | None
     config_fingerprint: str | None
 
 
@@ -246,13 +248,23 @@ def _load_submission_run_context(
     manifest = _load_run_manifest(run_dir)
     run_id = str(manifest["run_id"])
     selected_model_id = _resolve_selected_model_id(manifest, requested_model_id=model_id)
+    observed_label_pair_raw = manifest.get("observed_label_pair")
+    observed_label_pair = None
+    if isinstance(observed_label_pair_raw, list):
+        if len(observed_label_pair_raw) != 2:
+            raise ValueError("Run manifest observed_label_pair must contain exactly two labels when present.")
+        observed_label_pair = (observed_label_pair_raw[0], observed_label_pair_raw[1])
+    elif manifest.get("negative_label") is not None and manifest.get("positive_label") is not None:
+        observed_label_pair = (manifest["negative_label"], manifest["positive_label"])
     return SubmissionRunContext(
         run_id=run_id,
         competition_slug=str(_require_manifest_value(manifest, "competition_slug")),
         task_type=str(_require_manifest_value(manifest, "task_type")),
+        primary_metric=str(_require_manifest_value(manifest, "primary_metric")),
         model_id=selected_model_id,
         id_column=str(_require_manifest_value(manifest, "id_column")),
         label_column=str(_require_manifest_value(manifest, "label_column")),
+        observed_label_pair=observed_label_pair,
         config_fingerprint=manifest.get("config_fingerprint"),
     )
 
@@ -384,6 +396,50 @@ def _validate_submission_ids(
     )
 
 
+def _normalize_binary_label(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bool, np.bool_)):
+        return "True" if bool(value) else "False"
+    if isinstance(value, (int, np.integer)):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)) and float(value).is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _validate_binary_probability_predictions(prediction_values: pd.Series) -> None:
+    if not pd.api.types.is_numeric_dtype(prediction_values):
+        raise ValueError("Binary probability submissions must be numeric.")
+    if not prediction_values.map(pd.notna).all():
+        raise ValueError("Binary probability submissions contain missing values.")
+    if not np.isfinite(prediction_values.to_numpy(dtype=float)).all():
+        raise ValueError("Binary probability submissions must be finite.")
+    if ((prediction_values < 0.0) | (prediction_values > 1.0)).any():
+        raise ValueError("Binary probability submissions must be within [0, 1].")
+
+
+def _validate_binary_label_predictions(
+    prediction_values: pd.Series,
+    observed_label_pair: tuple[object, object] | None,
+) -> None:
+    if observed_label_pair is None:
+        raise ValueError(
+            "Binary label submissions require observed_label_pair metadata in the run manifest."
+        )
+    if not prediction_values.map(pd.notna).all():
+        raise ValueError("Binary label submissions contain missing values.")
+
+    allowed_labels = {_normalize_binary_label(label) for label in observed_label_pair}
+    normalized_predictions = prediction_values.map(_normalize_binary_label)
+    invalid_labels = sorted(set(normalized_predictions) - allowed_labels)
+    if invalid_labels:
+        raise ValueError(
+            "Binary label submissions must contain only observed class labels. "
+            f"Allowed labels: {sorted(allowed_labels)}; invalid labels: {invalid_labels[:10]}"
+        )
+
+
 def prepare_submission_file(
     run_dir: Path,
     model_id: str | None = None,
@@ -413,14 +469,14 @@ def prepare_submission_file(
         )
     if run_context.task_type == "binary":
         prediction_values = prediction_df[run_context.label_column]
-        if not pd.api.types.is_numeric_dtype(prediction_values):
-            raise ValueError("Binary submission predictions must be numeric probabilities.")
-        if not prediction_values.map(pd.notna).all():
-            raise ValueError("Binary submission predictions contain missing values.")
-        if not np.isfinite(prediction_values.to_numpy(dtype=float)).all():
-            raise ValueError("Binary submission predictions must be finite.")
-        if ((prediction_values < 0.0) | (prediction_values > 1.0)).any():
-            raise ValueError("Binary submission predictions must be within [0, 1].")
+        binary_prediction_kind = get_binary_prediction_kind(run_context.primary_metric)
+        if binary_prediction_kind == "probability":
+            _validate_binary_probability_predictions(prediction_values)
+        else:
+            _validate_binary_label_predictions(
+                prediction_values=prediction_values,
+                observed_label_pair=run_context.observed_label_pair,
+            )
     _validate_submission_ids(
         prediction_df=prediction_df,
         sample_submission_df=sample_submission_df,

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_positive_label, score_predictions
-from tabular_shenanigans.data import load_competition_dataset_context
+from tabular_shenanigans.data import get_binary_prediction_kind, load_competition_dataset_context
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
@@ -271,6 +271,9 @@ def _train_single_model(
     test_predictions_per_fold: list[np.ndarray] = []
     fold_metrics: list[dict[str, object]] = []
     use_named_columns = model_name.startswith("LGBM")
+    binary_prediction_kind = None
+    if task_type == "binary":
+        binary_prediction_kind = get_binary_prediction_kind(primary_metric)
 
     for fold_index, train_idx, valid_idx in split_indices:
         x_fold_train = x_train_raw.iloc[train_idx]
@@ -340,6 +343,12 @@ def _train_single_model(
     mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
     if task_type == "regression" and primary_metric == "rmsle":
         mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
+    if task_type == "binary" and binary_prediction_kind == "label":
+        if positive_label is None or negative_label is None:
+            raise ValueError("Binary label exports require resolved class metadata.")
+        final_test_predictions = np.where(mean_test_predictions >= 0.5, positive_label, negative_label)
+    else:
+        final_test_predictions = mean_test_predictions
 
     model_dir = run_dir / resolved_model_id
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -362,7 +371,7 @@ def _train_single_model(
     test_predictions_df = pd.DataFrame(
         {
             id_column: test_ids.to_numpy(),
-            label_column: mean_test_predictions,
+            label_column: final_test_predictions,
         }
     )
     test_predictions_df.to_csv(model_dir / "test_predictions.csv", index=False)


### PR DESCRIPTION
## Summary
- export label-valued binary test and submission artifacts for accuracy-scored runs
- keep roc_auc and log_loss binary artifacts probability-based and validate each metric contract explicitly
- document the binary prediction artifact contract in the README and technical guide

Closes #48

## Verification
- uv run python -m compileall main.py src/tabular_shenanigans
- synthetic numeric-label accuracy run writes 0/1 labels to test_predictions.csv and submission.csv
- synthetic string-label accuracy run with explicit positive_label writes class labels and passes submission validation
- synthetic roc_auc run on the same binary data still writes probabilities in [0, 1]
