### PR TITLE
Restructure config around competition and experiment sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Load and validate a single local repository-root `config.yaml`.
 - Fetch Kaggle competition data into `data/<competition_slug>/` when the zip is missing.
 - Require explicit `task_type` and `primary_metric` in config.
-- Select one or more baseline or booster model recipes per run from config via canonical `model_ids`.
+- Separate stable competition settings from the current experiment candidate in config via top-level `competition` and `experiment` sections.
 - Ship tracked binary and regression example configs that can be copied into the local runtime config.
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
@@ -26,11 +26,8 @@ The repository is developed and manually verified primarily against these Playgr
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Run stage-specific CLI entrypoints for `fetch`, `eda`, `preprocess`, `train`, and submit-only flows against explicit run artifacts.
-- Run an explicit `tune` stage that evaluates Optuna trials for one configured model recipe, writes study artifacts, and retrains the best trial into the standard training artifact layout.
-- Train one or more cross-validated model recipes with fold-local, model-specific preprocessing:
-  - `onehot` preprocessing: `onehot_ridge`, `onehot_elasticnet`, `onehot_logreg`
-  - `ordinal` preprocessing: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `ordinal_xgboost`
-  - `native` preprocessing: `native_catboost`
+- Run an explicit `tune` stage that evaluates Optuna trials for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes study artifacts, and retrains the best trial into the standard training artifact layout.
+- Train one cross-validated model candidate at a time using config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
 - Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
 - Write tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, including `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
@@ -57,7 +54,7 @@ cp config.regression.example.yaml config.yaml
 
 `config.yaml` is the only runtime config source. It is intentionally ignored by Git so you can keep local competition-specific settings without committing them.
 
-The current pipeline fetches competition data if needed, runs config-aware EDA, trains one or more CV model recipes with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
+The current pipeline fetches competition data if needed, runs config-aware EDA, trains the current experiment candidate with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
 
 ## Stage Commands
 `uv run python main.py` still runs the full default pipeline: fetch, EDA, train, and submit.
@@ -76,7 +73,7 @@ Stage behavior:
 - `eda`: fetches if needed, then writes EDA report CSVs
 - `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
 - `train`: fetches if needed, then trains and writes normal training artifacts
-- `tune`: fetches if needed, runs an Optuna study for `tuning.model_id`, writes tuning artifacts, then retrains the best trial into the normal training artifact layout
+- `tune`: fetches if needed, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts, then retrains the best trial into the normal training artifact layout
 - `submit`: requires an explicit existing run selection and never retrains implicitly
 
 The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
@@ -97,50 +94,58 @@ Runtime config workflow:
 - edit only `config.yaml` for local runs
 - keep `config.yaml` untracked; the application does not read the example files directly
 
-Required keys:
-- `competition_slug`
+The flat config layout is no longer supported. `config.yaml` must now contain top-level `competition` and `experiment` sections.
+
+Required top-level sections:
+- `competition`
+- `experiment`
+
+`competition` keys:
+- `slug`
 - `task_type`: `regression` or `binary`
 - `primary_metric`: one of `rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`
+- optional `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
+- optional schema overrides:
+  - `id_column`
+  - `label_column`
+- `cv`:
+  - `n_splits` (default `7`)
+  - `shuffle` (default `true`)
+  - `random_state` (default `42`)
+- optional `features` block:
+  - `force_categorical`
+  - `force_numeric`
+  - `drop_columns`
+  - `low_cardinality_int_threshold`
 
-Optional binary-classification key:
-- `positive_label`: explicit positive class for binary competitions; required unless the observed training labels follow one of the documented safe conventions: `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
+`experiment` keys:
+- `name`
+- optional `notes`
+- required `candidate` block
+- optional `submit` block
 
-Optional model-selection key:
-- `model_ids`: ordered list of canonical baseline model recipes for the configured task
-  - regression: `onehot_ridge`, `onehot_elasticnet` (default), `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-  - binary classification: `onehot_logreg` (default), `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
+Current `experiment.candidate` contract:
+- `candidate_type`: currently only `model` is supported
+- `candidate_id`
+- `preprocessor`: `onehot`, `ordinal`, or `native`
+- `model_family`
+  - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+  - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+- optional `model_params`
+- optional `optimization`:
+  - `enabled`
+  - `method`: currently only `optuna`
+  - `n_trials`
+  - `timeout_seconds`
+  - `random_state`
 
-Optional submission schema keys:
-- `id_column`: override for the inferred identifier column; the resolved ID column is excluded from modeled features by default
-- `label_column`: override for the inferred submission/target column
+Supported `model_family + preprocessor` combinations:
+- regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
+- binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
 
-Optional preprocessing keys:
-- `force_categorical`: list of feature names to force into the categorical pipeline
-- `force_numeric`: list of feature names to force into the numeric pipeline
-- `drop_columns`: additional feature names to remove before preprocessing after the ID column is already excluded by default
-- `low_cardinality_int_threshold`: integer columns at or below this unique-count threshold are treated as categorical by default
-
-Model preprocessing notes:
-- `native_catboost` preserves a pandas feature frame and uses CatBoost native categorical handling.
-- `ordinal_lightgbm` and `ordinal_xgboost` reuse the repository ordinal categorical path.
-
-Optional CV keys:
-- `cv_n_splits`: number of CV folds (default `7`)
-- `cv_shuffle`: whether to shuffle before splitting (default `true`)
-- `cv_random_state`: random seed for deterministic folds (default `42`)
-
-Optional tuning block:
-- `tuning.enabled`: enables the `tune` stage for the current config (default `false`)
-- `tuning.model_id`: one canonical tunable model recipe for the configured task
-  - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
-  - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
-- `tuning.n_trials`: optional Optuna trial limit
-- `tuning.timeout_seconds`: optional wall-clock limit
-- `tuning.random_state`: Optuna sampler seed (default `42`)
-
-Optional submission keys:
-- `submit_enabled`: if `true`, submit to Kaggle after training (default `false`)
-- `submit_message_prefix`: optional prefix used in auto-generated submission messages
+Current `experiment.submit` keys:
+- `enabled`: if `true`, submit to Kaggle after training (default `false`)
+- `message_prefix`: optional prefix used in auto-generated submission messages
 
 Binary prediction artifact contract:
 - `roc_auc` and `log_loss`: `test_predictions.csv` and `submission.csv` contain positive-class probabilities in `[0, 1]`
