### PR TITLE
Add stage-specific CLI entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The repository is developed and manually verified primarily against these Playgr
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
+- Run stage-specific CLI entrypoints for `fetch`, `eda`, `preprocess`, `train`, and submit-only flows against explicit run artifacts.
 - Train one or more cross-validated model recipes with fold-local, model-specific preprocessing:
   - `onehot` preprocessing: `onehot_ridge`, `onehot_elasticnet`, `onehot_logreg`
   - `ordinal` preprocessing: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `ordinal_xgboost`
@@ -54,6 +55,31 @@ cp config.regression.example.yaml config.yaml
 `config.yaml` is the only runtime config source. It is intentionally ignored by Git so you can keep local competition-specific settings without committing them.
 
 The current pipeline fetches competition data if needed, runs config-aware EDA, trains one or more CV model recipes with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
+
+## Stage Commands
+`uv run python main.py` still runs the full default pipeline: fetch, EDA, train, and submit.
+
+Available stage-specific commands:
+- `uv run python main.py fetch`
+- `uv run python main.py eda`
+- `uv run python main.py preprocess`
+- `uv run python main.py train`
+- `uv run python main.py submit --run-dir artifacts/<competition_slug>/train/<run_id>`
+- `uv run python main.py submit --run-id <run_id>`
+
+Stage behavior:
+- `fetch`: ensures competition data is present locally
+- `eda`: fetches if needed, then writes EDA report CSVs
+- `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
+- `train`: fetches if needed, then trains and writes normal training artifacts
+- `submit`: requires an explicit existing run selection and never retrains implicitly
+
+The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
+- `preprocess_summary.csv`
+- `preprocess_features.csv`
+- `preprocess_models.csv`
+
+`submit` can take an optional `--model-id` when targeting a specific model artifact from a multi-model run.
 
 ## Config Overview
 Tracked example configs:
@@ -135,6 +161,7 @@ Manual verification for each target:
 ## Outputs
 - Competition data: `data/<competition_slug>/`
 - EDA reports: `reports/<competition_slug>/`
+  - when `preprocess` stage is run, also includes `preprocess_summary.csv`, `preprocess_features.csv`, and `preprocess_models.csv`
 - Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
   - includes `run_diagnostics.csv`, `model_summary.csv`, and `run_manifest.json`
   - includes per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -22,13 +22,24 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
 11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
+## CLI Stages
+- `uv run python main.py`: default full pipeline (`fetch` -> `eda` -> `train` -> `submit`)
+- `uv run python main.py fetch`: ensure competition data is present
+- `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
+- `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
+- `uv run python main.py train`: fetch if needed, load the shared dataset context, and write training artifacts
+- `uv run python main.py submit --run-dir artifacts/.../train/<run_id>`: prepare or submit from an explicit existing run artifact
+- `uv run python main.py submit --run-id <run_id>`: resolve the run under `artifacts/<competition_slug>/train/<run_id>` using the configured competition slug
+
+The `preprocess` stage is intentionally diagnostic. It is not part of the default runtime contract and it does not create a second training artifact layout.
+
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading, data fetch, one shared dataset load, EDA, training, and submission.
+- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, EDA, preprocess diagnostics, training, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, compatibility alias resolution, optional booster loading, and estimator construction for supported presets.
-- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, and scheme-specific preprocessing pipelines, including native-frame support for CatBoost.
+- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/train.py`: config-selected multi-model training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
@@ -101,6 +112,10 @@ Manual verification steps for each target:
   - `target_summary.csv`
   - `feature_type_counts.csv`
   - `run_summary.csv`
+  - when the `preprocess` stage is run:
+    - `preprocess_summary.csv`
+    - `preprocess_features.csv`
+    - `preprocess_models.csv`
 - Training artifacts under `artifacts/<competition_slug>/train/<run_id>/`:
   - `run_diagnostics.csv`
   - `model_summary.csv`

--- a/main.py
+++ b/main.py
@@ -1,28 +1,77 @@
+import argparse
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
-from tabular_shenanigans.config import load_config
+from tabular_shenanigans.config import AppConfig, load_config
 from tabular_shenanigans.data import fetch_competition_data, load_competition_dataset_context
 from tabular_shenanigans.eda import run_eda
