### PR TITLE
Add booster tuning search spaces (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Manual verification for each target:
 
 Manual verification for tuning:
 - run `uv run python main.py tune` with `tuning.enabled: true`, one supported `tuning.model_id`, and at least one stopping condition
+- supported tunable `model_id`s are:
+  - binary: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
+  - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
 - confirm `artifacts/<competition_slug>/tune/<study_id>/study_manifest.json` is written
 - confirm `artifacts/<competition_slug>/tune/<study_id>/trials.csv` records trial state, score, and params
 - confirm `artifacts/<competition_slug>/train/<run_id>/run_manifest.json` records `tuning_provenance`

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -39,7 +39,7 @@ model_ids:
 # tune uses tuning.model_id only; normal train still uses top-level model_ids.
 # tuning:
 #   enabled: true
-#   model_id: ordinal_hgb
+#   model_id: ordinal_lightgbm
 #   n_trials: 25
 #   # timeout_seconds: 3600
 #   random_state: 42

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -36,7 +36,7 @@ model_ids:
 # tune uses tuning.model_id only; normal train still uses top-level model_ids.
 # tuning:
 #   enabled: true
-#   model_id: ordinal_hgb
+#   model_id: ordinal_lightgbm
 #   n_trials: 25
 #   # timeout_seconds: 3600
 #   random_state: 42

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -161,6 +161,9 @@ Manual verification steps for each target:
 - `model_ids` must contain one or more canonical supported presets for the configured task; if omitted, the task default is used
 - the `tune` stage requires `tuning.enabled=true`, uses `tuning.model_id` only, and retrains exactly one tuned candidate into the normal train artifact layout
 - `tuning.model_id` must be one of the supported tunable model recipes for the configured task
+- supported tunable recipes are:
+  - binary: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
+  - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
 - tuning must have at least one stopping condition: `tuning.n_trials` or `tuning.timeout_seconds`
 - Submit-time `model_id` remains the trained-model selector for choosing one artifact from a run
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -365,6 +365,46 @@ def _build_logreg_tuning_space(trial: object) -> dict[str, object]:
     }
 
 
+def _build_lightgbm_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "colsample_bytree": trial.suggest_float("colsample_bytree", 0.5, 1.0),
+        "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.2, log=True),
+        "max_depth": trial.suggest_int("max_depth", 3, 12),
+        "min_child_samples": trial.suggest_int("min_child_samples", 10, 100),
+        "n_estimators": trial.suggest_int("n_estimators", 200, 1200, step=100),
+        "num_leaves": trial.suggest_int("num_leaves", 16, 255),
+        "reg_alpha": trial.suggest_float("reg_alpha", 1e-10, 10.0, log=True),
+        "reg_lambda": trial.suggest_float("reg_lambda", 1e-10, 10.0, log=True),
+        "subsample": trial.suggest_float("subsample", 0.5, 1.0),
+    }
+
+
+def _build_xgboost_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "colsample_bytree": trial.suggest_float("colsample_bytree", 0.5, 1.0),
+        "gamma": trial.suggest_float("gamma", 1e-10, 10.0, log=True),
+        "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.2, log=True),
+        "max_depth": trial.suggest_int("max_depth", 3, 12),
+        "min_child_weight": trial.suggest_float("min_child_weight", 1.0, 20.0),
+        "n_estimators": trial.suggest_int("n_estimators", 200, 1200, step=100),
+        "reg_alpha": trial.suggest_float("reg_alpha", 1e-10, 10.0, log=True),
+        "reg_lambda": trial.suggest_float("reg_lambda", 1e-10, 10.0, log=True),
+        "subsample": trial.suggest_float("subsample", 0.5, 1.0),
+    }
+
+
+def _build_catboost_tuning_space(trial: object) -> dict[str, object]:
+    return {
+        "bagging_temperature": trial.suggest_float("bagging_temperature", 0.0, 10.0),
+        "border_count": trial.suggest_int("border_count", 32, 255),
+        "depth": trial.suggest_int("depth", 4, 10),
+        "iterations": trial.suggest_int("iterations", 200, 1200, step=100),
+        "l2_leaf_reg": trial.suggest_float("l2_leaf_reg", 1.0, 20.0, log=True),
+        "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.2, log=True),
+        "random_strength": trial.suggest_float("random_strength", 1e-10, 10.0, log=True),
+    }
+
+
 def _build_catboost_fit_kwargs(
     x_train_processed: object,
     numeric_columns: list[str],
@@ -422,6 +462,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LGBMRegressor",
             preprocessing_scheme_id="ordinal",
             builder=_build_lightgbm_regressor,
+            tuning_space_builder=_build_lightgbm_tuning_space,
         ),
         "native_catboost": ModelDefinition(
             model_id="native_catboost",
@@ -429,12 +470,14 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             preprocessing_scheme_id="native",
             builder=_build_catboost_regressor,
             fit_kwargs_builder=_build_catboost_fit_kwargs,
+            tuning_space_builder=_build_catboost_tuning_space,
         ),
         "ordinal_xgboost": ModelDefinition(
             model_id="ordinal_xgboost",
             model_name="XGBRegressor",
             preprocessing_scheme_id="ordinal",
             builder=_build_xgboost_regressor,
+            tuning_space_builder=_build_xgboost_tuning_space,
         ),
     },
     "binary": {
@@ -471,6 +514,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LGBMClassifier",
             preprocessing_scheme_id="ordinal",
             builder=_build_lightgbm_classifier,
+            tuning_space_builder=_build_lightgbm_tuning_space,
         ),
         "native_catboost": ModelDefinition(
             model_id="native_catboost",
@@ -478,12 +522,14 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             preprocessing_scheme_id="native",
             builder=_build_catboost_classifier,
             fit_kwargs_builder=_build_catboost_fit_kwargs,
+            tuning_space_builder=_build_catboost_tuning_space,
         ),
         "ordinal_xgboost": ModelDefinition(
             model_id="ordinal_xgboost",
             model_name="XGBClassifier",
             preprocessing_scheme_id="ordinal",
             builder=_build_xgboost_classifier,
+            tuning_space_builder=_build_xgboost_tuning_space,
         ),
     },
 }


### PR DESCRIPTION
Closes #63

## Summary
- add Optuna tuning support for `ordinal_lightgbm`, `ordinal_xgboost`, and `native_catboost`
- expose the new tunable model IDs through the existing config validation path
- update the docs and example configs to reflect the expanded tuning surface

## Manual Verification
- `./.venv/bin/python -m compileall main.py src`
- binary smoke tune: `playground-series-s6e3` with `tuning.model_id: ordinal_lightgbm`, `cv_n_splits: 2`, `n_trials: 1`
- regression smoke tune: `playground-series-s5e10` with `tuning.model_id: ordinal_xgboost`, `cv_n_splits: 2`, `n_trials: 1`
- binary smoke tune: `playground-series-s6e3` with `tuning.model_id: native_catboost`, `cv_n_splits: 2`, `n_trials: 1`
- confirmed each study wrote `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json` and retrained a best-trial run with `tuning_provenance`