### PR TITLE
Add prepare stage with persisted competition context and frozen folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ The repository is developed and manually verified primarily against these Playgr
 - Require explicit `task_type` and `primary_metric` in config.
 - Separate stable competition settings from the current experiment candidate in config via top-level `competition` and `experiment` sections.
 - Ship tracked binary and regression example configs that can be copied into the local runtime config.
+- Persist a competition-level context under `artifacts/<competition_slug>/` with `competition.json` and `folds.csv`.
 - Infer Playground-style submission schema from dataset files:
   - `id_column` as the only column shared by `train.csv`, `test.csv`, and `sample_submission.csv`
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
-- Run stage-specific CLI entrypoints for `fetch`, `eda`, `preprocess`, `train`, and submit-only flows against explicit run artifacts.
+- Freeze CV assignments once per prepared competition context and reuse them across `train` and `tune`.
+- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `preprocess`, `train`, and submit-only flows against explicit run artifacts.
 - Run an explicit `tune` stage that evaluates Optuna trials for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes study artifacts, and retrains the best trial into the standard training artifact layout.
 - Train one cross-validated model candidate at a time using config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
 - Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
@@ -54,13 +56,14 @@ cp config.regression.example.yaml config.yaml
 
 `config.yaml` is the only runtime config source. It is intentionally ignored by Git so you can keep local competition-specific settings without committing them.
 
-The current pipeline fetches competition data if needed, runs config-aware EDA, trains the current experiment candidate with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
+The current pipeline fetches competition data if needed, prepares competition metadata plus frozen folds, trains the current experiment candidate with fold-local preprocessing and task-aware diagnostics, writes prediction artifacts, and prepares a validated submission file.
 
 ## Stage Commands
-`uv run python main.py` still runs the full default pipeline: fetch, EDA, train, and submit.
+`uv run python main.py` still runs the full default pipeline: fetch, prepare, train, and submit.
 
 Available stage-specific commands:
 - `uv run python main.py fetch`
+- `uv run python main.py prepare`
 - `uv run python main.py eda`
 - `uv run python main.py preprocess`
 - `uv run python main.py train`
@@ -70,10 +73,11 @@ Available stage-specific commands:
 
 Stage behavior:
 - `fetch`: ensures competition data is present locally
+- `prepare`: fetches if needed, writes EDA report CSVs, persists `competition.json`, and freezes `folds.csv`
 - `eda`: fetches if needed, then writes EDA report CSVs
 - `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
-- `train`: fetches if needed, then trains and writes normal training artifacts
-- `tune`: fetches if needed, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts, then retrains the best trial into the normal training artifact layout
+- `train`: fetches if needed, prepares competition context when it is missing, then trains and writes normal training artifacts on the frozen folds
+- `tune`: fetches if needed, prepares competition context when it is missing, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true` on the frozen folds, writes tuning artifacts, then retrains the best trial into the normal training artifact layout
 - `submit`: requires an explicit existing run selection and never retrains implicitly
 
 The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
@@ -172,6 +176,8 @@ Tracked example configs for those targets:
 Manual verification for each target:
 - copy the corresponding example file to `config.yaml`
 - confirm the competition archive includes `train.csv`, `test.csv`, and `sample_submission.csv`