@@ -148,9 +153,9 @@ Binary prediction artifact contract:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-`model_ids` is the config-driven model-selection interface. If `model_ids` is omitted, the workflow selects the current default recipe for the configured task: `onehot_elasticnet` for regression and `onehot_logreg` for binary classification. For a single-model run, use a one-entry `model_ids` list. Config-time model selection accepts canonical preprocessing-first recipe IDs only. Submit-time `--model-id` still selects one trained model artifact from an existing run.
+The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id` so the existing train, tune, and submit paths can continue working during the transition to the broader candidate-centric workflow.
 
-`tune` uses `tuning.model_id` only. It does not reuse the top-level `model_ids` list for trial evaluation. After the study completes, the best trial is retrained as a single-model normal training run and the resulting `run_manifest.json` records `tuning_provenance`.
+`tune` uses the current experiment candidate only. When `experiment.candidate.optimization.enabled=true`, the tune stage evaluates that candidate, writes study artifacts, and retrains the best trial into the normal single-model training artifact layout.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -169,15 +174,15 @@ Manual verification for each target:
 - confirm the competition archive includes `train.csv`, `test.csv`, and `sample_submission.csv`
 - confirm the pipeline infers `id_column` and `label_column` without overrides
 - confirm `artifacts/<competition_slug>/train/<run_id>/model_summary.csv` is written
-- confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv` is written for each selected model
+- confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv` is written for the resolved internal model artifact
 - confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order, for the submitted model
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
 Manual verification for tuning:
-- run `uv run python main.py tune` with `tuning.enabled: true`, one supported `tuning.model_id`, and at least one stopping condition
-- supported tunable `model_id`s are:
-  - binary: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-  - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
+- run `uv run python main.py tune` with `experiment.candidate.optimization.enabled: true` and at least one stopping condition
+- supported tunable combinations are:
+  - binary: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
+  - regression: `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
 - confirm `artifacts/<competition_slug>/tune/<study_id>/study_manifest.json` is written
 - confirm `artifacts/<competition_slug>/tune/<study_id>/trials.csv` records trial state, score, and params
 - confirm `artifacts/<competition_slug>/train/<run_id>/run_manifest.json` records `tuning_provenance`
