### PR TITLE
Thread config and shared dataset through pipeline

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -8,8 +8,8 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 1. Load and validate the local repository-root `config.yaml`.
 2. Use explicit `task_type` and `primary_metric` from config.
 3. Download the competition zip into `data/<competition_slug>/` when it is missing.
-4. Read `train.csv`, `test.csv`, and `sample_submission.csv` from the zip as needed.
-5. Run EDA and write report CSVs under `reports/<competition_slug>/`.
+4. Load one shared dataset context from `train.csv`, `test.csv`, and `sample_submission.csv`.
+5. Run EDA against that shared dataset context and write report CSVs under `reports/<competition_slug>/`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
 7. During training, build fold-local preprocessing from the selected model recipe:
    - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
@@ -23,14 +23,14 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading, data fetch, EDA, training, and submission.
+- `main.py`: orchestration entrypoint for config loading, data fetch, one shared dataset load, EDA, training, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
-- `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV, including missingness, categorical cardinality, target summary, and feature-type counts.
+- `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, compatibility alias resolution, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and scheme-specific preprocessing pipelines, including native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: config-selected multi-model training, shared split handling, artifact writing, and run ledger updates.
+- `src/tabular_shenanigans/train.py`: config-selected multi-model training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 from tabular_shenanigans.config import load_config
-from tabular_shenanigans.data import fetch_competition_data
+from tabular_shenanigans.data import fetch_competition_data, load_competition_dataset_context
 from tabular_shenanigans.eda import run_eda
 from tabular_shenanigans.submit import run_submission
 from tabular_shenanigans.train import run_training
@@ -18,38 +18,16 @@ def main() -> None:
     )
     data_dir = fetch_competition_data(config.competition_slug)
     print(f"Data ready: {data_dir}")
