### PR TITLE
Add Optuna tuning stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@ The repository is developed and manually verified primarily against these Playgr
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Run stage-specific CLI entrypoints for `fetch`, `eda`, `preprocess`, `train`, and submit-only flows against explicit run artifacts.
+- Run an explicit `tune` stage that evaluates Optuna trials for one configured model recipe, writes study artifacts, and retrains the best trial into the standard training artifact layout.
 - Train one or more cross-validated model recipes with fold-local, model-specific preprocessing:
   - `onehot` preprocessing: `onehot_ridge`, `onehot_elasticnet`, `onehot_logreg`
   - `ordinal` preprocessing: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `ordinal_xgboost`
   - `native` preprocessing: `native_catboost`
 - Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
+- Write tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, including `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
 
 ## Tooling
 - Python for orchestration
 - Kaggle CLI for competition data and submissions
+- Optuna for local hyperparameter tuning
 - `gh` CLI for repository management
 - `uv` for environment management
 
@@ -64,6 +67,7 @@ Available stage-specific commands:
 - `uv run python main.py eda`
 - `uv run python main.py preprocess`
 - `uv run python main.py train`
+- `uv run python main.py tune`
 - `uv run python main.py submit --run-dir artifacts/<competition_slug>/train/<run_id>`
 - `uv run python main.py submit --run-id <run_id>`
 
@@ -72,6 +76,7 @@ Stage behavior:
 - `eda`: fetches if needed, then writes EDA report CSVs
 - `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
 - `train`: fetches if needed, then trains and writes normal training artifacts
+- `tune`: fetches if needed, runs an Optuna study for `tuning.model_id`, writes tuning artifacts, then retrains the best trial into the normal training artifact layout
 - `submit`: requires an explicit existing run selection and never retrains implicitly
 
 The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
@@ -124,6 +129,15 @@ Optional CV keys:
 - `cv_shuffle`: whether to shuffle before splitting (default `true`)
 - `cv_random_state`: random seed for deterministic folds (default `42`)
 
+Optional tuning block:
+- `tuning.enabled`: enables the `tune` stage for the current config (default `false`)
+- `tuning.model_id`: one canonical tunable model recipe for the configured task
+  - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+  - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+- `tuning.n_trials`: optional Optuna trial limit
+- `tuning.timeout_seconds`: optional wall-clock limit
+- `tuning.random_state`: Optuna sampler seed (default `42`)
+
 Optional submission keys:
 - `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `submit_message_prefix`: optional prefix used in auto-generated submission messages
@@ -135,6 +149,8 @@ Binary prediction artifact contract:
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
 `model_ids` is the config-driven model-selection interface. If `model_ids` is omitted, the workflow selects the current default recipe for the configured task: `onehot_elasticnet` for regression and `onehot_logreg` for binary classification. For a single-model run, use a one-entry `model_ids` list. Config-time model selection accepts canonical preprocessing-first recipe IDs only. Submit-time `--model-id` still selects one trained model artifact from an existing run.
+
+`tune` uses `tuning.model_id` only. It does not reuse the top-level `model_ids` list for trial evaluation. After the study completes, the best trial is retrained as a single-model normal training run and the resulting `run_manifest.json` records `tuning_provenance`.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -157,16 +173,25 @@ Manual verification for each target:
 - confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order, for the submitted model
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
+Manual verification for tuning:
+- run `uv run python main.py tune` with `tuning.enabled: true`, one supported `tuning.model_id`, and at least one stopping condition
+- confirm `artifacts/<competition_slug>/tune/<study_id>/study_manifest.json` is written
+- confirm `artifacts/<competition_slug>/tune/<study_id>/trials.csv` records trial state, score, and params
+- confirm `artifacts/<competition_slug>/train/<run_id>/run_manifest.json` records `tuning_provenance`
+
 ## Outputs
 - Competition data: `data/<competition_slug>/`
 - EDA reports: `reports/<competition_slug>/`
   - when `preprocess` stage is run, also includes `preprocess_summary.csv`, `preprocess_features.csv`, and `preprocess_models.csv`
+- Tuning artifacts: `artifacts/<competition_slug>/tune/<study_id>/`
+  - includes `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`
 - Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
   - includes `run_diagnostics.csv`, `model_summary.csv`, and `run_manifest.json`
   - includes per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/`
   - each model subdirectory includes `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
   - `run_manifest.json` is the canonical per-run metadata source
   - each model summary/manifest entry records the resolved `preprocessing_scheme_id`
+  - tuned retrain runs also record `tuning_provenance`
 - Run ledger: `artifacts/<competition_slug>/train/runs.csv` as a compact comparison/history table
 - Submission ledger: `artifacts/<competition_slug>/train/submissions.csv` as an append-only submission event table
 
@@ -176,6 +201,7 @@ Manual verification for each target:
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - Configured `model_ids` must use canonical preprocessing-aware training recipe IDs; run artifacts record the canonical `model_id` and `preprocessing_scheme_id`.
+- The `tune` stage uses `tuning.model_id` only, and the tuned best-trial retrain writes a standard single-model train artifact with `tuning_provenance`.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
@@ -186,4 +212,5 @@ Manual verification for each target:
 - Binary classification requires an explicit positive-class contract. If `positive_label` is omitted, the workflow only auto-resolves the positive class for labels `[0, 1]`, `[False, True]`, or `["No", "Yes"]`; other two-class label pairs fail fast.
 - `task_type` and `primary_metric` are explicitly configured for every run.
 - Runtime config comes from local repository-root `config.yaml` only; tracked example files are just starting points, and there are no CLI or environment overrides.
+- Tuning search spaces live in code next to model definitions; there is no YAML search-space DSL.
 - The current workflow is CPU-first and optimized for iteration speed over production hardening.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -35,5 +35,14 @@ model_ids:
 # cv_shuffle: true
 # cv_random_state: 42
 
+# Optional Optuna tuning settings for `uv run python main.py tune`.
+# tune uses tuning.model_id only; normal train still uses top-level model_ids.
+# tuning:
+#   enabled: true
+#   model_id: ordinal_hgb
+#   n_trials: 25
+#   # timeout_seconds: 3600
+#   random_state: 42
+
 submit_enabled: false
 # submit_message_prefix: s5e12-baseline

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -32,5 +32,14 @@ model_ids:
 # cv_shuffle: true
 # cv_random_state: 42
 
+# Optional Optuna tuning settings for `uv run python main.py tune`.
+# tune uses tuning.model_id only; normal train still uses top-level model_ids.
+# tuning:
+#   enabled: true
+#   model_id: ordinal_hgb
+#   n_trials: 25
+#   # timeout_seconds: 3600
+#   random_state: 42
+
 submit_enabled: false
 # submit_message_prefix: s5e10-baseline

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -22,12 +22,15 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
 11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
+When the explicit `tune` stage is selected, the workflow additionally runs an Optuna study for one configured `tuning.model_id`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard train artifact layout with `tuning_provenance` recorded in `run_manifest.json`.
+
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `eda` -> `train` -> `submit`)
 - `uv run python main.py fetch`: ensure competition data is present
 - `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
 - `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
 - `uv run python main.py train`: fetch if needed, load the shared dataset context, and write training artifacts
+- `uv run python main.py tune`: fetch if needed, load the shared dataset context, run an Optuna study for `tuning.model_id`, write tuning artifacts, and retrain the best trial into normal training artifacts
 - `uv run python main.py submit --run-dir artifacts/.../train/<run_id>`: prepare or submit from an explicit existing run artifact
 - `uv run python main.py submit --run-id <run_id>`: resolve the run under `artifacts/<competition_slug>/train/<run_id>` using the configured competition slug
 
@@ -36,14 +39,15 @@ The `preprocess` stage is intentionally diagnostic. It is not part of the defaul
 The default `submit` path supports current manifest-backed run artifacts only. Unsupported older local artifact layouts fail directly instead of using compatibility fallbacks.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, EDA, preprocess diagnostics, training, and submission.
+- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, EDA, preprocess diagnostics, training, tuning, and submission.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
-- `src/tabular_shenanigans/models.py`: model-recipe registry, canonical model-id validation, optional booster loading, and estimator construction for supported presets.
+- `src/tabular_shenanigans/models.py`: model-recipe registry, canonical model-id validation, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/train.py`: config-selected multi-model training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
+- `src/tabular_shenanigans/tune.py`: Optuna study execution, study artifact writing, and best-trial retraining into the standard train artifact layout.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
@@ -73,6 +77,14 @@ Input:
   - `cv_n_splits` (integer >= 2, default 7)
   - `cv_shuffle` (boolean, default true)
   - `cv_random_state` (integer, default 42)