+- run `uv run python main.py prepare`
+- confirm `artifacts/<competition_slug>/competition.json` and `artifacts/<competition_slug>/folds.csv` are written
 - confirm the pipeline infers `id_column` and `label_column` without overrides
 - confirm `artifacts/<competition_slug>/train/<run_id>/model_summary.csv` is written
 - confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv` is written for the resolved internal model artifact
@@ -189,6 +195,9 @@ Manual verification for tuning:
 
 ## Outputs
 - Competition data: `data/<competition_slug>/`
+- Competition context artifacts: `artifacts/<competition_slug>/`
+  - `competition.json`
+  - `folds.csv`
 - EDA reports: `reports/<competition_slug>/`
   - when `preprocess` stage is run, also includes `preprocess_summary.csv`, `preprocess_features.csv`, and `preprocess_models.csv`
 - Tuning artifacts: `artifacts/<competition_slug>/tune/<study_id>/`
@@ -210,6 +219,7 @@ Manual verification for tuning:
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
 - The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; run artifacts still record that resolved `model_id` and `preprocessing_scheme_id`.
+- `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` and `tune` consume that frozen context and auto-run `prepare` only when it is missing.
 - The `tune` stage uses the current experiment candidate only, and the tuned best-trial retrain writes a standard single-model train artifact with `tuning_provenance`.
 - Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
 - Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -9,9 +9,9 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 2. Use explicit `task_type` and `primary_metric` from config.
 3. Download the competition zip into `data/<competition_slug>/` when it is missing.
 4. Load one shared dataset context from `train.csv`, `test.csv`, and `sample_submission.csv`.
-5. Run EDA against that shared dataset context and write report CSVs under `reports/<competition_slug>/`.
+5. Run `prepare` to write report CSVs under `reports/<competition_slug>/`, persist `artifacts/<competition_slug>/competition.json`, and freeze `artifacts/<competition_slug>/folds.csv`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
-7. During training, build fold-local preprocessing from the selected model recipe:
+7. During training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected model recipe:
    - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
    - `ordinal`: numeric median imputation; categorical most-frequent imputation + `OrdinalEncoder`
    - `native`: numeric median imputation inside a pandas frame; categorical missing-value fill with native categorical columns preserved for CatBoost
@@ -22,15 +22,16 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
 11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
 
-When the explicit `tune` stage is selected, the workflow additionally runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard train artifact layout with `tuning_provenance` recorded in `run_manifest.json`.
+When the explicit `tune` stage is selected, the workflow additionally loads the frozen fold assignments from `folds.csv`, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard train artifact layout with `tuning_provenance` recorded in `run_manifest.json`.
 
 ## CLI Stages
-- `uv run python main.py`: default full pipeline (`fetch` -> `eda` -> `train` -> `submit`)
+- `uv run python main.py`: default full pipeline (`fetch` -> `prepare` -> `train` -> `submit`)
 - `uv run python main.py fetch`: ensure competition data is present
+- `uv run python main.py prepare`: fetch if needed, load the shared dataset context, write EDA reports, persist competition metadata, and freeze folds
 - `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
 - `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
-- `uv run python main.py train`: fetch if needed, load the shared dataset context, and write training artifacts
-- `uv run python main.py tune`: fetch if needed, load the shared dataset context, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into normal training artifacts
+- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, and write training artifacts on the frozen folds
+- `uv run python main.py tune`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into normal training artifacts on the frozen folds
 - `uv run python main.py submit --run-dir artifacts/.../train/<run_id>`: prepare or submit from an explicit existing run artifact
 - `uv run python main.py submit --run-id <run_id>`: resolve the run under `artifacts/<competition_slug>/train/<run_id>` using the configured competition slug
 
@@ -39,15 +40,16 @@ The `preprocess` stage is intentionally diagnostic. It is not part of the defaul
 The default `submit` path supports current manifest-backed run artifacts only. Unsupported older local artifact layouts fail directly instead of using compatibility fallbacks.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, EDA, preprocess diagnostics, training, tuning, and submission.
+- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, preprocess diagnostics, training, tuning, and submission.
+- `src/tabular_shenanigans/competition.py`: competition-level preparation, `competition.json` persistence, `folds.csv` persistence, prepared-context validation, and split reconstruction from frozen folds.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, shared split handling, artifact writing, and run ledger updates.
-- `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate, study artifact writing, and best-trial retraining into the standard train artifact layout.
+- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, artifact writing, and run ledger updates.
+- `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate on the frozen fold assignments, study artifact writing, and best-trial retraining into the standard train artifact layout.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
@@ -118,6 +120,8 @@ LightGBM, CatBoost, and XGBoost require the optional booster dependencies instal
 Manual verification steps for each target:
 - copy the corresponding tracked example config to `config.yaml`
 - verify the competition assets include `train.csv`, `test.csv`, and `sample_submission.csv`
+- run `uv run python main.py prepare`
+- confirm `artifacts/<competition_slug>/competition.json` and `artifacts/<competition_slug>/folds.csv` are generated
 - run the workflow from a clean repo state with explicit `competition` plus one current `experiment.candidate`
 - confirm inferred `id_column` and `label_column`
 - confirm `model_summary.csv` is generated in the run directory
@@ -131,6 +135,9 @@ Manual verification steps for each target:
 - A validated in-memory config object from Pydantic
 - Competition files downloaded under `data/<competition_slug>/`
 - EDA summary printed to terminal
+- Competition context artifacts under `artifacts/<competition_slug>/`:
+  - `competition.json`
+  - `folds.csv`
 - EDA report CSV files under `reports/<competition_slug>/`
   - `columns_train.csv`
   - `columns_test.csv`
@@ -170,6 +177,8 @@ Manual verification steps for each target:
 - top-level `competition` and `experiment` sections must be present in config for every run
 - the old flat config layout is unsupported
 - `competition.task_type` and `competition.primary_metric` must be present in config for every run
+- `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`
+- `train` and `tune` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
 - the current runtime supports one `experiment.candidate` of type `model`
 - `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
 - the `tune` stage requires `experiment.candidate.optimization.enabled=true`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal train artifact layout