@@ -203,8 +208,9 @@ Manual verification for tuning:
 - Competition zip contents include `train.csv`, `test.csv`, and `sample_submission.csv`.
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
-- Configured `model_ids` must use canonical preprocessing-aware training recipe IDs; run artifacts record the canonical `model_id` and `preprocessing_scheme_id`.
-- The `tune` stage uses `tuning.model_id` only, and the tuned best-trial retrain writes a standard single-model train artifact with `tuning_provenance`.
+- `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
+- The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; run artifacts still record that resolved `model_id` and `preprocessing_scheme_id`.
+- The `tune` stage uses the current experiment candidate only, and the tuned best-trial retrain writes a standard single-model train artifact with `tuning_provenance`.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -1,48 +1,58 @@
 # Copy to repository-root config.yaml before running:
 # cp config.binary.example.yaml config.yaml
-competition_slug: playground-series-s5e12
-task_type: binary
-primary_metric: roc_auc
+competition:
+  slug: playground-series-s5e12
+  task_type: binary
+  primary_metric: roc_auc
 
-# Use canonical model_ids. For a single-model smoke test, keep a one-entry list.
-model_ids:
-  - onehot_logreg
-  - ordinal_lightgbm
-  - native_catboost
-  - ordinal_xgboost
-# model_ids:
-#   - ordinal_lightgbm
+  # Set this when labels are not one of the auto-resolved safe pairs:
+  # [0, 1], [False, True], or ["No", "Yes"].
+  # positive_label: "Yes"
 
-# Set this when labels are not one of the auto-resolved safe pairs:
-# [0, 1], [False, True], or ["No", "Yes"].
-# positive_label: "Yes"
+  # Optional schema overrides when inference is ambiguous or the competition is not Playground-shaped.
+  # id_column: id
+  # label_column: target
 
-# Optional schema overrides when inference is ambiguous or the competition is not Playground-shaped.
-# id_column: id
-# label_column: target
+  cv:
+    n_splits: 7
+    shuffle: true
+    random_state: 42
 
-# Optional feature-typing overrides.
-# force_categorical:
-#   - some_integer_flag
-# force_numeric:
-#   - some_count_feature
-# drop_columns:
-#   - some_leaky_column
-# low_cardinality_int_threshold: 20
+  # Optional feature-typing overrides:
+  # features:
+  #   force_categorical:
+  #     - some_integer_flag
+  #   force_numeric:
+  #     - some_count_feature
+  #   drop_columns:
+  #     - some_leaky_column
+  #   low_cardinality_int_threshold: 20
 
-# Optional CV settings.
-# cv_n_splits: 7
-# cv_shuffle: true
-# cv_random_state: 42
+experiment:
+  name: baseline-logreg
+  notes: onehot logistic-regression baseline for the default binary smoke test
 
-# Optional Optuna tuning settings for `uv run python main.py tune`.
-# tune uses tuning.model_id only; normal train still uses top-level model_ids.
-# tuning:
-#   enabled: true
-#   model_id: ordinal_lightgbm
-#   n_trials: 25
-#   # timeout_seconds: 3600
-#   random_state: 42
+  candidate:
+    candidate_type: model
+    candidate_id: baseline_logreg_v1
+    preprocessor: onehot
+    model_family: logistic_regression
+    model_params: {}
 
-submit_enabled: false
-# submit_message_prefix: s5e12-baseline
+    # Alternative binary model candidates:
+    # preprocessor: ordinal
+    # model_family: lightgbm
+    # preprocessor: native
+    # model_family: catboost
+
+    # Optional tuning settings for `uv run python main.py tune`.
+    optimization:
+      enabled: false
+      # method: optuna
+      # n_trials: 25
+      # timeout_seconds: 3600
+      # random_state: 42
+
+  submit:
+    enabled: false
+    # message_prefix: s5e12-baseline

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -1,45 +1,54 @@
 # Copy to repository-root config.yaml before running:
 # cp config.regression.example.yaml config.yaml
-competition_slug: playground-series-s5e10
-task_type: regression
-primary_metric: mse
+competition:
+  slug: playground-series-s5e10
+  task_type: regression
+  primary_metric: mse
 
-# Use canonical model_ids. For a single-model smoke test, keep a one-entry list.
-model_ids:
-  - onehot_ridge
-  - onehot_elasticnet
-  - ordinal_lightgbm
-  - native_catboost
-  - ordinal_xgboost
-# model_ids:
-#   - onehot_elasticnet
+  # Optional schema overrides when inference is ambiguous or the competition is not Playground-shaped.
+  # id_column: id
+  # label_column: target
 
-# Optional schema overrides when inference is ambiguous or the competition is not Playground-shaped.
-# id_column: id
-# label_column: target
+  cv:
+    n_splits: 7
+    shuffle: true
+    random_state: 42
 
-# Optional feature-typing overrides.
-# force_categorical:
-#   - some_integer_flag
-# force_numeric:
-#   - some_count_feature
-# drop_columns:
-#   - some_leaky_column
-# low_cardinality_int_threshold: 20
+  # Optional feature-typing overrides:
+  # features:
+  #   force_categorical:
+  #     - some_integer_flag
+  #   force_numeric:
+  #     - some_count_feature
+  #   drop_columns:
+  #     - some_leaky_column
+  #   low_cardinality_int_threshold: 20
 
-# Optional CV settings.
-# cv_n_splits: 7
-# cv_shuffle: true
-# cv_random_state: 42
+experiment:
+  name: baseline-elasticnet
+  notes: onehot elastic-net baseline for the default regression smoke test
 
-# Optional Optuna tuning settings for `uv run python main.py tune`.
-# tune uses tuning.model_id only; normal train still uses top-level model_ids.
-# tuning:
-#   enabled: true
-#   model_id: ordinal_lightgbm
-#   n_trials: 25
-#   # timeout_seconds: 3600
-#   random_state: 42
+  candidate:
+    candidate_type: model
+    candidate_id: baseline_elasticnet_v1
+    preprocessor: onehot
+    model_family: elasticnet
+    model_params: {}
 
-submit_enabled: false
-# submit_message_prefix: s5e10-baseline
+    # Alternative regression model candidates:
+    # preprocessor: ordinal
+    # model_family: lightgbm
+    # preprocessor: native
+    # model_family: catboost
+
+    # Optional tuning settings for `uv run python main.py tune`.
+    optimization:
+      enabled: false
+      # method: optuna
+      # n_trials: 25
+      # timeout_seconds: 3600
+      # random_state: 42
+
+  submit:
+    enabled: false
+    # message_prefix: s5e10-baseline

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -15,14 +15,14 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
    - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
    - `ordinal`: numeric median imputation; categorical most-frequent imputation + `OrdinalEncoder`
    - `native`: numeric median imputation inside a pandas frame; categorical missing-value fill with native categorical columns preserved for CatBoost
-8. Train the configured baseline model or models from the resolved `model_ids` list:
-   - regression: `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-   - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
+8. Resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
+   - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
+   - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
 9. Write run-level diagnostics, `model_summary.csv`, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
 10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
 11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
-When the explicit `tune` stage is selected, the workflow additionally runs an Optuna study for one configured `tuning.model_id`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard train artifact layout with `tuning_provenance` recorded in `run_manifest.json`.
+When the explicit `tune` stage is selected, the workflow additionally runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard train artifact layout with `tuning_provenance` recorded in `run_manifest.json`.
 
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `eda` -> `train` -> `submit`)
@@ -30,7 +30,7 @@ When the explicit `tune` stage is selected, the workflow additionally runs an Op
 - `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
 - `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
 - `uv run python main.py train`: fetch if needed, load the shared dataset context, and write training artifacts
-- `uv run python main.py tune`: fetch if needed, load the shared dataset context, run an Optuna study for `tuning.model_id`, write tuning artifacts, and retrain the best trial into normal training artifacts
+- `uv run python main.py tune`: fetch if needed, load the shared dataset context, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into normal training artifacts
 - `uv run python main.py submit --run-dir artifacts/.../train/<run_id>`: prepare or submit from an explicit existing run artifact
 - `uv run python main.py submit --run-id <run_id>`: resolve the run under `artifacts/<competition_slug>/train/<run_id>` using the configured competition slug
 
