### PR TITLE
Require canonical model_ids in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Load and validate a single local repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Require explicit `task_type` and `primary_metric` in config.
-- Select one or more baseline or booster model recipes per run from config via `model_ids`, with `model_id` retained as the single-model shorthand.
+- Select one or more baseline or booster model recipes per run from config via canonical `model_ids`.
 - Ship tracked binary and regression example configs that can be copied into the local runtime config.
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
@@ -101,11 +101,9 @@ Optional binary-classification key:
 - `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 
 Optional model-selection key:
-- `model_ids`: ordered list of baseline model recipes for the configured task
-- `model_id`: single-model shorthand retained for backward compatibility; mutually exclusive with `model_ids`
+- `model_ids`: ordered list of canonical baseline model recipes for the configured task
   - regression: `onehot_ridge`, `onehot_elasticnet` (default), `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
   - binary classification: `onehot_logreg` (default), `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-  - compatibility aliases accepted during transition: `elasticnet`, `logistic_regression`, `random_forest`, `lightgbm`, `catboost`, `xgb`
 
 Optional submission schema keys:
 - `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
@@ -136,7 +134,7 @@ Binary prediction artifact contract:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-`model_ids` is the preferred config-driven model interface. If both `model_id` and `model_ids` are omitted, the workflow selects the current default recipe for the configured task: `onehot_elasticnet` for regression and `onehot_logreg` for binary classification. If `model_id` is provided, it resolves to a single-entry `model_ids` list. Backward-compatible aliases are normalized to the canonical preprocessing-first IDs during config loading, so run artifacts always use the canonical IDs.
+`model_ids` is the config-driven model-selection interface. If `model_ids` is omitted, the workflow selects the current default recipe for the configured task: `onehot_elasticnet` for regression and `onehot_logreg` for binary classification. For a single-model run, use a one-entry `model_ids` list. Config-time model selection accepts canonical preprocessing-first recipe IDs only. Submit-time `--model-id` still selects one trained model artifact from an existing run.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -177,7 +175,7 @@ Manual verification for each target:
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
-- Model IDs resolve to preprocessing-aware training recipes; run artifacts record the canonical `model_id` and `preprocessing_scheme_id`.
+- Configured `model_ids` must use canonical preprocessing-aware training recipe IDs; run artifacts record the canonical `model_id` and `preprocessing_scheme_id`.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -4,13 +4,14 @@ competition_slug: playground-series-s5e12
 task_type: binary
 primary_metric: roc_auc
 
-# Prefer model_ids for multi-model baselines. Swap to model_id for a single-model smoke test.
+# Use canonical model_ids. For a single-model smoke test, keep a one-entry list.
 model_ids:
   - onehot_logreg
   - ordinal_lightgbm
   - native_catboost
   - ordinal_xgboost
-# model_id: ordinal_lightgbm
+# model_ids:
+#   - ordinal_lightgbm
 
 # Set this when labels are not one of the auto-resolved safe pairs:
 # [0, 1], [False, True], or ["No", "Yes"].

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -4,14 +4,15 @@ competition_slug: playground-series-s5e10
 task_type: regression
 primary_metric: mse
 
-# Prefer model_ids for multi-model baselines. Swap to model_id for a single-model smoke test.
+# Use canonical model_ids. For a single-model smoke test, keep a one-entry list.
 model_ids:
   - onehot_ridge
   - onehot_elasticnet
   - ordinal_lightgbm
   - native_catboost
   - ordinal_xgboost
-# model_id: onehot_elasticnet
+# model_ids:
+#   - onehot_elasticnet
 
 # Optional schema overrides when inference is ambiguous or the competition is not Playground-shaped.
 # id_column: id

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -40,7 +40,7 @@ The default `submit` path supports current manifest-backed run artifacts only. U
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
-- `src/tabular_shenanigans/models.py`: model-recipe registry, compatibility alias resolution, optional booster loading, and estimator construction for supported presets.
+- `src/tabular_shenanigans/models.py`: model-recipe registry, canonical model-id validation, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/train.py`: config-selected multi-model training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
@@ -56,11 +56,9 @@ Input:
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
 - Optional model-selection key:
-  - `model_ids` (ordered list of baseline model recipes for the configured task)
-  - `model_id` (single-model shorthand; mutually exclusive with `model_ids`)
+  - `model_ids` (ordered list of canonical baseline model recipes for the configured task)
     - regression: `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
     - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-    - compatibility aliases accepted during transition: `elasticnet`, `logistic_regression`, `random_forest`, `lightgbm`, `catboost`, `xgb`
 - Optional binary-classification key:
   - `positive_label` (explicit positive class for binary competitions; required unless observed labels match one of the documented safe conventions `[0, 1]`, `[False, True]`, or `["No", "Yes"]`)
 - Optional submission schema keys:
@@ -137,9 +135,9 @@ Manual verification steps for each target:
 - No config overrides via CLI or environment variables
 - Tracked example config files are documentation and starting points only; they are never read automatically at runtime
 - `task_type` and `primary_metric` must be present in config for every run
-- `model_ids` is the preferred model-selection interface; `model_id` remains the single-model shorthand and the two keys are mutually exclusive
-- `model_ids` must resolve to one or more supported presets for the configured task; if omitted, the task default is used
-- Configured model IDs are normalized to canonical preprocessing-first recipe IDs during config loading
+- `model_ids` is the config-time model-selection interface
+- `model_ids` must contain one or more canonical supported presets for the configured task; if omitted, the task default is used
+- Submit-time `model_id` remains the trained-model selector for choosing one artifact from a run
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
@@ -170,7 +168,8 @@ Hard-error cases include:
 - Missing `task_type` or `primary_metric` -> hard error
 - Unknown/unsupported configured `primary_metric` -> hard error
 - Invalid task/metric pairing (for example `binary` + `rmse`) -> hard error
-- Invalid `model_id` or `model_ids` for the configured task -> hard error
+- Removed config key `model_id` -> hard error
+- Invalid configured `model_ids` for the configured task -> hard error
 - Empty or duplicate `model_ids` -> hard error
 - Missing/invalid competition zip contents -> hard error
 - `id_column` inference not exactly one column -> hard error

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -7,8 +7,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
 from tabular_shenanigans.models import (
     get_default_model_id,
-    get_supported_model_ids,
-    is_model_id_valid_for_task,
     resolve_model_id,
 )
 
@@ -23,7 +21,6 @@ class AppConfig(BaseModel):
     competition_slug: str = Field(min_length=1)
     task_type: Literal["regression", "binary"]
     primary_metric: str
-    model_id: str | None = None
     model_ids: list[str] | None = None
     positive_label: str | int | bool | None = None
     id_column: str | None = None
@@ -52,34 +49,18 @@ class AppConfig(BaseModel):
             )
         self.primary_metric = normalized_primary_metric
 
-        if self.model_id is not None and self.model_ids is not None:
-            raise ValueError("model_id and model_ids are mutually exclusive. Use only one of them.")
-
         if self.model_ids is not None:
             if not self.model_ids:
-                raise ValueError("model_ids must contain at least one model_id.")
-            resolved_model_ids = self.model_ids
-        elif self.model_id is not None:
-            resolved_model_ids = [self.model_id]
+                raise ValueError("model_ids must contain at least one canonical model_id.")
+            resolved_model_ids = list(self.model_ids)
         else:
             resolved_model_ids = [get_default_model_id(self.task_type)]
 
-        supported_model_ids = get_supported_model_ids(self.task_type, include_aliases=True)
-        invalid_model_ids = [
-            model_id for model_id in resolved_model_ids if not is_model_id_valid_for_task(self.task_type, model_id)
-        ]
-        if invalid_model_ids:
-            raise ValueError(
-                f"Configured model_ids {invalid_model_ids} are not valid for task_type '{self.task_type}'. "
-                f"Supported model_ids: {supported_model_ids}"
-            )
-
         canonical_model_ids = [resolve_model_id(self.task_type, model_id) for model_id in resolved_model_ids]
         if len(set(canonical_model_ids)) != len(canonical_model_ids):
-            raise ValueError(f"model_ids must not contain duplicates after alias resolution: {canonical_model_ids}")
+            raise ValueError(f"model_ids must not contain duplicates: {canonical_model_ids}")
 
         self.model_ids = canonical_model_ids
-        self.model_id = canonical_model_ids[0] if len(canonical_model_ids) == 1 else None
 
         if self.task_type != "binary" and self.positive_label is not None:
             raise ValueError("positive_label is only supported for binary task_type.")