@@ -212,6 +221,8 @@ Hard-error cases include:
 - enabled optimization without `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds` -> hard error
 - enabled optimization for an unsupported candidate combination -> hard error
 - Missing/invalid competition zip contents -> hard error
+- Missing `competition.json` or `folds.csv` during `train`/`tune` -> auto-run `prepare`
+- Prepared competition context that no longer matches the current config or resolved dataset schema -> hard error
 - `id_column` inference not exactly one column -> hard error
 - `label_column` inference not exactly one column -> hard error
 - Invalid `id_column` or `label_column` override -> hard error

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
+from tabular_shenanigans.competition import prepare_competition
 from tabular_shenanigans.config import AppConfig, load_config
 from tabular_shenanigans.data import fetch_competition_data, load_competition_dataset_context
 from tabular_shenanigans.eda import run_eda
@@ -20,6 +21,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="stage")
 
     subparsers.add_parser("fetch", help="Download competition data if it is missing.")
+    subparsers.add_parser("prepare", help="Persist EDA reports, competition metadata, and frozen folds.")
     subparsers.add_parser("eda", help="Run EDA reports only.")
     subparsers.add_parser("preprocess", help="Write preprocessing diagnostics only.")
     subparsers.add_parser("train", help="Run training only.")
@@ -73,11 +75,18 @@ def _resolve_run_dir(config: AppConfig, args: argparse.Namespace) -> Path:
     return Path("artifacts") / config.competition_slug / "train" / str(args.run_id)
 
 
-def _run_full_pipeline(config: AppConfig) -> None:
+def _prepare_competition_stage(config: AppConfig):
     _ensure_data_ready(config)
     dataset_context = _load_shared_dataset_context(config)
-    report_dir = run_eda(config=config, dataset_context=dataset_context)
-    print(f"EDA reports ready: {report_dir}")
+    prepared_context = prepare_competition(config=config, dataset_context=dataset_context)
+    print(f"Competition context ready: {prepared_context.manifest_path}")
+    print(f"Frozen folds ready: {prepared_context.folds_path}")
+    print(f"EDA reports ready: {prepared_context.report_dir}")
+    return dataset_context, prepared_context
+
+
+def _run_full_pipeline(config: AppConfig) -> None:
+    dataset_context, _ = _prepare_competition_stage(config)
     train_dir = run_training(config=config, dataset_context=dataset_context)
     print(f"Training artifacts ready: {train_dir}")
     submission_path, submission_status = run_submission(config=config, run_dir=train_dir)
@@ -136,6 +145,10 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.stage == "fetch":
         _ensure_data_ready(config)
+        return
+
+    if args.stage == "prepare":
+        _prepare_competition_stage(config)
         return
 
     if args.stage == "eda":