@@ -40,14 +40,14 @@ The default `submit` path supports current manifest-backed run artifacts only. U
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, EDA, preprocess diagnostics, training, tuning, and submission.
-- `src/tabular_shenanigans/config.py`: Pydantic-backed config schema, metric normalization, and runtime contract validation.
+- `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
-- `src/tabular_shenanigans/models.py`: model-recipe registry, canonical model-id validation, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
+- `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: config-selected multi-model training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
-- `src/tabular_shenanigans/tune.py`: Optuna study execution, study artifact writing, and best-trial retraining into the standard train artifact layout.
+- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
+- `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate, study artifact writing, and best-trial retraining into the standard train artifact layout.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
@@ -55,39 +55,48 @@ Input:
 - One local runtime config file: `config.yaml` (single source of truth)
 - Tracked example configs: `config.binary.example.yaml` and `config.regression.example.yaml`
 - Expected workflow: copy one example file to `config.yaml`, then edit `config.yaml` for the local run
-- Required keys:
-  - `competition_slug`
+- Required top-level keys:
+  - `competition`
+  - `experiment`
+- `competition` keys:
+  - `slug`
   - `task_type` (`regression` or `binary`)
   - `primary_metric` (`rmse`, `mse`, `rmsle`, `mae`, `roc_auc`, `log_loss`, `accuracy`)
-- Optional model-selection key:
-  - `model_ids` (ordered list of canonical baseline model recipes for the configured task)
-    - regression: `onehot_ridge`, `onehot_elasticnet`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-    - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-- Optional binary-classification key:
-  - `positive_label` (explicit positive class for binary competitions; required unless observed labels match one of the documented safe conventions `[0, 1]`, `[False, True]`, or `["No", "Yes"]`)
-- Optional submission schema keys:
-  - `id_column` (optional override for the inferred identifier column; resolved IDs are kept as metadata and excluded from modeled features)
-  - `label_column` (optional override for the inferred submission/target column)
-- Optional keys for preprocessing:
-  - `force_categorical` (list of column names)
-  - `force_numeric` (list of column names)
-  - `drop_columns` (list of additional modeled-feature columns to remove after the ID column is excluded by default)
-  - `low_cardinality_int_threshold` (positive integer)
-- Optional keys for CV:
-  - `cv_n_splits` (integer >= 2, default 7)
-  - `cv_shuffle` (boolean, default true)
-  - `cv_random_state` (integer, default 42)
-- Optional tuning block:
-  - `tuning.enabled` (boolean, default false)
-  - `tuning.model_id` (one explicit canonical tunable model recipe for the configured task)
-    - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
-    - binary classification: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`
-  - `tuning.n_trials` (integer >= 1, optional)
-  - `tuning.timeout_seconds` (integer >= 1, optional)
-  - `tuning.random_state` (integer, default 42)
-- Optional keys for submission:
-  - `submit_enabled` (boolean, default false)
-  - `submit_message_prefix` (string, optional)
+  - optional `positive_label` (explicit positive class for binary competitions; required unless observed labels match one of the documented safe conventions `[0, 1]`, `[False, True]`, or `["No", "Yes"]`)
+  - optional schema overrides:
+    - `id_column`
+    - `label_column`
+  - `cv`:
+    - `n_splits` (integer >= 2, default 7)
+    - `shuffle` (boolean, default true)
+    - `random_state` (integer, default 42)
+  - optional `features` block:
+    - `force_categorical` (list of column names)
+    - `force_numeric` (list of column names)
+    - `drop_columns` (list of additional modeled-feature columns to remove after the ID column is excluded by default)
+    - `low_cardinality_int_threshold` (positive integer)
+- `experiment` keys:
+  - `name`
+  - optional `notes`
+  - required `candidate`
+  - optional `submit`
+- Current `experiment.candidate` keys:
+  - `candidate_type` (currently only `model`)
+  - `candidate_id`
+  - `preprocessor` (`onehot`, `ordinal`, or `native`)
+  - `model_family`
+    - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+    - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+  - optional `model_params`
+  - optional `optimization`:
+    - `enabled` (boolean, default false)
+    - `method` (currently only `optuna`)
+    - `n_trials` (integer >= 1, optional)
+    - `timeout_seconds` (integer >= 1, optional)
+    - `random_state` (integer, default 42)
+- Current `experiment.submit` keys:
+  - `enabled` (boolean, default false)
+  - `message_prefix` (string, optional)
 
 Binary prediction artifact contract:
 - `roc_auc` and `log_loss` write positive-class probabilities to `test_predictions.csv` and `submission.csv`