@@ -102,5 +83,11 @@ def load_config(path: str = "config.yaml") -> AppConfig:
 
     if not isinstance(raw_data, dict):
         raise ConfigError("Config must be a top-level mapping.")
+    if "model_id" in raw_data:
+        raise ConfigError(
+            "Config key 'model_id' is no longer supported. "
+            "Use model_ids with canonical recipe IDs instead, for example: "
+            "model_ids: [onehot_logreg]"
+        )
 
     return AppConfig.model_validate(raw_data)

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -369,38 +369,9 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
     },
 }
 
-MODEL_ID_ALIASES: dict[str, dict[str, str]] = {
-    "regression": {
-        "catboost": "native_catboost",
-        "catboost_native": "native_catboost",
-        "elasticnet": "onehot_elasticnet",
-        "lightgbm": "ordinal_lightgbm",
-        "random_forest": "ordinal_randomforest",
-        "xgb": "ordinal_xgboost",
-        "xgboost": "ordinal_xgboost",
-    },
-    "binary": {
-        "catboost": "native_catboost",
-        "catboost_native": "native_catboost",
-        "lightgbm": "ordinal_lightgbm",
-        "logistic_regression": "onehot_logreg",
-        "random_forest": "ordinal_randomforest",
-        "xgb": "ordinal_xgboost",
-        "xgboost": "ordinal_xgboost",
-    },
-}
-
-
 def _get_task_model_registry(task_type: str) -> dict[str, ModelDefinition]:
     try:
         return MODEL_REGISTRY[task_type]
-    except KeyError as exc:
-        raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
-
-
-def _get_task_model_aliases(task_type: str) -> dict[str, str]:
-    try:
-        return MODEL_ID_ALIASES[task_type]
     except KeyError as exc:
         raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
 
@@ -412,11 +383,8 @@ def get_default_model_id(task_type: str) -> str:
         raise ValueError(f"Unsupported task_type for model selection: {task_type}") from exc
 
 
-def get_supported_model_ids(task_type: str, include_aliases: bool = False) -> list[str]:
-    supported_model_ids = sorted(_get_task_model_registry(task_type))
-    if not include_aliases:
-        return supported_model_ids
-    return sorted(supported_model_ids + list(_get_task_model_aliases(task_type)))
+def get_supported_model_ids(task_type: str) -> list[str]:
+    return sorted(_get_task_model_registry(task_type))
 
 
 def resolve_model_id(task_type: str, model_id: str) -> str:
@@ -424,14 +392,10 @@ def resolve_model_id(task_type: str, model_id: str) -> str:
     if model_id in task_registry:
         return model_id
 
-    task_aliases = _get_task_model_aliases(task_type)
-    if model_id in task_aliases:
-        return task_aliases[model_id]
-
-    supported_model_ids = get_supported_model_ids(task_type, include_aliases=True)
+    supported_model_ids = get_supported_model_ids(task_type)
     raise ValueError(
-        f"Configured model_id '{model_id}' is not valid for task_type '{task_type}'. "
-        f"Supported model_ids: {supported_model_ids}"
+        f"Model id '{model_id}' is not valid for task_type '{task_type}'. "
+        f"Use canonical model_ids only. Supported model_ids: {supported_model_ids}"
     )
 
 

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -587,7 +587,6 @@ def _build_config_snapshot(
         "competition_slug": config.competition_slug,
         "task_type": config.task_type,
         "primary_metric": config.primary_metric,
-        "model_id": model_ids[0] if len(model_ids) == 1 else None,
         "model_ids": model_ids,
         "positive_label": positive_label,
         "id_column": id_column,


### PR DESCRIPTION
## Summary
- remove config-time support for the model_id shorthand and require model_ids only
- retire model-selection alias resolution and accept canonical recipe IDs only
- update tracked example configs and docs while keeping submit-time model_id selection and artifact naming unchanged

Closes #47

## Verification
- uv run python -m compileall main.py src
- synthetic config validation checks: removed model_id key now fails directly, alias IDs now fail directly, omitted model_ids still resolve to the task default
- synthetic binary multi-model train plus submit dry run using canonical model_ids with explicit submit-time model_id selection
- synthetic single-model regression train smoke run using a one-entry canonical model_ids list
- local ignored config.yaml migrated to a one-entry model_ids list so the workspace remains runnable after the contract change