--- a/src/tabular_shenanigans/competition.py
+++ b/src/tabular_shenanigans/competition.py
@@ -1,0 +1,335 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.cv import build_splitter, resolve_positive_label
+from tabular_shenanigans.data import CompetitionDatasetContext
+from tabular_shenanigans.eda import run_eda
+from tabular_shenanigans.preprocess import prepare_feature_frames
+
+
+@dataclass(frozen=True)
+class PreparedCompetitionContext:
+    competition_dir: Path
+    report_dir: Path
+    manifest_path: Path
+    folds_path: Path
+    manifest: dict[str, object]
+    fold_assignments: np.ndarray
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]]
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _competition_dir(competition_slug: str) -> Path:
+    return Path("artifacts") / competition_slug
+
+
+def _competition_manifest_path(competition_slug: str) -> Path:
+    return _competition_dir(competition_slug) / "competition.json"
+
+
+def _competition_folds_path(competition_slug: str) -> Path:
+    return _competition_dir(competition_slug) / "folds.csv"
+
+
+def has_prepared_competition_context(competition_slug: str) -> bool:
+    manifest_path = _competition_manifest_path(competition_slug)
+    folds_path = _competition_folds_path(competition_slug)
+    return manifest_path.exists() and folds_path.exists()
+
+
+def materialize_split_indices(
+    task_type: str,
+    x_train_raw: pd.DataFrame,
+    y_train: pd.Series,
+    n_splits: int,
+    shuffle: bool,
+    random_state: int,
+) -> list[tuple[int, np.ndarray, np.ndarray]]:
+    splitter = build_splitter(
+        task_type=task_type,
+        n_splits=n_splits,
+        shuffle=shuffle,
+        random_state=random_state,
+    )
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]] = []
+    for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train_raw, y_train), start=1):
+        split_indices.append((fold_index, train_idx, valid_idx))
+    return split_indices
+
+
+def build_fold_assignments(
+    row_count: int,
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
+) -> np.ndarray:
+    fold_assignments = np.full(row_count, fill_value=-1, dtype=int)
+    for fold_index, _, valid_idx in split_indices:
+        if (fold_assignments[valid_idx] >= 0).any():
+            raise ValueError("Fold assignment failed: at least one training row received multiple validation folds.")
+        fold_assignments[valid_idx] = fold_index
+    if (fold_assignments < 0).any():
+        raise ValueError("Fold assignment failed: at least one training row did not receive a validation fold.")
+    return fold_assignments
+
+
+def build_split_indices_from_fold_assignments(
+    fold_assignments: np.ndarray,
+) -> list[tuple[int, np.ndarray, np.ndarray]]:
+    if fold_assignments.ndim != 1:
+        raise ValueError("Fold assignments must be one-dimensional.")
+    if fold_assignments.size == 0:
+        raise ValueError("Fold assignments cannot be empty.")
+    if (fold_assignments < 1).any():
+        raise ValueError("Fold assignments must be positive 1-based fold numbers.")
+
+    fold_values = sorted(int(fold) for fold in np.unique(fold_assignments).tolist())
+    expected_folds = list(range(1, len(fold_values) + 1))
+    if fold_values != expected_folds:
+        raise ValueError(
+            "Fold assignments must contain contiguous 1-based fold numbers. "
+            f"Expected {expected_folds}, got {fold_values}"
+        )
+
+    row_indices = np.arange(fold_assignments.shape[0], dtype=int)
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]] = []
+    for fold_index in fold_values:
+        valid_idx = row_indices[fold_assignments == fold_index]
+        train_idx = row_indices[fold_assignments != fold_index]
+        if valid_idx.size == 0:
+            raise ValueError(f"Fold assignment failed: fold {fold_index} has no validation rows.")
+        if train_idx.size == 0:
+            raise ValueError(f"Fold assignment failed: fold {fold_index} has no training rows.")
+        split_indices.append((fold_index, train_idx, valid_idx))
+    return split_indices
+
+
+def _build_competition_manifest(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+    x_train_raw: pd.DataFrame,
+    positive_label: object | None,
+    observed_label_pair: tuple[object, object] | None,
+) -> dict[str, object]:
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "competition_slug": config.competition_slug,
+        "task_type": config.task_type,
+        "primary_metric": config.primary_metric,
+        "id_column": dataset_context.id_column,
+        "label_column": dataset_context.label_column,
+        "positive_label": positive_label,
+        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
+        "train_rows": int(dataset_context.train_df.shape[0]),
+        "test_rows": int(dataset_context.test_df.shape[0]),
+        "feature_columns": x_train_raw.columns.tolist(),
+        "cv": config.competition.cv.model_dump(mode="python"),
+        "features": config.competition.features.model_dump(mode="python"),
+    }
+
+
+def _write_competition_manifest(manifest_path: Path, manifest: dict[str, object]) -> None:
+    manifest_path.write_text(
+        json.dumps(_json_ready(manifest), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _write_fold_assignments(folds_path: Path, fold_assignments: np.ndarray) -> None:
+    folds_df = pd.DataFrame(
+        {
+            "row_idx": np.arange(fold_assignments.shape[0], dtype=int),
+            "fold": fold_assignments.astype(int),
+        }
+    )
+    folds_df.to_csv(folds_path, index=False)
+
+
+def prepare_competition(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+) -> PreparedCompetitionContext:
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+
+    x_train_raw, _, y_train = prepare_feature_frames(
+        train_df=train_df,
+        test_df=test_df,
+        id_column=id_column,
+        label_column=label_column,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
+    )
+
+    positive_label = config.positive_label
+    observed_label_pair = None
+    if config.task_type == "binary":
+        _, positive_label, observed_label_pair = resolve_positive_label(
+            y_values=y_train,
+            configured_positive_label=positive_label,
+        )
+
+    split_indices = materialize_split_indices(
+        task_type=config.task_type,
+        x_train_raw=x_train_raw,
+        y_train=y_train,
+        n_splits=config.cv_n_splits,
+        shuffle=config.cv_shuffle,
+        random_state=config.cv_random_state,
+    )
+    fold_assignments = build_fold_assignments(row_count=x_train_raw.shape[0], split_indices=split_indices)
+    report_dir = run_eda(config=config, dataset_context=dataset_context)
+
+    competition_dir = _competition_dir(config.competition_slug)
+    competition_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = _competition_manifest_path(config.competition_slug)
+    folds_path = _competition_folds_path(config.competition_slug)
+    manifest = _build_competition_manifest(
+        config=config,
+        dataset_context=dataset_context,
+        x_train_raw=x_train_raw,
+        positive_label=positive_label,
+        observed_label_pair=observed_label_pair,
+    )
+    _write_competition_manifest(manifest_path=manifest_path, manifest=manifest)
+    _write_fold_assignments(folds_path=folds_path, fold_assignments=fold_assignments)
+    return PreparedCompetitionContext(
+        competition_dir=competition_dir,
+        report_dir=report_dir,
+        manifest_path=manifest_path,
+        folds_path=folds_path,
+        manifest=manifest,
+        fold_assignments=fold_assignments,
+        split_indices=split_indices,
+    )
+
+
+def _load_competition_manifest(manifest_path: Path) -> dict[str, object]:
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"Missing prepared competition context: {manifest_path}. Run `uv run python main.py prepare` first."
+        ) from exc
+
+    if not isinstance(manifest, dict):
+        raise ValueError(f"Prepared competition manifest must be a JSON object: {manifest_path}")
+    return manifest
+
+
+def _load_fold_assignments(folds_path: Path) -> np.ndarray:
+    try:
+        folds_df = pd.read_csv(folds_path)
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"Missing prepared fold assignments: {folds_path}. Run `uv run python main.py prepare` first."
+        ) from exc
+
+    expected_columns = ["row_idx", "fold"]
+    if folds_df.columns.tolist() != expected_columns:
+        raise ValueError(f"Prepared folds file must have columns {expected_columns}: {folds_path}")
+    expected_row_idx = np.arange(folds_df.shape[0], dtype=int)
+    if not np.array_equal(folds_df["row_idx"].to_numpy(dtype=int), expected_row_idx):
+        raise ValueError(f"Prepared folds file must contain sequential row_idx values starting at 0: {folds_path}")
+    return folds_df["fold"].to_numpy(dtype=int)
+
+
+def _validate_prepared_context(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+    manifest: dict[str, object],
+    fold_assignments: np.ndarray,
+    expected_feature_columns: list[str] | None,
+) -> None:
+    expected_cv = config.competition.cv.model_dump(mode="python")
+    expected_features = config.competition.features.model_dump(mode="python")
+    train_rows = int(dataset_context.train_df.shape[0])
+    test_rows = int(dataset_context.test_df.shape[0])
+
+    if manifest.get("competition_slug") != config.competition_slug:
+        raise ValueError("Prepared competition context does not match the configured competition slug.")
+    if manifest.get("task_type") != config.task_type:
+        raise ValueError("Prepared competition context does not match the configured task_type. Re-run prepare.")
+    if manifest.get("primary_metric") != config.primary_metric:
+        raise ValueError("Prepared competition context does not match the configured primary_metric. Re-run prepare.")
+    if manifest.get("id_column") != dataset_context.id_column:
+        raise ValueError("Prepared competition context does not match the resolved id_column. Re-run prepare.")
+    if manifest.get("label_column") != dataset_context.label_column:
+        raise ValueError("Prepared competition context does not match the resolved label_column. Re-run prepare.")
+    if manifest.get("cv") != expected_cv:
+        raise ValueError("Prepared competition context does not match competition.cv. Re-run prepare.")
+    if manifest.get("features") != expected_features:
+        raise ValueError("Prepared competition context does not match competition.features. Re-run prepare.")
+    if manifest.get("train_rows") != train_rows:
+        raise ValueError("Prepared competition context does not match train row count. Re-run prepare.")
+    if manifest.get("test_rows") != test_rows:
+        raise ValueError("Prepared competition context does not match test row count. Re-run prepare.")
+    if fold_assignments.shape[0] != train_rows:
+        raise ValueError("Prepared fold assignments do not match the training row count. Re-run prepare.")
+    if expected_feature_columns is not None and manifest.get("feature_columns") != expected_feature_columns:
+        raise ValueError("Prepared competition context does not match the resolved feature columns. Re-run prepare.")
+
+    split_indices = build_split_indices_from_fold_assignments(fold_assignments)
+    if len(split_indices) != config.cv_n_splits:
+        raise ValueError("Prepared fold assignments do not match competition.cv.n_splits. Re-run prepare.")
+
+
+def load_prepared_competition_context(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+    expected_feature_columns: list[str] | None = None,
+) -> PreparedCompetitionContext:
+    manifest_path = _competition_manifest_path(config.competition_slug)
+    folds_path = _competition_folds_path(config.competition_slug)
+    manifest = _load_competition_manifest(manifest_path=manifest_path)
+    fold_assignments = _load_fold_assignments(folds_path=folds_path)
+    _validate_prepared_context(
+        config=config,
+        dataset_context=dataset_context,
+        manifest=manifest,
+        fold_assignments=fold_assignments,
+        expected_feature_columns=expected_feature_columns,
+    )
+    return PreparedCompetitionContext(
+        competition_dir=_competition_dir(config.competition_slug),
+        report_dir=Path("reports") / config.competition_slug,
+        manifest_path=manifest_path,
+        folds_path=folds_path,
+        manifest=manifest,
+        fold_assignments=fold_assignments,
+        split_indices=build_split_indices_from_fold_assignments(fold_assignments),
+    )
+
+
+def ensure_prepared_competition_context(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+    expected_feature_columns: list[str] | None = None,
+) -> PreparedCompetitionContext:
+    if has_prepared_competition_context(config.competition_slug):
+        return load_prepared_competition_context(
+            config=config,
+            dataset_context=dataset_context,
+            expected_feature_columns=expected_feature_columns,
+        )
+
+    print("Prepared competition context missing; running prepare.")
+    return prepare_competition(config=config, dataset_context=dataset_context)

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
-from tabular_shenanigans.cv import build_splitter, is_higher_better, resolve_positive_label, score_predictions
+from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
@@ -310,40 +311,6 @@ def _build_diagnostic_rows(
         return [row]
 
     raise ValueError(f"Unsupported task_type for diagnostics: {task_type}")
-
-
-def _materialize_split_indices(
-    task_type: str,
-    x_train_raw: pd.DataFrame,
-    y_train: pd.Series,
-    n_splits: int,
-    shuffle: bool,
-    random_state: int,
-) -> list[tuple[int, np.ndarray, np.ndarray]]:
-    splitter = build_splitter(
-        task_type=task_type,
-        n_splits=n_splits,
-        shuffle=shuffle,
-        random_state=random_state,
-    )
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]] = []
-    for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train_raw, y_train), start=1):
-        split_indices.append((fold_index, train_idx, valid_idx))
-    return split_indices
-
-
-def _build_fold_assignments(
-    row_count: int,
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-) -> np.ndarray:
-    fold_assignments = np.full(row_count, fill_value=-1, dtype=int)
-    for fold_index, _, valid_idx in split_indices:
-        if (fold_assignments[valid_idx] >= 0).any():
-            raise ValueError("Fold assignment failed: at least one training row received multiple validation folds.")
-        fold_assignments[valid_idx] = fold_index
-    if (fold_assignments < 0).any():
-        raise ValueError("Fold assignment failed: at least one training row did not receive a validation fold.")
-    return fold_assignments
 
 
 def _build_run_diagnostics(
@@ -758,15 +725,13 @@ def run_training(
             configured_positive_label=positive_label,
         )
 
-    split_indices = _materialize_split_indices(
-        task_type=task_type,
-        x_train_raw=x_train_raw,
-        y_train=y_train,
-        n_splits=config.cv_n_splits,
-        shuffle=config.cv_shuffle,
-        random_state=config.cv_random_state,
+    prepared_context = ensure_prepared_competition_context(
+        config=config,
+        dataset_context=dataset_context,
+        expected_feature_columns=x_train_raw.columns.tolist(),
     )
-    fold_assignments = _build_fold_assignments(x_train_raw.shape[0], split_indices)
+    split_indices = prepared_context.split_indices
+    fold_assignments = prepared_context.fold_assignments
     run_diagnostics_df = _build_run_diagnostics(
         task_type=task_type,
         y_train=y_train,

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import optuna
 import pandas as pd
 
+from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label
 from tabular_shenanigans.data import CompetitionDatasetContext
@@ -15,7 +16,6 @@ from tabular_shenanigans.train import (
     TrainingModelSpec,
     _build_target_summary,
     _evaluate_model_spec,
-    _materialize_split_indices,
     _json_ready,
     run_training,
 )
@@ -183,14 +183,12 @@ def run_tuning(
             configured_positive_label=positive_label,
         )
 
-    split_indices = _materialize_split_indices(
-        task_type=task_type,
-        x_train_raw=x_train_raw,
-        y_train=y_train,
-        n_splits=config.cv_n_splits,
-        shuffle=config.cv_shuffle,
-        random_state=config.cv_random_state,
+    prepared_context = ensure_prepared_competition_context(
+        config=config,
+        dataset_context=dataset_context,
+        expected_feature_columns=x_train_raw.columns.tolist(),
     )
+    split_indices = prepared_context.split_indices
     target_summary = _build_target_summary(
         task_type=task_type,
         y_train=y_train,


### PR DESCRIPTION
Closes #73

Summary
- add a competition preparation module that writes artifacts/<competition_slug>/competition.json and folds.csv
- add a prepare CLI stage and make the default pipeline run fetch -> prepare -> train -> submit
- make train and tune consume the prepared frozen folds instead of generating their own CV splits
- update README and technical guide for the new workflow contract

Verification
- uv run python main.py prepare with a temporary smoke-binary-canonical config
- uv run python main.py train on the prepared smoke dataset
- uv run python main.py tune with 2 Optuna trials on the same prepared smoke dataset
- PYTHONPATH=src .venv/bin/python -m compileall main.py src/tabular_shenanigans
- confirmed artifacts/smoke-binary-canonical/competition.json and folds.csv were written, with 240 training rows split evenly across 3 folds