+from tabular_shenanigans.preprocess import run_preprocess
 from tabular_shenanigans.submit import run_submission
 from tabular_shenanigans.train import run_training
 
 
-def main() -> None:
-    config = load_config()
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the TabularShenanigans workflow or one explicit stage.",
+    )
+    subparsers = parser.add_subparsers(dest="stage")
+
+    subparsers.add_parser("fetch", help="Download competition data if it is missing.")
+    subparsers.add_parser("eda", help="Run EDA reports only.")
+    subparsers.add_parser("preprocess", help="Write preprocessing diagnostics only.")
+    subparsers.add_parser("train", help="Run training only.")
+
+    submit_parser = subparsers.add_parser("submit", help="Prepare or submit from an existing run artifact.")
+    run_selection = submit_parser.add_mutually_exclusive_group(required=True)
+    run_selection.add_argument(
+        "--run-dir",
+        type=Path,
+        help="Explicit run directory such as artifacts/<competition_slug>/train/<run_id>.",
+    )
+    run_selection.add_argument(
+        "--run-id",
+        help="Run identifier resolved under artifacts/<competition_slug>/train/<run_id> using config.competition_slug.",
+    )
+    submit_parser.add_argument(
+        "--model-id",
+        help="Optional model_id to submit from a multi-model run; defaults to the run manifest best_model_id.",
+    )
+
+    return parser
+
+
+def _print_resolved_setup(config: AppConfig) -> None:
     print(
         "Resolved competition setup: "
         f"task_type={config.task_type}, primary_metric={config.primary_metric}, model_ids={config.model_ids}"
     )
+
+
+def _ensure_data_ready(config: AppConfig) -> Path:
     data_dir = fetch_competition_data(config.competition_slug)
     print(f"Data ready: {data_dir}")