-    report_dir = run_eda(
+    dataset_context = load_competition_dataset_context(
         competition_slug=config.competition_slug,
-        id_column=config.id_column,
-        label_column=config.label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+        configured_id_column=config.id_column,
+        configured_label_column=config.label_column,
     )
+    report_dir = run_eda(config=config, dataset_context=dataset_context)
     print(f"EDA reports ready: {report_dir}")
-    train_dir = run_training(
-        competition_slug=config.competition_slug,
-        task_type=config.task_type,
-        primary_metric=config.primary_metric,
-        model_ids=config.model_ids,
-        positive_label=config.positive_label,
-        id_column=config.id_column,
-        label_column=config.label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
-        cv_n_splits=config.cv_n_splits,
-        cv_shuffle=config.cv_shuffle,
-        cv_random_state=config.cv_random_state,
-    )
+    train_dir = run_training(config=config, dataset_context=dataset_context)
     print(f"Training artifacts ready: {train_dir}")
-    submission_path, submission_status = run_submission(
-        run_dir=train_dir,
-        submit_enabled=config.submit_enabled,
-        submit_message_prefix=config.submit_message_prefix,
-    )
+    submission_path, submission_status = run_submission(config=config, run_dir=train_dir)
     print(f"Submission file ready: {submission_path} ({submission_status})")
 
 

--- a/src/tabular_shenanigans/eda.py
+++ b/src/tabular_shenanigans/eda.py
@@ -2,7 +2,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
-from tabular_shenanigans.data import load_competition_dataset_context
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.data import CompetitionDatasetContext
 from tabular_shenanigans.preprocess import prepare_feature_frames, summarize_feature_types
 
 
@@ -79,19 +80,9 @@ def _target_summary(train_df: pd.DataFrame, target_column: str) -> pd.DataFrame:
 
 
 def run_eda(
-    competition_slug: str,
-    id_column: str | None = None,
-    label_column: str | None = None,
-    force_categorical: list[str] | None = None,
-    force_numeric: list[str] | None = None,
-    drop_columns: list[str] | None = None,
-    low_cardinality_int_threshold: int | None = None,
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
 ) -> Path:
-    dataset_context = load_competition_dataset_context(
-        competition_slug=competition_slug,
-        configured_id_column=id_column,
-        configured_label_column=label_column,
-    )
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
     id_column = dataset_context.id_column
@@ -102,12 +93,12 @@ def run_eda(
         test_df=test_df,
         id_column=id_column,
         label_column=label_column,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        drop_columns=drop_columns,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
     )
 
-    report_dir = Path("reports") / competition_slug
+    report_dir = Path("reports") / config.competition_slug
     report_dir.mkdir(parents=True, exist_ok=True)
 
     _column_summary(train_df).to_csv(report_dir / "columns_train.csv", index=False)
@@ -120,9 +111,9 @@ def run_eda(
     _target_summary(train_df, label_column).to_csv(report_dir / "target_summary.csv", index=False)
     feature_type_counts = summarize_feature_types(
         x_train_raw=x_train_raw,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        low_cardinality_int_threshold=low_cardinality_int_threshold,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
     )
     feature_type_counts.to_csv(report_dir / "feature_type_counts.csv", index=False)
 

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.data import get_binary_prediction_kind, load_sample_submission_template, validate_sample_submission_schema
 
 SUBMISSION_LEDGER_COLUMNS = [
@@ -504,9 +505,8 @@ def build_submission_message(
 
 
 def run_submission(
+    config: AppConfig,
     run_dir: Path,
-    submit_enabled: bool,
-    submit_message_prefix: str | None = None,
     model_id: str | None = None,
 ) -> tuple[Path, str]:
     run_context = _load_submission_run_context(run_dir=run_dir, model_id=model_id)
@@ -514,11 +514,11 @@ def run_submission(
     submission_path = prepare_submission_file(run_dir=run_dir, model_id=model_id)
     message = build_submission_message(
         run_dir=run_dir,
-        submit_message_prefix=submit_message_prefix,
+        submit_message_prefix=config.submit_message_prefix,
         model_id=model_id,
     )
 
-    if submit_enabled:
+    if config.submit_enabled:
         completed = subprocess.run(
             [
                 "kaggle",
@@ -552,7 +552,7 @@ def run_submission(
         "model_name": run_metadata["model_name"],
         "config_fingerprint": run_context.config_fingerprint,
         "submission_path": str(submission_path),
-        "submit_enabled": submit_enabled,
+        "submit_enabled": config.submit_enabled,
         "status": status,
         "message": message,
     }

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -6,8 +6,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_positive_label, score_predictions
-from tabular_shenanigans.data import get_binary_prediction_kind, load_competition_dataset_context
+from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
@@ -533,26 +534,15 @@ def _build_run_ledger_row(
 
 
 def run_training(
-    competition_slug: str,
-    task_type: str,
-    primary_metric: str,
-    model_ids: list[str],
-    id_column: str | None = None,
-    label_column: str | None = None,
-    force_categorical: list[str] | None = None,
-    force_numeric: list[str] | None = None,
-    drop_columns: list[str] | None = None,
-    low_cardinality_int_threshold: int | None = None,
-    cv_n_splits: int = 7,
-    cv_shuffle: bool = True,
-    cv_random_state: int = 42,
-    positive_label: str | int | bool | None = None,
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
 ) -> Path:
-    dataset_context = load_competition_dataset_context(
-        competition_slug=competition_slug,
-        configured_id_column=id_column,
-        configured_label_column=label_column,
-    )
+    competition_slug = config.competition_slug
+    task_type = config.task_type
+    primary_metric = config.primary_metric
+    model_ids = config.model_ids
+    positive_label = config.positive_label
+
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
     id_column = dataset_context.id_column
@@ -563,9 +553,9 @@ def run_training(
         test_df=test_df,
         id_column=id_column,
         label_column=label_column,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        drop_columns=drop_columns,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
     )
 
     observed_label_pair = None
@@ -580,9 +570,9 @@ def run_training(
         task_type=task_type,
         x_train_raw=x_train_raw,
         y_train=y_train,
-        n_splits=cv_n_splits,
-        shuffle=cv_shuffle,
-        random_state=cv_random_state,
+        n_splits=config.cv_n_splits,
+        shuffle=config.cv_shuffle,
+        random_state=config.cv_random_state,
     )
     fold_assignments = _build_fold_assignments(x_train_raw.shape[0], split_indices)
     run_diagnostics_df = _build_run_diagnostics(
@@ -620,10 +610,10 @@ def run_training(
             split_indices=split_indices,
             fold_assignments=fold_assignments,
             run_dir=run_dir,
-            force_categorical=force_categorical,
-            force_numeric=force_numeric,
-            low_cardinality_int_threshold=low_cardinality_int_threshold,
-            cv_random_state=cv_random_state,
+            force_categorical=config.force_categorical,
+            force_numeric=config.force_numeric,
+            low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+            cv_random_state=config.cv_random_state,
             positive_label=positive_label,
             negative_label=negative_label,
         )
@@ -670,13 +660,13 @@ def run_training(
         "positive_label": positive_label,
         "id_column": id_column,
         "label_column": label_column,
-        "force_categorical": force_categorical or [],
-        "force_numeric": force_numeric or [],
-        "drop_columns": drop_columns or [],
-        "low_cardinality_int_threshold": low_cardinality_int_threshold,
-        "cv_n_splits": cv_n_splits,
-        "cv_shuffle": cv_shuffle,
-        "cv_random_state": cv_random_state,
+        "force_categorical": config.force_categorical,
+        "force_numeric": config.force_numeric,
+        "drop_columns": config.drop_columns,
+        "low_cardinality_int_threshold": config.low_cardinality_int_threshold,
+        "cv_n_splits": config.cv_n_splits,
+        "cv_shuffle": config.cv_shuffle,
+        "cv_random_state": config.cv_random_state,
     }
     fingerprint_payload = {
         "config_snapshot": config_snapshot,
@@ -719,9 +709,9 @@ def run_training(
 
     ledger_row = _build_run_ledger_row(
         run_manifest=run_manifest,
-        cv_n_splits=cv_n_splits,
-        cv_shuffle=cv_shuffle,
-        cv_random_state=cv_random_state,
+        cv_n_splits=config.cv_n_splits,
+        cv_shuffle=config.cv_shuffle,
+        cv_random_state=config.cv_random_state,
     )
     ledger_path = Path("artifacts") / competition_slug / "train" / "runs.csv"
     _append_run_ledger(ledger_path, ledger_row)


### PR DESCRIPTION
Closes #44

## Summary
- load one shared competition dataset context in `main.py` and reuse it for EDA and training
- thread `AppConfig` through EDA, training, and submission to reduce long argument lists
- update the technical guide to reflect the shared dataset orchestration

## Verification
- `uv run python -m compileall main.py src`
- `rg -n "load_competition_dataset_context" main.py src/tabular_shenanigans`
  - confirms the normal pipeline loads the dataset in `main.py` instead of separately in EDA and training
- `PYTHONPATH=src uv run python - <<'PY' ...`
  - synthetic shared-dataset pipeline run through `run_eda`, `run_training`, and `run_submission`
- `PYTHONPATH=src uv run python - <<'PY' ...`
  - patched `main.main()` smoke run confirming the full pipeline completes with exactly one dataset load call