+- Optional tuning block:
+  - `tuning.enabled` (boolean, default false)
+  - `tuning.model_id` (one explicit canonical tunable model recipe for the configured task)
+    - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+    - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
+  - `tuning.n_trials` (integer >= 1, optional)
+  - `tuning.timeout_seconds` (integer >= 1, optional)
+  - `tuning.random_state` (integer, default 42)
 - Optional keys for submission:
   - `submit_enabled` (boolean, default false)
   - `submit_message_prefix` (string, optional)
@@ -83,6 +95,8 @@ Binary prediction artifact contract:
 
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
+tuning requires at least one stopping condition: `tuning.n_trials` or `tuning.timeout_seconds`.
+tune uses `tuning.model_id` only; the normal `train` stage still uses top-level `model_ids`.
 LightGBM, CatBoost, and XGBoost require the optional booster dependencies installed via `uv sync --extra boosters`.
 
 ## Preferred Verification Targets
@@ -99,6 +113,8 @@ Manual verification steps for each target:
 - confirm `test_predictions.csv` is generated in each model directory
 - confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected model directory
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
+- when tuning is enabled, run `uv run python main.py tune` and confirm `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json` are generated under `artifacts/<competition_slug>/tune/<study_id>/`
+- when tuning is enabled, confirm the best-trial retrain writes a standard train artifact and records `tuning_provenance` in `run_manifest.json`
 
 ## Artifact Contract
 - A validated in-memory config object from Pydantic
@@ -127,6 +143,12 @@ Manual verification steps for each target:
     - `submission.csv` when prepared or submitted
 - `run_manifest.json` is the canonical per-run metadata source
 - Each model entry in `model_summary.csv` and `run_manifest.json` records the resolved `preprocessing_scheme_id`
+- tuned retrain runs record `tuning_provenance` in `run_manifest.json`
+- Tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`:
+  - `study_manifest.json`
+  - `study_summary.csv`
+  - `trials.csv`
+  - `best_params.json`
 - Training ledger at `artifacts/<competition_slug>/train/runs.csv` with compact comparison fields and task-aware target summary fields
 - Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv` with submission event metadata only
 
@@ -137,6 +159,9 @@ Manual verification steps for each target:
 - `task_type` and `primary_metric` must be present in config for every run
 - `model_ids` is the config-time model-selection interface
 - `model_ids` must contain one or more canonical supported presets for the configured task; if omitted, the task default is used
+- the `tune` stage requires `tuning.enabled=true`, uses `tuning.model_id` only, and retrains exactly one tuned candidate into the normal train artifact layout
+- `tuning.model_id` must be one of the supported tunable model recipes for the configured task
+- tuning must have at least one stopping condition: `tuning.n_trials` or `tuning.timeout_seconds`
 - Submit-time `model_id` remains the trained-model selector for choosing one artifact from a run
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
@@ -171,6 +196,9 @@ Hard-error cases include:
 - Removed config key `model_id` -> hard error
 - Invalid configured `model_ids` for the configured task -> hard error
 - Empty or duplicate `model_ids` -> hard error
+- `tuning.enabled=true` without `tuning.model_id` -> hard error
+- `tuning.enabled=true` without `tuning.n_trials` or `tuning.timeout_seconds` -> hard error
+- unsupported configured `tuning.model_id` for the configured task -> hard error
 - Missing/invalid competition zip contents -> hard error
 - `id_column` inference not exactly one column -> hard error
 - `label_column` inference not exactly one column -> hard error

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from tabular_shenanigans.data import fetch_competition_data, load_competition_da
 from tabular_shenanigans.eda import run_eda
 from tabular_shenanigans.preprocess import run_preprocess
 from tabular_shenanigans.submit import run_submission
+from tabular_shenanigans.tune import run_tuning
 from tabular_shenanigans.train import run_training
 
 
@@ -22,6 +23,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("eda", help="Run EDA reports only.")
     subparsers.add_parser("preprocess", help="Write preprocessing diagnostics only.")
     subparsers.add_parser("train", help="Run training only.")
+    subparsers.add_parser("tune", help="Run Optuna tuning and retrain the best trial.")
 
     submit_parser = subparsers.add_parser("submit", help="Prepare or submit from an existing run artifact.")
     run_selection = submit_parser.add_mutually_exclusive_group(required=True)
@@ -101,6 +103,14 @@ def _run_train_stage(config: AppConfig) -> None:
     print(f"Training artifacts ready: {train_dir}")
 
 
+def _run_tune_stage(config: AppConfig) -> None:
+    _ensure_data_ready(config)
+    dataset_context = _load_shared_dataset_context(config)
+    tuning_result = run_tuning(config=config, dataset_context=dataset_context)
+    print(f"Tuning artifacts ready: {tuning_result.study_dir}")
+    print(f"Best-trial training artifacts ready: {tuning_result.train_dir}")
+
+
 def _run_submit_stage(config: AppConfig, args: argparse.Namespace) -> None:
     run_dir = _resolve_run_dir(config, args)
     print(f"Using run_dir: {run_dir}")
@@ -136,6 +146,10 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.stage == "train":
         _run_train_stage(config)
+        return
+
+    if args.stage == "tune":
+        _run_tune_stage(config)
         return
 
     if args.stage == "submit":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "kaggle>=2.0.0",
+    "optuna>=4.7.0",
     "pandas>=3.0.1",
     "pydantic",
     "PyYAML",

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -7,12 +7,24 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
 from tabular_shenanigans.models import (
     get_default_model_id,
+    get_tunable_model_ids,
+    is_model_tunable,
     resolve_model_id,
 )
 
 
 class ConfigError(ValueError):
     pass
+
+
+class TuningConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    model_id: str | None = None
+    n_trials: int | None = Field(default=None, ge=1)
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    random_state: int = 42
 
 
 class AppConfig(BaseModel):
@@ -32,6 +44,7 @@ class AppConfig(BaseModel):
     cv_n_splits: int = Field(default=7, ge=2)
     cv_shuffle: bool = True
     cv_random_state: int = 42
+    tuning: TuningConfig | None = None
     submit_enabled: bool = False
     submit_message_prefix: str | None = None
 
@@ -64,6 +77,22 @@ class AppConfig(BaseModel):
 
         if self.task_type != "binary" and self.positive_label is not None:
             raise ValueError("positive_label is only supported for binary task_type.")
+
+        if self.tuning is not None and self.tuning.enabled:
+            if self.tuning.model_id is None:
+                raise ValueError("tuning.model_id is required when tuning.enabled=true.")
+            if self.tuning.n_trials is None and self.tuning.timeout_seconds is None:
+                raise ValueError(
+                    "At least one tuning stopping condition is required. "
+                    "Set tuning.n_trials or tuning.timeout_seconds."
+                )
+            canonical_tuning_model_id = resolve_model_id(self.task_type, self.tuning.model_id)
+            if not is_model_tunable(self.task_type, canonical_tuning_model_id):
+                raise ValueError(
+                    f"Configured tuning.model_id '{canonical_tuning_model_id}' does not support tuning for task_type "
+                    f"'{self.task_type}'. Supported tunable model_ids: {get_tunable_model_ids(self.task_type)}"
+                )
+            self.tuning.model_id = canonical_tuning_model_id
         return self
 
 

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -14,8 +14,9 @@ from sklearn.ensemble import (
 )
 from sklearn.linear_model import ElasticNet, LogisticRegression, Ridge
 
-ModelBuilder = Callable[[int], tuple[object, dict[str, object]]]
+ModelBuilder = Callable[[int, dict[str, object] | None], tuple[object, dict[str, object]]]
 FitKwargsBuilder = Callable[[object, list[str], list[str]], dict[str, object]]
+TuningSpaceBuilder = Callable[[object], dict[str, object]]
 
 
 @dataclass(frozen=True)
@@ -25,6 +26,7 @@ class ModelDefinition:
     preprocessing_scheme_id: str
     builder: ModelBuilder
     fit_kwargs_builder: FitKwargsBuilder | None = None