-    dataset_context = load_competition_dataset_context(
+    return data_dir
+
+
+def _load_shared_dataset_context(config: AppConfig):
+    return load_competition_dataset_context(
         competition_slug=config.competition_slug,
         configured_id_column=config.id_column,
         configured_label_column=config.label_column,
     )
+
+
+def _resolve_run_dir(config: AppConfig, args: argparse.Namespace) -> Path:
+    if args.run_dir is not None:
+        return args.run_dir
+    return Path("artifacts") / config.competition_slug / "train" / str(args.run_id)
+
+
+def _run_full_pipeline(config: AppConfig) -> None:
+    _ensure_data_ready(config)
+    dataset_context = _load_shared_dataset_context(config)
     report_dir = run_eda(config=config, dataset_context=dataset_context)
     print(f"EDA reports ready: {report_dir}")
     train_dir = run_training(config=config, dataset_context=dataset_context)
@@ -31,5 +80,70 @@ def main() -> None:
     print(f"Submission file ready: {submission_path} ({submission_status})")
 
 
+def _run_eda_stage(config: AppConfig) -> None:
+    _ensure_data_ready(config)
+    dataset_context = _load_shared_dataset_context(config)
+    report_dir = run_eda(config=config, dataset_context=dataset_context)
+    print(f"EDA reports ready: {report_dir}")
+
+
+def _run_preprocess_stage(config: AppConfig) -> None:
+    _ensure_data_ready(config)
+    dataset_context = _load_shared_dataset_context(config)
+    report_dir = run_preprocess(config=config, dataset_context=dataset_context)
+    print(f"Preprocess reports ready: {report_dir}")
+
+
+def _run_train_stage(config: AppConfig) -> None:
+    _ensure_data_ready(config)
+    dataset_context = _load_shared_dataset_context(config)
+    train_dir = run_training(config=config, dataset_context=dataset_context)
+    print(f"Training artifacts ready: {train_dir}")
+
+
+def _run_submit_stage(config: AppConfig, args: argparse.Namespace) -> None:
+    run_dir = _resolve_run_dir(config, args)
+    print(f"Using run_dir: {run_dir}")
+    submission_path, submission_status = run_submission(
+        config=config,
+        run_dir=run_dir,
+        model_id=args.model_id,
+    )
+    print(f"Submission file ready: {submission_path} ({submission_status})")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = load_config()
+    _print_resolved_setup(config)
+
+    if args.stage is None:
+        _run_full_pipeline(config)
+        return
+
+    if args.stage == "fetch":
+        _ensure_data_ready(config)
+        return
+
+    if args.stage == "eda":
+        _run_eda_stage(config)
+        return
+
+    if args.stage == "preprocess":
+        _run_preprocess_stage(config)
+        return
+
+    if args.stage == "train":
+        _run_train_stage(config)
+        return
+
+    if args.stage == "submit":
+        _run_submit_stage(config, args)
+        return
+
+    raise ValueError(f"Unsupported stage: {args.stage}")
+
+
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -1,11 +1,18 @@
+from datetime import datetime, timezone
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
+import numpy as np
 import pandas as pd
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer, OneHotEncoder, OrdinalEncoder, StandardScaler
+
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.data import CompetitionDatasetContext
+from tabular_shenanigans.models import get_model_definition
 
 PreprocessorBuilder = Callable[[list[str], list[str], list[str]], object]
 
@@ -52,6 +59,20 @@ def _resolve_feature_types(
     ordered_numeric_columns = [column for column in all_columns if column in numeric_columns]
     categorical_columns = [column for column in all_columns if column not in numeric_columns]
     return ordered_numeric_columns, categorical_columns
+
+
+def resolve_feature_types(
+    x_train_raw: pd.DataFrame,
+    force_categorical: list[str] | None = None,
+    force_numeric: list[str] | None = None,
+    low_cardinality_int_threshold: int | None = None,
+) -> tuple[list[str], list[str]]:
+    return _resolve_feature_types(
+        x_train_raw=x_train_raw,
+        force_categorical=force_categorical or [],
+        force_numeric=force_numeric or [],
+        low_cardinality_int_threshold=low_cardinality_int_threshold,
+    )
 
 
 class NativeFramePreprocessor:
@@ -281,7 +302,7 @@ def summarize_feature_types(
     force_categorical = force_categorical or []
     force_numeric = force_numeric or []
 
-    numeric_columns, categorical_columns = _resolve_feature_types(
+    numeric_columns, categorical_columns = resolve_feature_types(
         x_train_raw=x_train_raw,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
@@ -295,3 +316,125 @@ def summarize_feature_types(
             {"feature_type": "total", "feature_count": int(x_train_raw.shape[1])},
         ]
     )
+
+
+def _transformed_column_count(transformed_values: object) -> int:
+    if isinstance(transformed_values, pd.DataFrame):
+        return int(transformed_values.shape[1])
+    return int(np.asarray(transformed_values).shape[1])
+
+
+def _transformed_output_kind(transformed_values: object) -> str:
+    if isinstance(transformed_values, pd.DataFrame):
+        return "dataframe"
+    if isinstance(transformed_values, np.ndarray):
+        return "ndarray"
+    return type(transformed_values).__name__
+
+
+def run_preprocess(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+) -> Path:
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+
+    x_train_raw, x_test_raw, _ = prepare_feature_frames(
+        train_df=train_df,
+        test_df=test_df,
+        id_column=id_column,
+        label_column=label_column,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
+    )
+    numeric_columns, categorical_columns = resolve_feature_types(
+        x_train_raw=x_train_raw,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+    )
+
+    report_dir = Path("reports") / config.competition_slug
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    feature_rows: list[dict[str, object]] = []
+    forced_categorical = set(config.force_categorical)
+    forced_numeric = set(config.force_numeric)
+    numeric_column_set = set(numeric_columns)
+    for column in x_train_raw.columns:
+        forced_feature_type = ""
+        if column in forced_categorical:
+            forced_feature_type = "categorical"
+        elif column in forced_numeric:
+            forced_feature_type = "numeric"
+        inferred_feature_type = "numeric" if column in numeric_column_set else "categorical"
+        feature_rows.append(
+            {
+                "feature_name": column,
+                "train_dtype": str(x_train_raw[column].dtype),
+                "test_dtype": str(x_test_raw[column].dtype),
+                "train_null_pct": float(x_train_raw[column].isna().mean()),
+                "test_null_pct": float(x_test_raw[column].isna().mean()),
+                "train_nunique": int(x_train_raw[column].nunique(dropna=False)),
+                "forced_feature_type": forced_feature_type,
+                "inferred_feature_type": inferred_feature_type,
+            }
+        )
+    feature_details_df = pd.DataFrame(feature_rows)
+    feature_details_df.to_csv(report_dir / "preprocess_features.csv", index=False)
+
+    model_rows: list[dict[str, object]] = []
+    for model_id in config.model_ids:
+        model_definition = get_model_definition(config.task_type, model_id)
+        preprocessing_definition = get_preprocessing_definition(model_definition.preprocessing_scheme_id)
+        preprocessor, model_numeric_columns, model_categorical_columns = build_preprocessor(
+            scheme_id=model_definition.preprocessing_scheme_id,
+            x_train_raw=x_train_raw,
+            force_categorical=config.force_categorical,
+            force_numeric=config.force_numeric,
+            low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+        )
+        if model_definition.model_name.startswith("LGBM") and hasattr(preprocessor, "set_output"):
+            preprocessor.set_output(transform="pandas")
+        x_train_processed = preprocessor.fit_transform(x_train_raw)
+        x_test_processed = preprocessor.transform(x_test_raw)
+        model_rows.append(
+            {
+                "model_id": model_definition.model_id,
+                "model_name": model_definition.model_name,
+                "preprocessing_scheme_id": preprocessing_definition.scheme_id,
+                "preprocessing_scheme_name": preprocessing_definition.scheme_name,
+                "numeric_feature_count": len(model_numeric_columns),
+                "categorical_feature_count": len(model_categorical_columns),
+                "processed_train_rows": int(x_train_raw.shape[0]),
+                "processed_train_cols": _transformed_column_count(x_train_processed),
+                "processed_test_rows": int(x_test_raw.shape[0]),
+                "processed_test_cols": _transformed_column_count(x_test_processed),
+                "output_kind": _transformed_output_kind(x_train_processed),
+            }
+        )
+    model_preprocess_df = pd.DataFrame(model_rows)
+    model_preprocess_df.to_csv(report_dir / "preprocess_models.csv", index=False)
+
+    summary_df = pd.DataFrame(
+        [
+            {"metric": "generated_at_utc", "value": datetime.now(timezone.utc).isoformat()},
+            {"metric": "id_column", "value": id_column},
+            {"metric": "label_column", "value": label_column},
+            {"metric": "model_count", "value": len(config.model_ids)},
+            {"metric": "modeled_feature_count", "value": int(x_train_raw.shape[1])},
+            {"metric": "numeric_feature_count", "value": len(numeric_columns)},
+            {"metric": "categorical_feature_count", "value": len(categorical_columns)},
+        ]
+    )
+    summary_df.to_csv(report_dir / "preprocess_summary.csv", index=False)
+
+    print(f"Preprocess feature count: {int(x_train_raw.shape[1])}")
+    print(f"Numeric features: {len(numeric_columns)}")
+    print(f"Categorical features: {len(categorical_columns)}")
+    print(f"Model-specific preprocess summaries: {len(model_rows)}")
+
+    return report_dir


### PR DESCRIPTION
Closes #16

## Summary
- add subcommand-based stage entrypoints for `fetch`, `eda`, `preprocess`, `train`, and `submit`
- keep `uv run python main.py` as the default full pipeline
- require explicit run selection for submit-only flows via `--run-dir` or `--run-id`
- add a diagnostic `preprocess` stage that validates model-specific preprocessing paths and writes report CSVs under `reports/<competition_slug>/`
- document the stage interface in the README and technical guide

## Verification
- `uv run python -m compileall main.py src`
- `PYTHONPATH=src uv run python - <<'PY' ...`
  - synthetic multi-model smoke run through:
    - default full pipeline via `main.main([])`
    - `fetch`
    - `eda`
    - `preprocess`
    - `train`
    - `submit --run-dir ... --model-id ...`
    - `submit --run-id ... --model-id ...`
  - confirmed `preprocess_summary.csv`, `preprocess_features.csv`, and `preprocess_models.csv` are written
  - confirmed submit-only execution does not fetch, reload the dataset, or retrain
  - confirmed `submit` without explicit run selection fails fast at CLI parsing