@@ -95,8 +104,10 @@ Binary prediction artifact contract:
 
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
-tuning requires at least one stopping condition: `tuning.n_trials` or `tuning.timeout_seconds`.
-tune uses `tuning.model_id` only; the normal `train` stage still uses top-level `model_ids`.
+The old flat config layout is unsupported and fails fast.
+The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id`.
+optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.
+the `tune` stage uses the current experiment candidate only.
 LightGBM, CatBoost, and XGBoost require the optional booster dependencies installed via `uv sync --extra boosters`.
 
 ## Preferred Verification Targets
@@ -107,7 +118,7 @@ LightGBM, CatBoost, and XGBoost require the optional booster dependencies instal
 Manual verification steps for each target:
 - copy the corresponding tracked example config to `config.yaml`
 - verify the competition assets include `train.csv`, `test.csv`, and `sample_submission.csv`
-- run the workflow from a clean repo state with explicit `task_type`, `primary_metric`, and one or more selected models
+- run the workflow from a clean repo state with explicit `competition` plus one current `experiment.candidate`
 - confirm inferred `id_column` and `label_column`
 - confirm `model_summary.csv` is generated in the run directory
 - confirm `test_predictions.csv` is generated in each model directory
@@ -156,15 +167,13 @@ Manual verification steps for each target:
 - One runtime config source only: local repository-root `config.yaml`
 - No config overrides via CLI or environment variables
 - Tracked example config files are documentation and starting points only; they are never read automatically at runtime
-- `task_type` and `primary_metric` must be present in config for every run
-- `model_ids` is the config-time model-selection interface
-- `model_ids` must contain one or more canonical supported presets for the configured task; if omitted, the task default is used
-- the `tune` stage requires `tuning.enabled=true`, uses `tuning.model_id` only, and retrains exactly one tuned candidate into the normal train artifact layout
-- `tuning.model_id` must be one of the supported tunable model recipes for the configured task
-- supported tunable recipes are:
-  - binary: `onehot_logreg`, `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-  - regression: `ordinal_randomforest`, `ordinal_extratrees`, `ordinal_hgb`, `ordinal_lightgbm`, `native_catboost`, `ordinal_xgboost`
-- tuning must have at least one stopping condition: `tuning.n_trials` or `tuning.timeout_seconds`
+- top-level `competition` and `experiment` sections must be present in config for every run
+- the old flat config layout is unsupported
+- `competition.task_type` and `competition.primary_metric` must be present in config for every run
+- the current runtime supports one `experiment.candidate` of type `model`
+- `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
+- the `tune` stage requires `experiment.candidate.optimization.enabled=true`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal train artifact layout
+- enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
 - Submit-time `model_id` remains the trained-model selector for choosing one artifact from a run
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
@@ -196,12 +205,12 @@ Hard-error cases include:
 - Missing `task_type` or `primary_metric` -> hard error
 - Unknown/unsupported configured `primary_metric` -> hard error
 - Invalid task/metric pairing (for example `binary` + `rmse`) -> hard error
-- Removed config key `model_id` -> hard error
-- Invalid configured `model_ids` for the configured task -> hard error
-- Empty or duplicate `model_ids` -> hard error
-- `tuning.enabled=true` without `tuning.model_id` -> hard error
-- `tuning.enabled=true` without `tuning.n_trials` or `tuning.timeout_seconds` -> hard error
-- unsupported configured `tuning.model_id` for the configured task -> hard error
+- Missing required top-level `competition` or `experiment` sections -> hard error
+- Any use of the old flat config layout -> hard error
+- Unsupported `experiment.candidate.candidate_type` -> hard error
+- Invalid configured `experiment.candidate.model_family + preprocessor` combination for the configured task -> hard error
+- enabled optimization without `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds` -> hard error
+- enabled optimization for an unsupported candidate combination -> hard error
 - Missing/invalid competition zip contents -> hard error
 - `id_column` inference not exactly one column -> hard error
 - `label_column` inference not exactly one column -> hard error
@@ -219,7 +228,7 @@ Hard-error cases include:
 - Submission schema or ID mismatch against `sample_submission.csv` -> hard error
 - Binary probability artifact outside `[0, 1]` for `roc_auc` or `log_loss` -> hard error
 - Binary label artifact containing values outside the observed label pair for `accuracy` -> hard error
-- Kaggle submission command failure when `submit_enabled=true` -> hard error
+- Kaggle submission command failure when `experiment.submit.enabled=true` -> hard error
 
 ## Design Guardrails
 - Keep implementation simple and avoid speculative abstractions.
@@ -232,7 +241,7 @@ Hard-error cases include:
 - Keep EDA script-driven and CSV-oriented rather than notebook- or plot-first.
 
 ## Extension Notes
-- New config keys should be added to `AppConfig` in `config.py` and documented in both this file and `README.md` when user-facing.
+- New user-facing config keys should be added to the relevant nested config model in `config.py` and documented in both this file and `README.md`.
 - If the user-facing config workflow changes, update `config.binary.example.yaml` and `config.regression.example.yaml` alongside the docs.
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
 - New model families should be introduced in `models.py` with explicit task compatibility, canonical recipe IDs, and matching artifact outputs.

--- a/main.py
+++ b/main.py
@@ -47,7 +47,9 @@ def build_parser() -> argparse.ArgumentParser:
 def _print_resolved_setup(config: AppConfig) -> None:
     print(
         "Resolved competition setup: "
-        f"task_type={config.task_type}, primary_metric={config.primary_metric}, model_ids={config.model_ids}"
+        f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
+        f"candidate_id={config.candidate_id}, model_family={config.model_family}, "
+        f"preprocessor={config.preprocessor}, model_id={config.resolved_model_id}"
     )
 
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -6,10 +6,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
 from tabular_shenanigans.models import (
-    get_default_model_id,
-    get_tunable_model_ids,
+    get_tunable_candidate_model_specs,
     is_model_tunable,
-    resolve_model_id,
+    resolve_candidate_model_id,
 )
 
 
@@ -27,73 +26,243 @@ class TuningConfig(BaseModel):
     random_state: int = 42
 
 
-class AppConfig(BaseModel):
+class CompetitionCvConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    competition_slug: str = Field(min_length=1)
-    task_type: Literal["regression", "binary"]
-    primary_metric: str
-    model_ids: list[str] | None = None
-    positive_label: str | int | bool | None = None
-    id_column: str | None = None
-    label_column: str | None = None
+    n_splits: int = Field(default=7, ge=2)
+    shuffle: bool = True
+    random_state: int = 42
+
+
+class CompetitionFeaturesConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     force_categorical: list[str] = Field(default_factory=list)
     force_numeric: list[str] = Field(default_factory=list)
     drop_columns: list[str] = Field(default_factory=list)
     low_cardinality_int_threshold: int | None = Field(default=None, ge=1)
-    cv_n_splits: int = Field(default=7, ge=2)
-    cv_shuffle: bool = True
-    cv_random_state: int = 42
-    tuning: TuningConfig | None = None
-    submit_enabled: bool = False
-    submit_message_prefix: str | None = None
+
+
+class CompetitionConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    slug: str = Field(min_length=1)
+    task_type: Literal["regression", "binary"]
+    primary_metric: str
+    positive_label: str | int | bool | None = None
+    id_column: str | None = None
+    label_column: str | None = None
+    cv: CompetitionCvConfig = Field(default_factory=CompetitionCvConfig)
+    features: CompetitionFeaturesConfig = Field(default_factory=CompetitionFeaturesConfig)
+
+
+class CandidateOptimizationConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    method: Literal["optuna"] = "optuna"
+    n_trials: int | None = Field(default=None, ge=1)
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    random_state: int = 42
+
+
+class ModelCandidateConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_type: Literal["model"] = "model"
+    candidate_id: str = Field(min_length=1)
+    preprocessor: Literal["onehot", "ordinal", "native"]
+    model_family: Literal[
+        "ridge",
+        "elasticnet",
+        "logistic_regression",
+        "random_forest",
+        "extra_trees",
+        "hist_gradient_boosting",
+        "lightgbm",
+        "catboost",
+        "xgboost",
+    ]
+    model_params: dict[str, object] = Field(default_factory=dict)
+    optimization: CandidateOptimizationConfig = Field(default_factory=CandidateOptimizationConfig)
 
     @model_validator(mode="after")
-    def validate_task_and_metric(self) -> "AppConfig":
-        normalized_primary_metric = normalize_primary_metric(self.primary_metric)
+    def validate_model_candidate(self) -> "ModelCandidateConfig":
+        if self.model_params and self.optimization.enabled:
+            raise ValueError(
+                "The current runtime does not support combining experiment.candidate.model_params "
+                "with enabled experiment.candidate.optimization."
+            )
+        return self
+
+
+class ExperimentSubmitConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    message_prefix: str | None = None
+
+
+class ExperimentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    notes: str | None = None
+    candidate: ModelCandidateConfig
+    submit: ExperimentSubmitConfig = Field(default_factory=ExperimentSubmitConfig)
+
+
+class AppConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    competition: CompetitionConfig
+    experiment: ExperimentConfig
+
+    @model_validator(mode="after")
+    def validate_config(self) -> "AppConfig":
+        normalized_primary_metric = normalize_primary_metric(self.competition.primary_metric)
         if normalized_primary_metric is None:
             raise ValueError(
-                "Configured primary_metric is not supported. "
+                "Configured competition.primary_metric is not supported. "
                 f"Supported values: {sorted(set(SUPPORTED_PRIMARY_METRICS.values()))}"
             )
-        if not is_metric_valid_for_task(self.task_type, normalized_primary_metric):
+        if not is_metric_valid_for_task(self.competition.task_type, normalized_primary_metric):
             raise ValueError(
-                f"Configured primary_metric '{normalized_primary_metric}' is not valid for task_type '{self.task_type}'."
+                "Configured competition.primary_metric "
+                f"'{normalized_primary_metric}' is not valid for task_type '{self.competition.task_type}'."
             )
-        self.primary_metric = normalized_primary_metric
+        self.competition.primary_metric = normalized_primary_metric
 
-        if self.model_ids is not None:
-            if not self.model_ids:
-                raise ValueError("model_ids must contain at least one canonical model_id.")
-            resolved_model_ids = list(self.model_ids)
-        else:
-            resolved_model_ids = [get_default_model_id(self.task_type)]
+        if self.competition.task_type != "binary" and self.competition.positive_label is not None:
+            raise ValueError("competition.positive_label is only supported for binary task_type.")
 
-        canonical_model_ids = [resolve_model_id(self.task_type, model_id) for model_id in resolved_model_ids]
-        if len(set(canonical_model_ids)) != len(canonical_model_ids):
-            raise ValueError(f"model_ids must not contain duplicates: {canonical_model_ids}")
-
-        self.model_ids = canonical_model_ids
-
-        if self.task_type != "binary" and self.positive_label is not None:
-            raise ValueError("positive_label is only supported for binary task_type.")
-
-        if self.tuning is not None and self.tuning.enabled:
-            if self.tuning.model_id is None:
-                raise ValueError("tuning.model_id is required when tuning.enabled=true.")
-            if self.tuning.n_trials is None and self.tuning.timeout_seconds is None:
+        resolved_model_id = self.resolved_model_id
+        optimization = self.experiment.candidate.optimization
+        if optimization.enabled:
+            if optimization.n_trials is None and optimization.timeout_seconds is None:
                 raise ValueError(
-                    "At least one tuning stopping condition is required. "
-                    "Set tuning.n_trials or tuning.timeout_seconds."
+                    "At least one experiment.candidate.optimization stopping condition is required. "
+                    "Set experiment.candidate.optimization.n_trials or "
+                    "experiment.candidate.optimization.timeout_seconds."
                 )
-            canonical_tuning_model_id = resolve_model_id(self.task_type, self.tuning.model_id)
-            if not is_model_tunable(self.task_type, canonical_tuning_model_id):
+            if not is_model_tunable(self.task_type, resolved_model_id):
+                supported_tunable_combinations = [
+                    f"{model_family}+{preprocessor}"
+                    for model_family, preprocessor, _ in get_tunable_candidate_model_specs(self.task_type)
+                ]
                 raise ValueError(
-                    f"Configured tuning.model_id '{canonical_tuning_model_id}' does not support tuning for task_type "
-                    f"'{self.task_type}'. Supported tunable model_ids: {get_tunable_model_ids(self.task_type)}"
+                    "Configured experiment.candidate does not support optimization for task_type "
+                    f"'{self.task_type}'. Supported tunable combinations: {supported_tunable_combinations}"
                 )
-            self.tuning.model_id = canonical_tuning_model_id
+
         return self
+
+    @property
+    def competition_slug(self) -> str:
+        return self.competition.slug
+
+    @property
+    def task_type(self) -> Literal["regression", "binary"]:
+        return self.competition.task_type
+
+    @property
+    def primary_metric(self) -> str:
+        return self.competition.primary_metric
+
+    @property
+    def positive_label(self) -> str | int | bool | None:
+        return self.competition.positive_label
+
+    @property
+    def id_column(self) -> str | None:
+        return self.competition.id_column
+
+    @property
+    def label_column(self) -> str | None:
+        return self.competition.label_column
+
+    @property
+    def force_categorical(self) -> list[str]:
+        return self.competition.features.force_categorical
+
+    @property
+    def force_numeric(self) -> list[str]:
+        return self.competition.features.force_numeric
+
+    @property
+    def drop_columns(self) -> list[str]:
+        return self.competition.features.drop_columns
+
+    @property
+    def low_cardinality_int_threshold(self) -> int | None:
+        return self.competition.features.low_cardinality_int_threshold
+
+    @property
+    def cv_n_splits(self) -> int:
+        return self.competition.cv.n_splits
+
+    @property
+    def cv_shuffle(self) -> bool:
+        return self.competition.cv.shuffle
+
+    @property
+    def cv_random_state(self) -> int:
+        return self.competition.cv.random_state
+
+    @property
+    def candidate_id(self) -> str:
+        return self.experiment.candidate.candidate_id
+
+    @property
+    def candidate_type(self) -> str:
+        return self.experiment.candidate.candidate_type
+
+    @property
+    def model_family(self) -> str:
+        return self.experiment.candidate.model_family
+
+    @property
+    def preprocessor(self) -> str:
+        return self.experiment.candidate.preprocessor
+
+    @property
+    def resolved_model_id(self) -> str:
+        return resolve_candidate_model_id(
+            task_type=self.task_type,
+            model_family=self.model_family,
+            preprocessor=self.preprocessor,
+        )
+
+    @property
+    def model_ids(self) -> list[str]:
+        return [self.resolved_model_id]
+
+    @property
+    def model_parameter_overrides(self) -> dict[str, object] | None:
+        if not self.experiment.candidate.model_params:
+            return None
+        return dict(self.experiment.candidate.model_params)
+
+    @property
+    def tuning(self) -> TuningConfig | None:
+        optimization = self.experiment.candidate.optimization
+        if not optimization.enabled:
+            return None
+        return TuningConfig(
+            enabled=True,
+            model_id=self.resolved_model_id,
+            n_trials=optimization.n_trials,
+            timeout_seconds=optimization.timeout_seconds,
+            random_state=optimization.random_state,
+        )
+
+    @property
+    def submit_enabled(self) -> bool:
+        return self.experiment.submit.enabled
+
+    @property
+    def submit_message_prefix(self) -> str | None:
+        return self.experiment.submit.message_prefix
 
 
 def load_config(path: str = "config.yaml") -> AppConfig:
@@ -112,11 +281,5 @@ def load_config(path: str = "config.yaml") -> AppConfig:
 
     if not isinstance(raw_data, dict):
         raise ConfigError("Config must be a top-level mapping.")
-    if "model_id" in raw_data:
-        raise ConfigError(
-            "Config key 'model_id' is no longer supported. "
-            "Use model_ids with canonical recipe IDs instead, for example: "
-            "model_ids: [onehot_logreg]"
-        )
 
     return AppConfig.model_validate(raw_data)

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -534,6 +534,73 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
     },
 }
 
+
+CANDIDATE_MODEL_REGISTRY: dict[str, dict[tuple[str, str], str]] = {
+    "regression": {
+        ("ridge", "onehot"): "onehot_ridge",
+        ("elasticnet", "onehot"): "onehot_elasticnet",
+        ("random_forest", "ordinal"): "ordinal_randomforest",
+        ("extra_trees", "ordinal"): "ordinal_extratrees",
+        ("hist_gradient_boosting", "ordinal"): "ordinal_hgb",
+        ("lightgbm", "ordinal"): "ordinal_lightgbm",
+        ("catboost", "native"): "native_catboost",
+        ("xgboost", "ordinal"): "ordinal_xgboost",
+    },
+    "binary": {
+        ("logistic_regression", "onehot"): "onehot_logreg",
+        ("random_forest", "ordinal"): "ordinal_randomforest",
+        ("extra_trees", "ordinal"): "ordinal_extratrees",
+        ("hist_gradient_boosting", "ordinal"): "ordinal_hgb",
+        ("lightgbm", "ordinal"): "ordinal_lightgbm",
+        ("catboost", "native"): "native_catboost",
+        ("xgboost", "ordinal"): "ordinal_xgboost",
+    },
+}
+
+
+def _get_task_candidate_model_registry(task_type: str) -> dict[tuple[str, str], str]:
+    try:
+        return CANDIDATE_MODEL_REGISTRY[task_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported task_type for candidate model selection: {task_type}") from exc
+
+
+def get_supported_candidate_model_specs(task_type: str) -> list[tuple[str, str, str]]:
+    task_registry = _get_task_candidate_model_registry(task_type)
+    return sorted(
+        (model_family, preprocessor, model_id)
+        for (model_family, preprocessor), model_id in task_registry.items()
+    )
+
+
+def get_tunable_candidate_model_specs(task_type: str) -> list[tuple[str, str, str]]:
+    return sorted(
+        (model_family, preprocessor, model_id)
+        for model_family, preprocessor, model_id in get_supported_candidate_model_specs(task_type)
+        if is_model_tunable(task_type, model_id)
+    )
+
+
+def resolve_candidate_model_id(
+    task_type: str,
+    model_family: str,
+    preprocessor: str,
+) -> str:
+    task_registry = _get_task_candidate_model_registry(task_type)
+    candidate_key = (model_family, preprocessor)
+    if candidate_key in task_registry:
+        return resolve_model_id(task_type, task_registry[candidate_key])
+
+    supported_combinations = [
+        f"{supported_model_family}+{supported_preprocessor}"
+        for supported_model_family, supported_preprocessor, _ in get_supported_candidate_model_specs(task_type)
+    ]
+    raise ValueError(
+        f"Candidate model_family '{model_family}' with preprocessor '{preprocessor}' is not valid for task_type "
+        f"'{task_type}'. Supported combinations: {supported_combinations}"
+    )
+
+
 def _get_task_model_registry(task_type: str) -> dict[str, ModelDefinition]:
     try:
         return MODEL_REGISTRY[task_type]

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -170,7 +170,13 @@ def _resolve_training_model_specs(
         if not model_specs:
             raise ValueError("Training requires at least one model specification.")
         return model_specs
-    return [TrainingModelSpec(model_id=model_id) for model_id in config.model_ids]
+    return [
+        TrainingModelSpec(
+            model_id=model_id,
+            parameter_overrides=config.model_parameter_overrides,
+        )
+        for model_id in config.model_ids
+    ]
 
 
 def _read_run_ledger(ledger_path: Path) -> pd.DataFrame:
@@ -682,20 +688,15 @@ def _build_config_snapshot(
     tuning_provenance: dict[str, object] | None = None,
 ) -> dict[str, object]:
     config_snapshot = {
-        "competition_slug": config.competition_slug,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
-        "model_ids": [model_spec.model_id for model_spec in model_specs],
-        "positive_label": positive_label,
-        "id_column": id_column,
-        "label_column": label_column,
-        "force_categorical": config.force_categorical,
-        "force_numeric": config.force_numeric,
-        "drop_columns": config.drop_columns,
-        "low_cardinality_int_threshold": config.low_cardinality_int_threshold,
-        "cv_n_splits": config.cv_n_splits,
-        "cv_shuffle": config.cv_shuffle,
-        "cv_random_state": config.cv_random_state,
+        "competition": {
+            **config.competition.model_dump(mode="python"),
+            "primary_metric": config.primary_metric,
+            "positive_label": positive_label,
+            "id_column": id_column,
+            "label_column": label_column,
+        },
+        "experiment": config.experiment.model_dump(mode="python"),
+        "resolved_model_ids": [model_spec.model_id for model_spec in model_specs],
     }
     parameter_overrides = {
         model_spec.model_id: model_spec.parameter_overrides
@@ -703,7 +704,7 @@ def _build_config_snapshot(
         if model_spec.parameter_overrides
     }
     if parameter_overrides:
-        config_snapshot["model_parameter_overrides"] = parameter_overrides
+        config_snapshot["resolved_model_parameter_overrides"] = parameter_overrides
     if tuning_provenance is not None:
         config_snapshot["tuning_provenance"] = tuning_provenance
     return config_snapshot

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -16,7 +16,6 @@ from tabular_shenanigans.train import (
     _build_target_summary,
     _evaluate_model_spec,
     _materialize_split_indices,
-    _resolve_training_model_specs,
     _json_ready,
     run_training,
 )
@@ -39,29 +38,16 @@ def _build_study_config_snapshot(
     id_column: str,
     label_column: str,
 ) -> dict[str, object]:
-    resolved_training_model_specs = _resolve_training_model_specs(config=config)
     return {
-        "competition_slug": config.competition_slug,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
-        "model_ids": [model_spec.model_id for model_spec in resolved_training_model_specs],
-        "positive_label": positive_label,
-        "id_column": id_column,
-        "label_column": label_column,
-        "force_categorical": config.force_categorical,
-        "force_numeric": config.force_numeric,
-        "drop_columns": config.drop_columns,
-        "low_cardinality_int_threshold": config.low_cardinality_int_threshold,
-        "cv_n_splits": config.cv_n_splits,
-        "cv_shuffle": config.cv_shuffle,
-        "cv_random_state": config.cv_random_state,
-        "tuning": {
-            "enabled": True,
-            "model_id": tuning_model_spec.model_id,
-            "n_trials": config.tuning.n_trials if config.tuning is not None else None,
-            "timeout_seconds": config.tuning.timeout_seconds if config.tuning is not None else None,
-            "random_state": config.tuning.random_state if config.tuning is not None else None,
+        "competition": {
+            **config.competition.model_dump(mode="python"),
+            "primary_metric": config.primary_metric,
+            "positive_label": positive_label,
+            "id_column": id_column,
+            "label_column": label_column,
         },
+        "experiment": config.experiment.model_dump(mode="python"),
+        "resolved_model_ids": [tuning_model_spec.model_id],
     }
 
 


### PR DESCRIPTION
## Summary
- replace the flat runtime config with nested `competition` and `experiment` sections
- resolve `experiment.candidate.model_family + preprocessor` to the current internal canonical model id
- keep the current train/tune/submit flows working through compatibility properties on `AppConfig`
- update the tracked example configs and docs to the new config layout

Closes #72

## Verification
- loaded both updated example configs with `load_config()` and confirmed they resolve to `onehot_logreg` and `onehot_elasticnet`
- confirmed an old flat config now fails naturally via schema validation with missing `competition`
- confirmed nested optimization config resolves through the existing tune compatibility path
- ran a smoke training job against local `smoke-binary-canonical` data using the new config shape and verified a normal train artifact was written
- ran `PYTHONPATH=src .venv/bin/python -m compileall main.py src/tabular_shenanigans`