+    tuning_space_builder: TuningSpaceBuilder | None = None
 
 
 class BinaryLabelEncodingClassifier:
@@ -59,67 +61,108 @@ class BinaryLabelEncodingClassifier:
         return self.estimator.predict_proba(x_values)
 
 
-def _build_ridge(random_state: int) -> tuple[Ridge, dict[str, object]]:
+def _merge_model_params(
+    default_params: dict[str, object],
+    parameter_overrides: dict[str, object] | None = None,
+) -> dict[str, object]:
+    merged_params = dict(default_params)
+    if parameter_overrides:
+        merged_params.update(parameter_overrides)
+    return merged_params
+
+
+def _build_ridge(random_state: int, parameter_overrides: dict[str, object] | None = None) -> tuple[Ridge, dict[str, object]]:
     del random_state
-    return Ridge(), {}
+    params = _merge_model_params({}, parameter_overrides)
+    return Ridge(**params), params
 
 
-def _build_elasticnet(random_state: int) -> tuple[ElasticNet, dict[str, object]]:
+def _build_elasticnet(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[ElasticNet, dict[str, object]]:
     del random_state
-    return ElasticNet(), {}
+    params = _merge_model_params({}, parameter_overrides)
+    return ElasticNet(**params), params
 
 
-def _build_random_forest_regressor(random_state: int) -> tuple[RandomForestRegressor, dict[str, object]]:
-    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
+def _build_random_forest_regressor(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[RandomForestRegressor, dict[str, object]]:
+    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return RandomForestRegressor(**params), params
 
 
-def _build_extra_trees_regressor(random_state: int) -> tuple[ExtraTreesRegressor, dict[str, object]]:
-    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
+def _build_extra_trees_regressor(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[ExtraTreesRegressor, dict[str, object]]:
+    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return ExtraTreesRegressor(**params), params
 
 
 def _build_hist_gradient_boosting_regressor(
     random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[HistGradientBoostingRegressor, dict[str, object]]:
-    params = {
-        "early_stopping": False,
-        "learning_rate": 0.05,
-        "max_iter": 300,
-        "random_state": random_state,
-    }
+    params = _merge_model_params(
+        {
+            "early_stopping": False,
+            "learning_rate": 0.05,
+            "max_iter": 300,
+            "random_state": random_state,
+        },
+        parameter_overrides,
+    )
     return HistGradientBoostingRegressor(**params), params
 
 
-def _build_logreg(random_state: int) -> tuple[LogisticRegression, dict[str, object]]:
+def _build_logreg(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[LogisticRegression, dict[str, object]]:
     del random_state
-    params = {"max_iter": 1000}
+    params = _merge_model_params({"max_iter": 1000}, parameter_overrides)
     return LogisticRegression(**params), params
 
 
-def _build_random_forest_classifier(random_state: int) -> tuple[RandomForestClassifier, dict[str, object]]:
-    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
+def _build_random_forest_classifier(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[RandomForestClassifier, dict[str, object]]:
+    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return RandomForestClassifier(**params), params
 
 
-def _build_extra_trees_classifier(random_state: int) -> tuple[ExtraTreesClassifier, dict[str, object]]:
-    params = {"n_estimators": 500, "n_jobs": -1, "random_state": random_state}
+def _build_extra_trees_classifier(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[ExtraTreesClassifier, dict[str, object]]:
+    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return ExtraTreesClassifier(**params), params
 
 
 def _build_hist_gradient_boosting_classifier(
     random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[HistGradientBoostingClassifier, dict[str, object]]:
-    params = {
-        "early_stopping": False,
-        "learning_rate": 0.05,
-        "max_iter": 300,
-        "random_state": random_state,
-    }
+    params = _merge_model_params(
+        {
+            "early_stopping": False,
+            "learning_rate": 0.05,
+            "max_iter": 300,
+            "random_state": random_state,
+        },
+        parameter_overrides,
+    )
     return HistGradientBoostingClassifier(**params), params
 
 
-def _build_lightgbm_regressor(random_state: int) -> tuple[object, dict[str, object]]:
+def _build_lightgbm_regressor(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[object, dict[str, object]]:
     try:
         from lightgbm import LGBMRegressor
     except ImportError as exc:
@@ -128,19 +171,25 @@ def _build_lightgbm_regressor(random_state: int) -> tuple[object, dict[str, obje
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = {
-        "colsample_bytree": 0.8,
-        "learning_rate": 0.05,
-        "n_estimators": 500,
-        "n_jobs": -1,
-        "random_state": random_state,
-        "subsample": 0.8,
-        "verbosity": -1,
-    }
+    params = _merge_model_params(
+        {
+            "colsample_bytree": 0.8,
+            "learning_rate": 0.05,
+            "n_estimators": 500,
+            "n_jobs": -1,
+            "random_state": random_state,
+            "subsample": 0.8,
+            "verbosity": -1,
+        },
+        parameter_overrides,
+    )
     return LGBMRegressor(**params), params
 
 
-def _build_lightgbm_classifier(random_state: int) -> tuple[object, dict[str, object]]:
+def _build_lightgbm_classifier(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[object, dict[str, object]]:
     try:
         from lightgbm import LGBMClassifier
     except ImportError as exc:
@@ -149,19 +198,25 @@ def _build_lightgbm_classifier(random_state: int) -> tuple[object, dict[str, obj
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = {
-        "colsample_bytree": 0.8,
-        "learning_rate": 0.05,
-        "n_estimators": 500,
-        "n_jobs": -1,
-        "random_state": random_state,
-        "subsample": 0.8,
-        "verbosity": -1,
-    }
+    params = _merge_model_params(
+        {
+            "colsample_bytree": 0.8,
+            "learning_rate": 0.05,
+            "n_estimators": 500,
+            "n_jobs": -1,
+            "random_state": random_state,
+            "subsample": 0.8,
+            "verbosity": -1,
+        },
+        parameter_overrides,
+    )
     return LGBMClassifier(**params), params
 
 
-def _build_catboost_regressor(random_state: int) -> tuple[object, dict[str, object]]:
+def _build_catboost_regressor(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[object, dict[str, object]]:
     try:
         from catboost import CatBoostRegressor
     except ImportError as exc:
@@ -170,20 +225,26 @@ def _build_catboost_regressor(random_state: int) -> tuple[object, dict[str, obje
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = {
-        "allow_writing_files": False,
-        "depth": 6,
-        "iterations": 500,
-        "learning_rate": 0.05,
-        "loss_function": "RMSE",
-        "random_seed": random_state,
-        "thread_count": -1,
-        "verbose": False,
-    }
+    params = _merge_model_params(
+        {
+            "allow_writing_files": False,
+            "depth": 6,
+            "iterations": 500,
+            "learning_rate": 0.05,
+            "loss_function": "RMSE",
+            "random_seed": random_state,
+            "thread_count": -1,
+            "verbose": False,
+        },
+        parameter_overrides,
+    )
     return CatBoostRegressor(**params), params
 
 
-def _build_catboost_classifier(random_state: int) -> tuple[object, dict[str, object]]:
+def _build_catboost_classifier(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[object, dict[str, object]]:
     try:
         from catboost import CatBoostClassifier
     except ImportError as exc:
@@ -192,20 +253,26 @@ def _build_catboost_classifier(random_state: int) -> tuple[object, dict[str, obj
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = {
-        "allow_writing_files": False,
-        "depth": 6,
-        "iterations": 500,
-        "learning_rate": 0.05,
-        "loss_function": "Logloss",
-        "random_seed": random_state,
-        "thread_count": -1,
-        "verbose": False,
-    }
+    params = _merge_model_params(
+        {
+            "allow_writing_files": False,
+            "depth": 6,
+            "iterations": 500,
+            "learning_rate": 0.05,
+            "loss_function": "Logloss",
+            "random_seed": random_state,
+            "thread_count": -1,
+            "verbose": False,
+        },
+        parameter_overrides,
+    )
     return CatBoostClassifier(**params), params
 
 
-def _build_xgboost_regressor(random_state: int) -> tuple[object, dict[str, object]]:
+def _build_xgboost_regressor(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[object, dict[str, object]]:
     try:
         from xgboost import XGBRegressor
     except ImportError as exc:
@@ -214,22 +281,28 @@ def _build_xgboost_regressor(random_state: int) -> tuple[object, dict[str, objec
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = {
-        "colsample_bytree": 0.8,
-        "eval_metric": "rmse",
-        "learning_rate": 0.05,
-        "max_depth": 6,
-        "n_estimators": 500,
-        "n_jobs": -1,
-        "objective": "reg:squarederror",
-        "random_state": random_state,
-        "subsample": 0.8,
-        "tree_method": "hist",
-    }
+    params = _merge_model_params(
+        {
+            "colsample_bytree": 0.8,
+            "eval_metric": "rmse",
+            "learning_rate": 0.05,
+            "max_depth": 6,
+            "n_estimators": 500,
+            "n_jobs": -1,
+            "objective": "reg:squarederror",
+            "random_state": random_state,
+            "subsample": 0.8,
+            "tree_method": "hist",
+        },
+        parameter_overrides,
+    )
     return XGBRegressor(**params), params
 
 
-def _build_xgboost_classifier(random_state: int) -> tuple[object, dict[str, object]]:
+def _build_xgboost_classifier(
+    random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
+) -> tuple[object, dict[str, object]]:
     try:
         from xgboost import XGBClassifier
     except ImportError as exc:
@@ -238,19 +311,58 @@ def _build_xgboost_classifier(random_state: int) -> tuple[object, dict[str, obje
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = {
-        "colsample_bytree": 0.8,
-        "eval_metric": "logloss",
-        "learning_rate": 0.05,
-        "max_depth": 6,
-        "n_estimators": 500,
-        "n_jobs": -1,
-        "objective": "binary:logistic",
-        "random_state": random_state,
-        "subsample": 0.8,
-        "tree_method": "hist",
-    }
+    params = _merge_model_params(
+        {
+            "colsample_bytree": 0.8,
+            "eval_metric": "logloss",
+            "learning_rate": 0.05,
+            "max_depth": 6,
+            "n_estimators": 500,
+            "n_jobs": -1,
+            "objective": "binary:logistic",
+            "random_state": random_state,
+            "subsample": 0.8,
+            "tree_method": "hist",
+        },
+        parameter_overrides,
+    )
     return BinaryLabelEncodingClassifier(XGBClassifier(**params)), params
+
+
+def _build_random_forest_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "max_depth": trial.suggest_int("max_depth", 4, 24),
+        "max_features": trial.suggest_float("max_features", 0.3, 1.0),
+        "min_samples_leaf": trial.suggest_int("min_samples_leaf", 1, 20),
+        "n_estimators": trial.suggest_int("n_estimators", 200, 1000, step=100),
+    }
+
+
+def _build_extra_trees_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "max_depth": trial.suggest_int("max_depth", 4, 24),
+        "max_features": trial.suggest_float("max_features", 0.3, 1.0),
+        "min_samples_leaf": trial.suggest_int("min_samples_leaf", 1, 20),
+        "n_estimators": trial.suggest_int("n_estimators", 200, 1000, step=100),
+    }
+
+
+def _build_hist_gradient_boosting_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "l2_regularization": trial.suggest_float("l2_regularization", 1e-10, 10.0, log=True),
+        "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.2, log=True),
+        "max_depth": trial.suggest_int("max_depth", 3, 12),
+        "max_iter": trial.suggest_int("max_iter", 100, 600, step=50),
+        "max_leaf_nodes": trial.suggest_int("max_leaf_nodes", 15, 255),
+        "min_samples_leaf": trial.suggest_int("min_samples_leaf", 10, 80),
+    }
+
+
+def _build_logreg_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "C": trial.suggest_float("C", 1e-3, 1e2, log=True),
+        "class_weight": trial.suggest_categorical("class_weight", [None, "balanced"]),
+    }
 
 
 def _build_catboost_fit_kwargs(
@@ -289,18 +401,21 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="RandomForestRegressor",
             preprocessing_scheme_id="ordinal",
             builder=_build_random_forest_regressor,
+            tuning_space_builder=_build_random_forest_tuning_space,
         ),
         "ordinal_extratrees": ModelDefinition(
             model_id="ordinal_extratrees",
             model_name="ExtraTreesRegressor",
             preprocessing_scheme_id="ordinal",
             builder=_build_extra_trees_regressor,
+            tuning_space_builder=_build_extra_trees_tuning_space,
         ),
         "ordinal_hgb": ModelDefinition(
             model_id="ordinal_hgb",
             model_name="HistGradientBoostingRegressor",
             preprocessing_scheme_id="ordinal",
             builder=_build_hist_gradient_boosting_regressor,
+            tuning_space_builder=_build_hist_gradient_boosting_tuning_space,
         ),
         "ordinal_lightgbm": ModelDefinition(
             model_id="ordinal_lightgbm",
@@ -328,24 +443,28 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LogisticRegression",
             preprocessing_scheme_id="onehot",
             builder=_build_logreg,
+            tuning_space_builder=_build_logreg_tuning_space,
         ),
         "ordinal_randomforest": ModelDefinition(
             model_id="ordinal_randomforest",
             model_name="RandomForestClassifier",
             preprocessing_scheme_id="ordinal",
             builder=_build_random_forest_classifier,
+            tuning_space_builder=_build_random_forest_tuning_space,
         ),
         "ordinal_extratrees": ModelDefinition(
             model_id="ordinal_extratrees",
             model_name="ExtraTreesClassifier",
             preprocessing_scheme_id="ordinal",
             builder=_build_extra_trees_classifier,
+            tuning_space_builder=_build_extra_trees_tuning_space,
         ),
         "ordinal_hgb": ModelDefinition(
             model_id="ordinal_hgb",
             model_name="HistGradientBoostingClassifier",
             preprocessing_scheme_id="ordinal",
             builder=_build_hist_gradient_boosting_classifier,
+            tuning_space_builder=_build_hist_gradient_boosting_tuning_space,
         ),
         "ordinal_lightgbm": ModelDefinition(
             model_id="ordinal_lightgbm",
@@ -387,6 +506,15 @@ def get_supported_model_ids(task_type: str) -> list[str]:
     return sorted(_get_task_model_registry(task_type))
 
 
+def get_tunable_model_ids(task_type: str) -> list[str]:
+    task_registry = _get_task_model_registry(task_type)
+    return sorted(
+        model_id
+        for model_id, model_definition in task_registry.items()
+        if model_definition.tuning_space_builder is not None
+    )
+
+
 def resolve_model_id(task_type: str, model_id: str) -> str:
     task_registry = _get_task_model_registry(task_type)
     if model_id in task_registry:
@@ -412,13 +540,30 @@ def is_model_id_valid_for_task(task_type: str, model_id: str) -> bool:
         return False
 
 
+def is_model_tunable(task_type: str, model_id: str) -> bool:
+    model_definition = get_model_definition(task_type, model_id)
+    return model_definition.tuning_space_builder is not None
+
+
+def build_tuning_space(task_type: str, model_id: str, trial: object) -> dict[str, object]:
+    model_definition = get_model_definition(task_type, model_id)
+    if model_definition.tuning_space_builder is None:
+        supported_model_ids = get_tunable_model_ids(task_type)
+        raise ValueError(
+            f"Model id '{model_definition.model_id}' does not support tuning for task_type '{task_type}'. "
+            f"Supported tunable model_ids: {supported_model_ids}"
+        )
+    return model_definition.tuning_space_builder(trial)
+
+
 def build_model(
     task_type: str,
     model_id: str,
     random_state: int,
+    parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[ModelDefinition, object, dict[str, object]]:
     model_definition = get_model_definition(task_type, model_id)
-    estimator, explicit_params = model_definition.builder(random_state)
+    estimator, explicit_params = model_definition.builder(random_state, parameter_overrides)
     return model_definition, estimator, explicit_params
 
 

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -106,6 +106,20 @@ class ModelRunResult:
 
 
 @dataclass(frozen=True)
+class TrainingModelSpec:
+    model_id: str
+    parameter_overrides: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class ModelEvaluationArtifacts:
+    model_result: ModelRunResult
+    fold_metrics_df: pd.DataFrame
+    oof_predictions: np.ndarray
+    final_test_predictions: np.ndarray
+
+
+@dataclass(frozen=True)
 class TrainingRunContext:
     run_id: str
     generated_at_utc: str
@@ -129,6 +143,7 @@ class TrainingRunContext:
     cv_n_splits: int
     cv_shuffle: bool
     cv_random_state: int
+    tuning_provenance: dict[str, object] | None = None
 
 
 def _json_ready(value: object) -> object:
@@ -145,6 +160,17 @@ def _json_ready(value: object) -> object:
 
 def _make_run_id() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _resolve_training_model_specs(
+    config: AppConfig,
+    model_specs: list[TrainingModelSpec] | None = None,
+) -> list[TrainingModelSpec]:
+    if model_specs is not None:
+        if not model_specs:
+            raise ValueError("Training requires at least one model specification.")
+        return model_specs
+    return [TrainingModelSpec(model_id=model_id) for model_id in config.model_ids]
 
 
 def _read_run_ledger(ledger_path: Path) -> pd.DataFrame:
@@ -352,27 +378,27 @@ def _build_run_diagnostics(
     return pd.DataFrame(run_diagnostics)
 
 
-def _train_single_model(
+def _evaluate_model_spec(
     task_type: str,
     primary_metric: str,
-    model_id: str,
+    model_spec: TrainingModelSpec,
     x_train_raw: pd.DataFrame,
     x_test_raw: pd.DataFrame,
     y_train: pd.Series,
-    test_ids: pd.Series,
-    id_column: str,
-    label_column: str,
     split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-    fold_assignments: np.ndarray,
-    run_dir: Path,
     force_categorical: list[str] | None,
     force_numeric: list[str] | None,
     low_cardinality_int_threshold: int | None,
     cv_random_state: int,
     positive_label: object | None,
     negative_label: object | None,
-) -> ModelRunResult:
-    model_definition, _, model_params = build_model(task_type, model_id, cv_random_state)
+) -> ModelEvaluationArtifacts:
+    model_definition, _, model_params = build_model(
+        task_type,
+        model_spec.model_id,
+        cv_random_state,
+        parameter_overrides=model_spec.parameter_overrides,
+    )
     resolved_model_id = model_definition.model_id
     model_name = model_definition.model_name
     preprocessing_scheme_id = model_definition.preprocessing_scheme_id
@@ -409,7 +435,12 @@ def _train_single_model(
             x_fold_valid_processed = np.asarray(x_fold_valid_processed)
             x_test_processed = np.asarray(x_test_processed)
 
-        _, model, _ = build_model(task_type, resolved_model_id, cv_random_state)
+        _, model, _ = build_model(
+            task_type,
+            resolved_model_id,
+            cv_random_state,
+            parameter_overrides=model_spec.parameter_overrides,
+        )
         model_fit_kwargs = build_model_fit_kwargs(
             model_definition=model_definition,
             x_train_processed=x_fold_train_processed,
@@ -460,20 +491,75 @@ def _train_single_model(
     else:
         final_test_predictions = mean_test_predictions
 
-    model_dir = run_dir / resolved_model_id
-    model_dir.mkdir(parents=True, exist_ok=True)
-
     fold_metrics_df = pd.DataFrame(fold_metrics)
-    fold_metrics_df.to_csv(model_dir / "fold_metrics.csv", index=False)
+    return ModelEvaluationArtifacts(
+        model_result=ModelRunResult(
+            model_id=resolved_model_id,
+            model_name=model_name,
+            preprocessing_scheme_id=preprocessing_scheme_id,
+            model_params=model_params,
+            cv_summary=CvSummary(
+                metric_name=primary_metric,
+                metric_mean=float(fold_metrics_df["metric_value"].mean()),
+                metric_std=float(fold_metrics_df["metric_value"].std(ddof=0)),
+                higher_is_better=is_higher_better(primary_metric),
+            ),
+        ),
+        fold_metrics_df=fold_metrics_df,
+        oof_predictions=oof_predictions,
+        final_test_predictions=np.asarray(final_test_predictions),
+    )
+
+
+def _train_single_model(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+    y_train: pd.Series,
+    test_ids: pd.Series,
+    id_column: str,
+    label_column: str,
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
+    fold_assignments: np.ndarray,
+    run_dir: Path,
+    force_categorical: list[str] | None,
+    force_numeric: list[str] | None,
+    low_cardinality_int_threshold: int | None,
+    cv_random_state: int,
+    positive_label: object | None,
+    negative_label: object | None,
+) -> ModelRunResult:
+    evaluation_artifacts = _evaluate_model_spec(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        model_spec=model_spec,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+        y_train=y_train,
+        split_indices=split_indices,
+        force_categorical=force_categorical,
+        force_numeric=force_numeric,
+        low_cardinality_int_threshold=low_cardinality_int_threshold,
+        cv_random_state=cv_random_state,
+        positive_label=positive_label,
+        negative_label=negative_label,
+    )
+    model_result = evaluation_artifacts.model_result
+
+    model_dir = run_dir / model_result.model_id
+    model_dir.mkdir(parents=True, exist_ok=True)
+    evaluation_artifacts.fold_metrics_df.to_csv(model_dir / "fold_metrics.csv", index=False)
 
     oof_df = pd.DataFrame(
         {
             "row_idx": np.arange(x_train_raw.shape[0], dtype=int),
             "y_true": y_train.to_numpy(),
-            "y_pred": oof_predictions,
+            "y_pred": evaluation_artifacts.oof_predictions,
             "fold": fold_assignments,
-            "model_id": resolved_model_id,
-            "model_name": model_name,
+            "model_id": model_result.model_id,
+            "model_name": model_result.model_name,
         }
     )
     oof_df.to_csv(model_dir / "oof_predictions.csv", index=False)
@@ -481,23 +567,12 @@ def _train_single_model(
     test_predictions_df = pd.DataFrame(
         {
             id_column: test_ids.to_numpy(),
-            label_column: final_test_predictions,
+            label_column: evaluation_artifacts.final_test_predictions,
         }
     )
     test_predictions_df.to_csv(model_dir / "test_predictions.csv", index=False)
 
-    return ModelRunResult(
-        model_id=resolved_model_id,
-        model_name=model_name,
-        preprocessing_scheme_id=preprocessing_scheme_id,
-        model_params=model_params,
-        cv_summary=CvSummary(
-            metric_name=primary_metric,
-            metric_mean=float(fold_metrics_df["metric_value"].mean()),
-            metric_std=float(fold_metrics_df["metric_value"].std(ddof=0)),
-            higher_is_better=is_higher_better(primary_metric),
-        ),
-    )
+    return model_result
 
 
 def _rank_model_results(
@@ -560,6 +635,7 @@ def _build_run_manifest(
         "train_cols": run_context.train_cols,
         "test_rows": run_context.test_rows,
         "test_cols": run_context.test_cols,
+        "tuning_provenance": run_context.tuning_provenance,
     }
 
     if len(models) == 1:
@@ -599,16 +675,17 @@ def _build_run_ledger_row(
 
 def _build_config_snapshot(
     config: AppConfig,
-    model_ids: list[str],
+    model_specs: list[TrainingModelSpec],
     positive_label: object | None,
     id_column: str,
     label_column: str,
+    tuning_provenance: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    return {
+    config_snapshot = {
         "competition_slug": config.competition_slug,
         "task_type": config.task_type,
         "primary_metric": config.primary_metric,
-        "model_ids": model_ids,
+        "model_ids": [model_spec.model_id for model_spec in model_specs],
         "positive_label": positive_label,
         "id_column": id_column,
         "label_column": label_column,
@@ -620,6 +697,16 @@ def _build_config_snapshot(
         "cv_shuffle": config.cv_shuffle,
         "cv_random_state": config.cv_random_state,
     }
+    parameter_overrides = {
+        model_spec.model_id: model_spec.parameter_overrides
+        for model_spec in model_specs
+        if model_spec.parameter_overrides
+    }
+    if parameter_overrides:
+        config_snapshot["model_parameter_overrides"] = parameter_overrides
+    if tuning_provenance is not None:
+        config_snapshot["tuning_provenance"] = tuning_provenance
+    return config_snapshot
 
 
 def _build_config_fingerprint(
@@ -637,12 +724,15 @@ def _build_config_fingerprint(
 def run_training(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
+    model_specs: list[TrainingModelSpec] | None = None,
+    tuning_provenance: dict[str, object] | None = None,
 ) -> Path:
     competition_slug = config.competition_slug
     task_type = config.task_type
     primary_metric = config.primary_metric
-    model_ids = config.model_ids
     positive_label = config.positive_label
+    resolved_model_specs = _resolve_training_model_specs(config=config, model_specs=model_specs)
+    configured_model_ids = [model_spec.model_id for model_spec in resolved_model_specs]
 
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
@@ -696,11 +786,11 @@ def run_training(
     run_diagnostics_df.to_csv(run_dir / "run_diagnostics.csv", index=False)
 
     model_results: list[ModelRunResult] = []
-    for configured_model_id in model_ids:
+    for model_spec in resolved_model_specs:
         model_result = _train_single_model(
             task_type=task_type,
             primary_metric=primary_metric,
-            model_id=configured_model_id,
+            model_spec=model_spec,
             x_train_raw=x_train_raw,
             x_test_raw=x_test_raw,
             y_train=y_train,
@@ -725,17 +815,18 @@ def run_training(
             f"std={model_result.cv_summary.metric_std:.6f}"
         )
 
-    model_results, best_model_result = _rank_model_results(model_results, model_ids)
+    model_results, best_model_result = _rank_model_results(model_results, configured_model_ids)
     model_summary_rows = _build_model_summary_rows(model_results)
     model_summary_df = pd.DataFrame(model_summary_rows)
     model_summary_df.to_csv(run_dir / "model_summary.csv", index=False)
 
     config_snapshot = _build_config_snapshot(
         config=config,
-        model_ids=model_ids,
+        model_specs=resolved_model_specs,
         positive_label=positive_label,
         id_column=id_column,
         label_column=label_column,
+        tuning_provenance=tuning_provenance,
     )
     config_fingerprint = _build_config_fingerprint(
         config_snapshot=config_snapshot,
@@ -766,6 +857,7 @@ def run_training(
         cv_n_splits=config.cv_n_splits,
         cv_shuffle=config.cv_shuffle,
         cv_random_state=config.cv_random_state,
+        tuning_provenance=tuning_provenance,
     )
     run_manifest = _build_run_manifest(run_context)
     run_manifest_json = json.dumps(_json_ready(run_manifest), indent=2)

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -1,0 +1,318 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import optuna
+import pandas as pd
+
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.cv import is_higher_better, resolve_positive_label
+from tabular_shenanigans.data import CompetitionDatasetContext
+from tabular_shenanigans.models import build_tuning_space, get_model_definition
+from tabular_shenanigans.preprocess import prepare_feature_frames
+from tabular_shenanigans.train import (
+    TrainingModelSpec,
+    _build_target_summary,
+    _evaluate_model_spec,
+    _materialize_split_indices,
+    _resolve_training_model_specs,
+    _json_ready,
+    run_training,
+)
+
+
+@dataclass(frozen=True)
+class TuningResult:
+    study_dir: Path
+    train_dir: Path
+
+
+def _make_study_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _build_study_config_snapshot(
+    config: AppConfig,
+    tuning_model_spec: TrainingModelSpec,
+    positive_label: object | None,
+    id_column: str,
+    label_column: str,
+) -> dict[str, object]:
+    resolved_training_model_specs = _resolve_training_model_specs(config=config)
+    return {
+        "competition_slug": config.competition_slug,
+        "task_type": config.task_type,
+        "primary_metric": config.primary_metric,
+        "model_ids": [model_spec.model_id for model_spec in resolved_training_model_specs],
+        "positive_label": positive_label,
+        "id_column": id_column,
+        "label_column": label_column,
+        "force_categorical": config.force_categorical,
+        "force_numeric": config.force_numeric,
+        "drop_columns": config.drop_columns,
+        "low_cardinality_int_threshold": config.low_cardinality_int_threshold,
+        "cv_n_splits": config.cv_n_splits,
+        "cv_shuffle": config.cv_shuffle,
+        "cv_random_state": config.cv_random_state,
+        "tuning": {
+            "enabled": True,
+            "model_id": tuning_model_spec.model_id,
+            "n_trials": config.tuning.n_trials if config.tuning is not None else None,
+            "timeout_seconds": config.tuning.timeout_seconds if config.tuning is not None else None,
+            "random_state": config.tuning.random_state if config.tuning is not None else None,
+        },
+    }
+
+
+def _build_trials_df(study: optuna.Study, metric_name: str) -> pd.DataFrame:
+    param_names = sorted({param_name for trial in study.trials for param_name in trial.params})
+    rows: list[dict[str, object]] = []
+    for trial in study.trials:
+        row = {
+            "trial_number": trial.number,
+            "state": trial.state.name,
+            "metric_name": metric_name,
+            "metric_value": trial.value,
+            "metric_std": trial.user_attrs.get("metric_std"),
+            "started_at_utc": trial.datetime_start.isoformat() if trial.datetime_start is not None else "",
+            "completed_at_utc": trial.datetime_complete.isoformat() if trial.datetime_complete is not None else "",
+            "duration_seconds": trial.duration.total_seconds() if trial.duration is not None else None,
+            "params_json": json.dumps(_json_ready(trial.params), sort_keys=True),
+            "model_params_json": json.dumps(_json_ready(trial.user_attrs.get("model_params")), sort_keys=True),
+        }
+        for param_name in param_names:
+            row[f"param_{param_name}"] = trial.params.get(param_name)
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _build_study_manifest(
+    config: AppConfig,
+    study: optuna.Study,
+    study_id: str,
+    study_config_snapshot: dict[str, object],
+    tuning_model_spec: TrainingModelSpec,
+    model_name: str,
+    preprocessing_scheme_id: str,
+    target_summary: dict[str, object],
+    train_dir: Path | None = None,
+) -> dict[str, object]:
+    best_trial = study.best_trial
+    return {
+        "study_id": study_id,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "competition_slug": config.competition_slug,
+        "task_type": config.task_type,
+        "primary_metric": config.primary_metric,
+        "optimization_direction": study.direction.name.lower(),
+        "config_snapshot": study_config_snapshot,
+        "model_id": tuning_model_spec.model_id,
+        "model_name": model_name,
+        "preprocessing_scheme_id": preprocessing_scheme_id,
+        "trial_count": len(study.trials),
+        "completed_trial_count": len([trial for trial in study.trials if trial.state == optuna.trial.TrialState.COMPLETE]),
+        "best_trial_number": best_trial.number,
+        "best_value": best_trial.value,
+        "best_params": best_trial.params,
+        "best_model_params": best_trial.user_attrs.get("model_params"),
+        "target_summary": target_summary,
+        "train_run_id": train_dir.name if train_dir is not None else None,
+        "train_run_dir": str(train_dir) if train_dir is not None else None,
+    }
+
+
+def _write_tuning_artifacts(
+    study_dir: Path,
+    study_manifest: dict[str, object],
+    trials_df: pd.DataFrame,
+) -> None:
+    best_params = study_manifest["best_params"]
+    study_summary = pd.DataFrame(
+        [
+            {
+                "study_id": study_manifest["study_id"],
+                "competition_slug": study_manifest["competition_slug"],
+                "task_type": study_manifest["task_type"],
+                "primary_metric": study_manifest["primary_metric"],
+                "optimization_direction": study_manifest["optimization_direction"],
+                "model_id": study_manifest["model_id"],
+                "model_name": study_manifest["model_name"],
+                "preprocessing_scheme_id": study_manifest["preprocessing_scheme_id"],
+                "trial_count": study_manifest["trial_count"],
+                "completed_trial_count": study_manifest["completed_trial_count"],
+                "best_trial_number": study_manifest["best_trial_number"],
+                "best_value": study_manifest["best_value"],
+                "train_run_id": study_manifest["train_run_id"],
+            }
+        ]
+    )
+    study_summary.to_csv(study_dir / "study_summary.csv", index=False)
+    trials_df.to_csv(study_dir / "trials.csv", index=False)
+    (study_dir / "best_params.json").write_text(
+        json.dumps(_json_ready(best_params), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    (study_dir / "study_manifest.json").write_text(
+        json.dumps(_json_ready(study_manifest), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def run_tuning(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+) -> TuningResult:
+    if config.tuning is None or not config.tuning.enabled:
+        raise ValueError("The tune stage requires tuning.enabled=true in config.yaml.")
+    if config.tuning.model_id is None:
+        raise ValueError("The tune stage requires tuning.model_id.")
+
+    task_type = config.task_type
+    primary_metric = config.primary_metric
+    tuning_model_spec = TrainingModelSpec(model_id=config.tuning.model_id)
+    model_definition = get_model_definition(task_type, tuning_model_spec.model_id)
+
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+
+    x_train_raw, x_test_raw, y_train = prepare_feature_frames(
+        train_df=train_df,
+        test_df=test_df,
+        id_column=id_column,
+        label_column=label_column,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
+    )
+
+    positive_label = config.positive_label
+    observed_label_pair = None
+    negative_label = None
+    if task_type == "binary":
+        negative_label, positive_label, observed_label_pair = resolve_positive_label(
+            y_values=y_train,
+            configured_positive_label=positive_label,
+        )
+
+    split_indices = _materialize_split_indices(
+        task_type=task_type,
+        x_train_raw=x_train_raw,
+        y_train=y_train,
+        n_splits=config.cv_n_splits,
+        shuffle=config.cv_shuffle,
+        random_state=config.cv_random_state,
+    )
+    target_summary = _build_target_summary(
+        task_type=task_type,
+        y_train=y_train,
+        positive_label=positive_label,
+        negative_label=negative_label,
+        observed_label_pair=observed_label_pair,
+    )
+
+    study_id = _make_study_id()
+    study_dir = Path("artifacts") / config.competition_slug / "tune" / study_id
+    study_dir.mkdir(parents=True, exist_ok=True)
+    study_config_snapshot = _build_study_config_snapshot(
+        config=config,
+        tuning_model_spec=tuning_model_spec,
+        positive_label=positive_label,
+        id_column=id_column,
+        label_column=label_column,
+    )
+
+    direction = "maximize" if is_higher_better(primary_metric) else "minimize"
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    sampler = optuna.samplers.TPESampler(seed=config.tuning.random_state)
+    study = optuna.create_study(direction=direction, sampler=sampler, study_name=study_id)
+
+    def objective(trial: optuna.Trial) -> float:
+        parameter_overrides = build_tuning_space(task_type, tuning_model_spec.model_id, trial)
+        evaluation_artifacts = _evaluate_model_spec(
+            task_type=task_type,
+            primary_metric=primary_metric,
+            model_spec=TrainingModelSpec(
+                model_id=tuning_model_spec.model_id,
+                parameter_overrides=parameter_overrides,
+            ),
+            x_train_raw=x_train_raw,
+            x_test_raw=x_test_raw,
+            y_train=y_train,
+            split_indices=split_indices,
+            force_categorical=config.force_categorical,
+            force_numeric=config.force_numeric,
+            low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+            cv_random_state=config.cv_random_state,
+            positive_label=positive_label,
+            negative_label=negative_label,
+        )
+        metric_mean = evaluation_artifacts.model_result.cv_summary.metric_mean
+        metric_std = evaluation_artifacts.model_result.cv_summary.metric_std
+        trial.set_user_attr("metric_std", metric_std)
+        trial.set_user_attr("model_params", _json_ready(evaluation_artifacts.model_result.model_params))
+        print(
+            f"Trial {trial.number}: {primary_metric}={metric_mean:.6f} "
+            f"(std={metric_std:.6f}) params={parameter_overrides}"
+        )
+        return metric_mean
+
+    study.optimize(
+        objective,
+        n_trials=config.tuning.n_trials,
+        timeout=config.tuning.timeout_seconds,
+        gc_after_trial=True,
+    )
+
+    trials_df = _build_trials_df(study=study, metric_name=primary_metric)
+    study_manifest = _build_study_manifest(
+        config=config,
+        study=study,
+        study_id=study_id,
+        study_config_snapshot=study_config_snapshot,
+        tuning_model_spec=tuning_model_spec,
+        model_name=model_definition.model_name,
+        preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
+        target_summary=target_summary,
+    )
+    _write_tuning_artifacts(study_dir=study_dir, study_manifest=study_manifest, trials_df=trials_df)
+
+    best_parameter_overrides = dict(study.best_trial.params)
+    tuning_provenance = {
+        "study_id": study_id,
+        "study_dir": str(study_dir),
+        "trial_number": study.best_trial.number,
+        "base_model_id": tuning_model_spec.model_id,
+        "parameter_overrides": best_parameter_overrides,
+    }
+    train_dir = run_training(
+        config=config,
+        dataset_context=dataset_context,
+        model_specs=[
+            TrainingModelSpec(
+                model_id=tuning_model_spec.model_id,
+                parameter_overrides=best_parameter_overrides,
+            )
+        ],
+        tuning_provenance=tuning_provenance,
+    )
+
+    updated_study_manifest = _build_study_manifest(
+        config=config,
+        study=study,
+        study_id=study_id,
+        study_config_snapshot=study_config_snapshot,
+        tuning_model_spec=tuning_model_spec,
+        model_name=model_definition.model_name,
+        preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
+        target_summary=target_summary,
+        train_dir=train_dir,
+    )
+    _write_tuning_artifacts(study_dir=study_dir, study_manifest=updated_study_manifest, trials_df=trials_df)
+    print(
+        f"Tuning complete: best_trial={study.best_trial.number}, "
+        f"best_{primary_metric}={study.best_value:.6f}, train_run={train_dir.name}"
+    )
+    return TuningResult(study_dir=study_dir, train_dir=train_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,20 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -113,6 +127,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
 ]
 
 [[package]]
@@ -219,6 +245,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
 ]
 
 [[package]]
@@ -349,6 +409,70 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -461,6 +585,24 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/cc/f48875411d1f176bce58e6343fd5d4131fc1db5420719ff25944bdc006c6/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:0cf032ee22b560447daf0456108a75e32bd74a4de6c6b64725637a359fa48cd8", size = 293563644, upload-time = "2026-03-03T05:34:46.166Z" },
     { url = "https://files.pythonhosted.org/packages/31/1e/9e366f36efc550f07d6737f199e3f6bffafdf28795d007f10a77dd274f5c/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:ecd0a012051abc20c1aa87328841efa8cade3ced65803046e38c2f03c0891fea", size = 293633942, upload-time = "2026-03-03T05:37:05.625Z" },
+]
+
+[[package]]
+name = "optuna"
+version = "4.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "colorlog" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/b2/b5e12de7b4486556fe2257611b55dbabf30d0300bdb031831aa943ad20e4/optuna-4.7.0.tar.gz", hash = "sha256:d91817e2079825557bd2e97de2e8c9ae260bfc99b32712502aef8a5095b2d2c0", size = 479740, upload-time = "2026-01-19T05:45:52.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/d1/6c8a4fbb38a9e3565f5c36b871262a85ecab3da48120af036b1e4937a15c/optuna-4.7.0-py3-none-any.whl", hash = "sha256:e41ec84018cecc10eabf28143573b1f0bde0ba56dba8151631a590ecbebc1186", size = 413894, upload-time = "2026-01-19T05:45:50.815Z" },
 ]
 
 [[package]]
@@ -853,11 +995,51 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/73/b4a9737255583b5fa858e0bb8e116eb94b88c910164ed2ed719147bde3de/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7", size = 9886075, upload-time = "2026-03-02T15:28:51.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c6/569dc8bf3cd375abc5907e82235923e986799f301cd79a903f784b996fca/sqlalchemy-2.0.48-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e3070c03701037aa418b55d36532ecb8f8446ed0135acb71c678dbdf12f5b6e4", size = 2152599, upload-time = "2026-03-02T15:49:14.41Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/f4e04a4bd5a24304f38cb0d4aa2ad4c0fb34999f8b884c656535e1b2b74c/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2645b7d8a738763b664a12a1542c89c940daa55196e8d73e55b169cc5c99f65f", size = 3278825, upload-time = "2026-03-02T15:50:38.269Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed", size = 3295200, upload-time = "2026-03-02T15:53:29.366Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/1609a4442aefd750ea2f32629559394ec92e89ac1d621a7f462b70f736ff/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b193a7e29fd9fa56e502920dca47dffe60f97c863494946bd698c6058a55658", size = 3226876, upload-time = "2026-03-02T15:50:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/6ae2ab5ea2fa989fbac4e674de01224b7a9d744becaf59bb967d62e99bed/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36ac4ddc3d33e852da9cb00ffb08cea62ca05c39711dc67062ca2bb1fae35fd8", size = 3265045, upload-time = "2026-03-02T15:53:31.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/82/ea4665d1bb98c50c19666e672f21b81356bd6077c4574e3d2bbb84541f53/sqlalchemy-2.0.48-cp313-cp313-win32.whl", hash = "sha256:389b984139278f97757ea9b08993e7b9d1142912e046ab7d82b3fbaeb0209131", size = 2113700, upload-time = "2026-03-02T15:54:35.825Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2b/b9040bec58c58225f073f5b0c1870defe1940835549dafec680cbd58c3c3/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl", hash = "sha256:d612c976cbc2d17edfcc4c006874b764e85e990c29ce9bd411f926bbfb02b9a2", size = 2139487, upload-time = "2026-03-02T15:54:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/7b17bd50244b78a49d22cc63c969d71dc4de54567dc152a9b46f6fae40ce/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f5bc24904d3bc3640961cddd2523e361257ef68585d6e364166dfbe8c78fae", size = 3558851, upload-time = "2026-03-02T15:57:48.607Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0d/213668e9aca61d370f7d2a6449ea4ec699747fac67d4bda1bb3d129025be/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb", size = 3525525, upload-time = "2026-03-02T16:04:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d7/a84edf412979e7d59c69b89a5871f90a49228360594680e667cb2c46a828/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1ccd42229aaac2df431562117ac7e667d702e8e44afdb6cf0e50fa3f18160f0b", size = 3466611, upload-time = "2026-03-02T15:57:50.759Z" },
+    { url = "https://files.pythonhosted.org/packages/86/55/42404ce5770f6be26a2b0607e7866c31b9a4176c819e9a7a5e0a055770be/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f0dcbc588cd5b725162c076eb9119342f6579c7f7f55057bb7e3c6ff27e13121", size = 3475812, upload-time = "2026-03-02T16:04:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/29b87775fadc43e627cf582fe3bda4d02e300f6b8f2747c764950d13784c/sqlalchemy-2.0.48-cp313-cp313t-win32.whl", hash = "sha256:9764014ef5e58aab76220c5664abb5d47d5bc858d9debf821e55cfdd0f128485", size = 2141335, upload-time = "2026-03-02T15:52:51.518Z" },
+    { url = "https://files.pythonhosted.org/packages/91/44/f39d063c90f2443e5b46ec4819abd3d8de653893aae92df42a5c4f5843de/sqlalchemy-2.0.48-cp313-cp313t-win_amd64.whl", hash = "sha256:e2f35b4cccd9ed286ad62e0a3c3ac21e06c02abc60e20aa51a3e305a30f5fa79", size = 2173095, upload-time = "2026-03-02T15:52:52.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b3/f437eaa1cf028bb3c927172c7272366393e73ccd104dcf5b6963f4ab5318/sqlalchemy-2.0.48-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e2d0d88686e3d35a76f3e15a34e8c12d73fc94c1dea1cd55782e695cc14086dd", size = 2154401, upload-time = "2026-03-02T15:49:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1c/b3abdf0f402aa3f60f0df6ea53d92a162b458fca2321d8f1f00278506402/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49b7bddc1eebf011ea5ab722fdbe67a401caa34a350d278cc7733c0e88fecb1f", size = 3274528, upload-time = "2026-03-02T15:50:41.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5e/327428a034407651a048f5e624361adf3f9fbac9d0fa98e981e9c6ff2f5e/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:426c5ca86415d9b8945c7073597e10de9644802e2ff502b8e1f11a7a2642856b", size = 3279523, upload-time = "2026-03-02T15:53:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ca/ece73c81a918add0965b76b868b7b5359e068380b90ef1656ee995940c02/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:288937433bd44e3990e7da2402fabc44a3c6c25d3704da066b85b89a85474ae0", size = 3224312, upload-time = "2026-03-02T15:50:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/fbaf1ae91fa4ee43f4fe79661cead6358644824419c26adb004941bdce7c/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8183dc57ae7d9edc1346e007e840a9f3d6aa7b7f165203a99e16f447150140d2", size = 3246304, upload-time = "2026-03-02T15:53:34.937Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5fb0deb13930b4f2f698c5541ae076c18981173e27dd00376dbaea7a9c82/sqlalchemy-2.0.48-cp314-cp314-win32.whl", hash = "sha256:1182437cb2d97988cfea04cf6cdc0b0bb9c74f4d56ec3d08b81e23d621a28cc6", size = 2116565, upload-time = "2026-03-02T15:54:38.321Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7e/e83615cb63f80047f18e61e31e8e32257d39458426c23006deeaf48f463b/sqlalchemy-2.0.48-cp314-cp314-win_amd64.whl", hash = "sha256:144921da96c08feb9e2b052c5c5c1d0d151a292c6135623c6b2c041f2a45f9e0", size = 2142205, upload-time = "2026-03-02T15:54:39.831Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e3/69d8711b3f2c5135e9cde5f063bc1605860f0b2c53086d40c04017eb1f77/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aee45fd2c6c0f2b9cdddf48c48535e7471e42d6fb81adfde801da0bd5b93241", size = 3563519, upload-time = "2026-03-02T15:57:52.387Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4f/a7cce98facca73c149ea4578981594aaa5fd841e956834931de503359336/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cddca31edf8b0653090cbb54562ca027c421c58ddde2c0685f49ff56a1690e0", size = 3528611, upload-time = "2026-03-02T16:04:42.097Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7d/5936c7a03a0b0cb0fa0cc425998821c6029756b0855a8f7ee70fba1de955/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7a936f1bb23d370b7c8cc079d5fce4c7d18da87a33c6744e51a93b0f9e97e9b3", size = 3472326, upload-time = "2026-03-02T15:57:54.423Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/33/cea7dfc31b52904efe3dcdc169eb4514078887dff1f5ae28a7f4c5d54b3c/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e004aa9248e8cb0a5f9b96d003ca7c1c0a5da8decd1066e7b53f59eb8ce7c62b", size = 3478453, upload-time = "2026-03-02T16:04:44.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/32107c4d13be077a9cae61e9ae49966a35dc4bf442a8852dd871db31f62e/sqlalchemy-2.0.48-cp314-cp314t-win32.whl", hash = "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f", size = 2147209, upload-time = "2026-03-02T15:52:54.274Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d7/1e073da7a4bc645eb83c76067284a0374e643bc4be57f14cc6414656f92c/sqlalchemy-2.0.48-cp314-cp314t-win_amd64.whl", hash = "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933", size = 2182198, upload-time = "2026-03-02T15:52:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
+]
+
+[[package]]
 name = "tabularshenanigans"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "kaggle" },
+    { name = "optuna" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -876,6 +1058,7 @@ requires-dist = [
     { name = "catboost", marker = "extra == 'boosters'", specifier = ">=1.2.10" },
     { name = "kaggle", specifier = ">=2.0.0" },
     { name = "lightgbm", marker = "extra == 'boosters'", specifier = ">=4.6.0" },
+    { name = "optuna", specifier = ">=4.7.0" },
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic" },
     { name = "pyyaml" },


### PR DESCRIPTION
Closes #38

## Summary
- add a first-class `tune` stage and validated `tuning` config block
- add code-owned Optuna search spaces for `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, and `ordinal_hgb`
- write tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`
- retrain the best trial into the standard train artifact layout and record `tuning_provenance` in `run_manifest.json`
- document the tuning workflow in the README, technical guide, and example configs

## Verification
- `PYTHONPATH=src uv run python -m compileall main.py src`
- validated config errors for missing tuning stopping conditions and unsupported `tuning.model_id`
- manual smoke run on `playground-series-s6e3` with `task_type: binary`, `primary_metric: roc_auc`, `tuning.model_id: ordinal_hgb`, `cv_n_splits: 2`, `n_trials: 1`
- manual smoke run on `playground-series-s5e10` with `task_type: regression`, `primary_metric: mse`, `tuning.model_id: ordinal_hgb`, `cv_n_splits: 2`, `n_trials: 1`
- manual smoke run on `smoke-binary-canonical` with `task_type: binary`, `primary_metric: roc_auc`, `tuning.model_id: onehot_logreg`, `cv_n_splits: 2`, `n_trials: 1`
