### PR TITLE
Rewrite training around single candidate artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The repository is developed and manually verified primarily against these Playgr
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Freeze CV assignments once per prepared competition context and reuse them across `train` and `tune`.
-- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `preprocess`, `train`, and submit-only flows against explicit run artifacts.
+- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `preprocess`, `train`, and submit-only flows against explicit artifact directories.
 - Run an explicit `tune` stage that evaluates Optuna trials for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes study artifacts, and retrains the best trial into the standard training artifact layout.
 - Train one cross-validated model candidate at a time using config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
-- Write a run-root `model_summary.csv`, task-aware run diagnostics, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`, with per-model prediction artifacts under `<run_id>/<model_id>/`.
+- Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
 - Write tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, including `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`.
-- Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the best model in the run or an explicitly selected model artifact.
+- Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact or an explicit legacy run artifact.
 
 ## Tooling
 - Python for orchestration
@@ -68,7 +68,7 @@ Available stage-specific commands:
 - `uv run python main.py preprocess`
 - `uv run python main.py train`
 - `uv run python main.py tune`
-- `uv run python main.py submit --run-dir artifacts/<competition_slug>/train/<run_id>`
+- `uv run python main.py submit --run-dir artifacts/<competition_slug>/candidates/<candidate_id>`
 - `uv run python main.py submit --run-id <run_id>`
 
 Stage behavior:
@@ -76,17 +76,17 @@ Stage behavior:
 - `prepare`: fetches if needed, writes EDA report CSVs, persists `competition.json`, and freezes `folds.csv`
 - `eda`: fetches if needed, then writes EDA report CSVs
 - `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
-- `train`: fetches if needed, prepares competition context when it is missing, then trains and writes normal training artifacts on the frozen folds
-- `tune`: fetches if needed, prepares competition context when it is missing, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true` on the frozen folds, writes tuning artifacts, then retrains the best trial into the normal training artifact layout
-- `submit`: requires an explicit existing run selection and never retrains implicitly
+- `train`: fetches if needed, prepares competition context when it is missing, then trains and writes one candidate artifact directory on the frozen folds
+- `tune`: fetches if needed, prepares competition context when it is missing, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true` on the frozen folds, writes tuning artifacts, then retrains the best trial into the normal candidate artifact layout
+- `submit`: requires an explicit existing artifact directory and never retrains implicitly
 
 The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
 - `preprocess_summary.csv`
 - `preprocess_features.csv`
 - `preprocess_models.csv`
 
-`submit` can take an optional `--model-id` when targeting a specific model artifact from a multi-model run.
-The default submit path supports current manifest-backed run artifacts only. Older local artifact layouts are unsupported and fail with direct errors.
+`submit` can take an optional `--model-id` only when targeting a legacy multi-model run artifact.
+The default submit path supports current candidate artifacts and legacy manifest-backed run artifacts. Older local artifact layouts are unsupported and fail with direct errors.
 
 ## Config Overview
 Tracked example configs:
@@ -155,7 +155,7 @@ Binary prediction artifact contract:
 - `roc_auc` and `log_loss`: `test_predictions.csv` and `submission.csv` contain positive-class probabilities in `[0, 1]`
 - `accuracy`: `test_predictions.csv` and `submission.csv` contain predicted class labels from the observed binary label set
 
-If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `run_manifest.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected run manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
+If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `candidate.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected artifact manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
 The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id` so the existing train, tune, and submit paths can continue working during the transition to the broader candidate-centric workflow.
 
@@ -179,9 +179,9 @@ Manual verification for each target:
 - run `uv run python main.py prepare`
 - confirm `artifacts/<competition_slug>/competition.json` and `artifacts/<competition_slug>/folds.csv` are written
 - confirm the pipeline infers `id_column` and `label_column` without overrides
-- confirm `artifacts/<competition_slug>/train/<run_id>/model_summary.csv` is written
-- confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv` is written for the resolved internal model artifact
-- confirm `artifacts/<competition_slug>/train/<run_id>/<model_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order, for the submitted model
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written for the resolved internal model artifact
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
 Manual verification for tuning:
@@ -191,7 +191,7 @@ Manual verification for tuning:
   - regression: `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
 - confirm `artifacts/<competition_slug>/tune/<study_id>/study_manifest.json` is written
 - confirm `artifacts/<competition_slug>/tune/<study_id>/trials.csv` records trial state, score, and params
-- confirm `artifacts/<competition_slug>/train/<run_id>/run_manifest.json` records `tuning_provenance`
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` records `tuning_provenance`
 
 ## Outputs
 - Competition data: `data/<competition_slug>/`
@@ -202,14 +202,10 @@ Manual verification for tuning:
   - when `preprocess` stage is run, also includes `preprocess_summary.csv`, `preprocess_features.csv`, and `preprocess_models.csv`
 - Tuning artifacts: `artifacts/<competition_slug>/tune/<study_id>/`
   - includes `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`
-- Training artifacts: `artifacts/<competition_slug>/train/<run_id>/`
-  - includes `run_diagnostics.csv`, `model_summary.csv`, and `run_manifest.json`
-  - includes per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/`
-  - each model subdirectory includes `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
-  - `run_manifest.json` is the canonical per-run metadata source
-  - each model summary/manifest entry records the resolved `preprocessing_scheme_id`
-  - tuned retrain runs also record `tuning_provenance`
-- Run ledger: `artifacts/<competition_slug>/train/runs.csv` as a compact comparison/history table
+- Candidate artifacts: `artifacts/<competition_slug>/candidates/<candidate_id>/`
+  - includes `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
+  - `candidate.json` is the canonical training metadata source
+  - tuned retrain candidates also record `tuning_provenance`
 - Submission ledger: `artifacts/<competition_slug>/train/submissions.csv` as an append-only submission event table
 
 ## Current Assumptions
@@ -218,13 +214,13 @@ Manual verification for tuning:
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
-- The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; run artifacts still record that resolved `model_id` and `preprocessing_scheme_id`.
+- The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` and `tune` consume that frozen context and auto-run `prepare` only when it is missing.
-- The `tune` stage uses the current experiment candidate only, and the tuned best-trial retrain writes a standard single-model train artifact with `tuning_provenance`.
-- Submission uses `run_manifest.json` as the canonical source for `competition_slug`, `task_type`, `id_column`, and `label_column`.
-- Submission metadata includes the selected `model_id`; when no model is selected explicitly, submission defaults to the run manifest `best_model_id`.
+- The `tune` stage uses the current experiment candidate only, and the tuned best-trial retrain writes a standard single-candidate artifact with `tuning_provenance`.
+- Submission uses `candidate.json` for current artifacts and `run_manifest.json` for legacy run artifacts as the schema/task source of truth.
+- Submission metadata includes the selected `model_id`; current candidate artifacts contain exactly one `model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
-- Submission requires the current per-model artifact layout under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
+- Submission supports the current candidate artifact layout under `artifacts/<competition_slug>/candidates/<candidate_id>/` and legacy run artifacts under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
 - Binary classification supports any two-class labels accepted by scikit-learn.
 - For binary `roc_auc` and `log_loss`, prediction artifacts use probabilities aligned to the resolved positive class.
 - For binary `accuracy`, prediction artifacts use class labels from the observed binary label set.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -18,11 +18,10 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 8. Resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
    - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
    - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
-9. Write run-level diagnostics, `model_summary.csv`, and a canonical `run_manifest.json` under `artifacts/<competition_slug>/train/<run_id>/`.
-10. Write per-model fold metrics, OOF predictions, and test predictions under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
-11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `run_manifest.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected model directory, and optionally submit to Kaggle.
+9. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
+10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` for current candidate artifacts or `run_manifest.json` for legacy run artifacts, apply metric-aware binary prediction validation, write `submission.csv` in the selected artifact directory, and optionally submit to Kaggle.
 
-When the explicit `tune` stage is selected, the workflow additionally loads the frozen fold assignments from `folds.csv`, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard train artifact layout with `tuning_provenance` recorded in `run_manifest.json`.
+When the explicit `tune` stage is selected, the workflow additionally loads the frozen fold assignments from `folds.csv`, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard candidate artifact layout with `tuning_provenance` recorded in `candidate.json`.
 
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `prepare` -> `train` -> `submit`)
@@ -30,14 +29,14 @@ When the explicit `tune` stage is selected, the workflow additionally loads the 
 - `uv run python main.py prepare`: fetch if needed, load the shared dataset context, write EDA reports, persist competition metadata, and freeze folds
 - `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
 - `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
-- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, and write training artifacts on the frozen folds
-- `uv run python main.py tune`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into normal training artifacts on the frozen folds
-- `uv run python main.py submit --run-dir artifacts/.../train/<run_id>`: prepare or submit from an explicit existing run artifact
+- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, and write one candidate artifact directory on the frozen folds
+- `uv run python main.py tune`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into a normal candidate artifact directory on the frozen folds
+- `uv run python main.py submit --run-dir artifacts/.../candidates/<candidate_id>`: prepare or submit from an explicit current candidate artifact
 - `uv run python main.py submit --run-id <run_id>`: resolve the run under `artifacts/<competition_slug>/train/<run_id>` using the configured competition slug
 
 The `preprocess` stage is intentionally diagnostic. It is not part of the default runtime contract and it does not create a second training artifact layout.
 
-The default `submit` path supports current manifest-backed run artifacts only. Unsupported older local artifact layouts fail directly instead of using compatibility fallbacks.
+The default `submit` path supports current candidate artifacts plus legacy manifest-backed run artifacts. Unsupported older local artifact layouts fail directly.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, preprocess diagnostics, training, tuning, and submission.
@@ -48,9 +47,9 @@ The default `submit` path supports current manifest-backed run artifacts only. U
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, artifact writing, and run ledger updates.
-- `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate on the frozen fold assignments, study artifact writing, and best-trial retraining into the standard train artifact layout.
-- `src/tabular_shenanigans/submit.py`: submission schema validation, model-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
+- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, candidate artifact writing, and candidate manifest generation.
+- `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate on the frozen fold assignments, study artifact writing, and best-trial retraining into the standard candidate artifact layout.
+- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate-or-legacy-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
 Input:
@@ -124,12 +123,12 @@ Manual verification steps for each target:
 - confirm `artifacts/<competition_slug>/competition.json` and `artifacts/<competition_slug>/folds.csv` are generated
 - run the workflow from a clean repo state with explicit `competition` plus one current `experiment.candidate`
 - confirm inferred `id_column` and `label_column`
-- confirm `model_summary.csv` is generated in the run directory
-- confirm `test_predictions.csv` is generated in each model directory
-- confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected model directory
+- confirm `candidate.json` is generated in the candidate directory
+- confirm `test_predictions.csv` is generated in the candidate directory
+- confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected candidate directory
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 - when tuning is enabled, run `uv run python main.py tune` and confirm `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json` are generated under `artifacts/<competition_slug>/tune/<study_id>/`
-- when tuning is enabled, confirm the best-trial retrain writes a standard train artifact and records `tuning_provenance` in `run_manifest.json`
+- when tuning is enabled, confirm the best-trial retrain writes a standard candidate artifact and records `tuning_provenance` in `candidate.json`
 
 ## Artifact Contract
 - A validated in-memory config object from Pydantic
@@ -150,24 +149,19 @@ Manual verification steps for each target:
     - `preprocess_summary.csv`
     - `preprocess_features.csv`
     - `preprocess_models.csv`
-- Training artifacts under `artifacts/<competition_slug>/train/<run_id>/`:
-  - `run_diagnostics.csv`
-  - `model_summary.csv`
-  - `run_manifest.json`
-  - per-model subdirectories `artifacts/<competition_slug>/train/<run_id>/<model_id>/` containing:
-    - `fold_metrics.csv`
-    - `oof_predictions.csv`
-    - `test_predictions.csv`
-    - `submission.csv` when prepared or submitted
-- `run_manifest.json` is the canonical per-run metadata source
-- Each model entry in `model_summary.csv` and `run_manifest.json` records the resolved `preprocessing_scheme_id`
-- tuned retrain runs record `tuning_provenance` in `run_manifest.json`
+- Candidate artifacts under `artifacts/<competition_slug>/candidates/<candidate_id>/`:
+  - `candidate.json`
+  - `fold_metrics.csv`
+  - `oof_predictions.csv`
+  - `test_predictions.csv`
+  - `submission.csv` when prepared or submitted
+- `candidate.json` is the canonical current training metadata source
+- tuned retrain candidates record `tuning_provenance` in `candidate.json`
 - Tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`:
   - `study_manifest.json`
   - `study_summary.csv`
   - `trials.csv`
   - `best_params.json`
-- Training ledger at `artifacts/<competition_slug>/train/runs.csv` with compact comparison fields and task-aware target summary fields
 - Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv` with submission event metadata only
 
 ## Runtime Invariants And Failure Behavior
@@ -181,9 +175,11 @@ Manual verification steps for each target:
 - `train` and `tune` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
 - the current runtime supports one `experiment.candidate` of type `model`
 - `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
-- the `tune` stage requires `experiment.candidate.optimization.enabled=true`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal train artifact layout
+- training must write exactly one candidate artifact directory keyed by `candidate_id`
+- rerunning an existing `candidate_id` must fail instead of mutating an existing artifact directory
+- the `tune` stage requires `experiment.candidate.optimization.enabled=true`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
-- Submit-time `model_id` remains the trained-model selector for choosing one artifact from a run
+- Submit-time `model_id` remains relevant only for legacy multi-model run artifacts
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
@@ -195,11 +191,11 @@ Manual verification steps for each target:
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
-- Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `run_manifest.json` rather than re-inferring them from raw train/test data
-- Multi-model submission must default to `best_model_id` unless a specific `model_id` is requested explicitly
+- Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `candidate.json` for current artifacts and `run_manifest.json` for legacy artifacts rather than re-inferring them from raw train/test data
+- Legacy multi-model submission must default to `best_model_id` unless a specific `model_id` is requested explicitly
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
 - The selected model artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
-- Submission requires the current per-model prediction layout at `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv`
+- Submission requires the current candidate prediction layout at `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` or the legacy per-model run layout at `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv`
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
@@ -234,8 +230,9 @@ Hard-error cases include:
 - Unsupported metric for chosen task -> hard error
 - Any CV/training fit or scoring failure -> hard error
 - Fold assignment gaps in OOF generation -> hard error
-- Requested submission `model_id` not present in the run manifest -> hard error
-- Missing or legacy-shaped submit artifacts outside the current manifest-backed per-model contract -> hard error
+- Candidate artifact directory already exists for the configured `candidate_id` -> hard error
+- Requested submission `model_id` not present in the legacy run manifest -> hard error
+- Missing or unsupported submit artifacts outside the current candidate contract or legacy run-manifest contract -> hard error
 - Submission schema or ID mismatch against `sample_submission.csv` -> hard error
 - Binary probability artifact outside `[0, 1]` for `roc_auc` or `log_loss` -> hard error
 - Binary label artifact containing values outside the observed label pair for `accuracy` -> hard error

--- a/main.py
+++ b/main.py
@@ -24,23 +24,23 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("prepare", help="Persist EDA reports, competition metadata, and frozen folds.")
     subparsers.add_parser("eda", help="Run EDA reports only.")
     subparsers.add_parser("preprocess", help="Write preprocessing diagnostics only.")
-    subparsers.add_parser("train", help="Run training only.")
+    subparsers.add_parser("train", help="Train the current candidate only.")
     subparsers.add_parser("tune", help="Run Optuna tuning and retrain the best trial.")
 
-    submit_parser = subparsers.add_parser("submit", help="Prepare or submit from an existing run artifact.")
+    submit_parser = subparsers.add_parser("submit", help="Prepare or submit from an existing artifact directory.")
     run_selection = submit_parser.add_mutually_exclusive_group(required=True)
     run_selection.add_argument(
         "--run-dir",
         type=Path,
-        help="Explicit run directory such as artifacts/<competition_slug>/train/<run_id>.",
+        help="Explicit artifact directory such as artifacts/<competition_slug>/candidates/<candidate_id>.",
     )
     run_selection.add_argument(
         "--run-id",
-        help="Run identifier resolved under artifacts/<competition_slug>/train/<run_id> using config.competition_slug.",
+        help="Legacy run identifier resolved under artifacts/<competition_slug>/train/<run_id> using config.competition_slug.",
     )
     submit_parser.add_argument(
         "--model-id",
-        help="Optional model_id to submit from a multi-model run; defaults to the run manifest best_model_id.",
+        help="Optional model_id for legacy multi-model run artifacts; ignored for current single-candidate artifacts.",
     )
 
     return parser
@@ -69,7 +69,7 @@ def _load_shared_dataset_context(config: AppConfig):
     )
 
 
-def _resolve_run_dir(config: AppConfig, args: argparse.Namespace) -> Path:
+def _resolve_artifact_dir(config: AppConfig, args: argparse.Namespace) -> Path:
     if args.run_dir is not None:
         return args.run_dir
     return Path("artifacts") / config.competition_slug / "train" / str(args.run_id)
@@ -87,9 +87,9 @@ def _prepare_competition_stage(config: AppConfig):
 
 def _run_full_pipeline(config: AppConfig) -> None:
     dataset_context, _ = _prepare_competition_stage(config)
-    train_dir = run_training(config=config, dataset_context=dataset_context)
-    print(f"Training artifacts ready: {train_dir}")
-    submission_path, submission_status = run_submission(config=config, run_dir=train_dir)
+    candidate_dir = run_training(config=config, dataset_context=dataset_context)
+    print(f"Candidate artifacts ready: {candidate_dir}")
+    submission_path, submission_status = run_submission(config=config, artifact_dir=candidate_dir)
     print(f"Submission file ready: {submission_path} ({submission_status})")
 
 
@@ -110,8 +110,8 @@ def _run_preprocess_stage(config: AppConfig) -> None:
 def _run_train_stage(config: AppConfig) -> None:
     _ensure_data_ready(config)
     dataset_context = _load_shared_dataset_context(config)
-    train_dir = run_training(config=config, dataset_context=dataset_context)
-    print(f"Training artifacts ready: {train_dir}")
+    candidate_dir = run_training(config=config, dataset_context=dataset_context)
+    print(f"Candidate artifacts ready: {candidate_dir}")
 
 
 def _run_tune_stage(config: AppConfig) -> None:
@@ -119,15 +119,15 @@ def _run_tune_stage(config: AppConfig) -> None:
     dataset_context = _load_shared_dataset_context(config)
     tuning_result = run_tuning(config=config, dataset_context=dataset_context)
     print(f"Tuning artifacts ready: {tuning_result.study_dir}")
-    print(f"Best-trial training artifacts ready: {tuning_result.train_dir}")
+    print(f"Best-trial candidate artifacts ready: {tuning_result.candidate_dir}")
 
 
 def _run_submit_stage(config: AppConfig, args: argparse.Namespace) -> None:
-    run_dir = _resolve_run_dir(config, args)
-    print(f"Using run_dir: {run_dir}")
+    artifact_dir = _resolve_artifact_dir(config, args)
+    print(f"Using artifact_dir: {artifact_dir}")
     submission_path, submission_status = run_submission(
         config=config,
-        run_dir=run_dir,
+        artifact_dir=artifact_dir,
         model_id=args.model_id,
     )
     print(f"Submission file ready: {submission_path} ({submission_status})")

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -26,7 +26,8 @@ SUBMISSION_LEDGER_COLUMNS = [
 
 @dataclass(frozen=True)
 class SubmissionContext:
-    run_id: str
+    artifact_kind: str
+    artifact_id: str
     competition_slug: str
     task_type: str
     primary_metric: str
@@ -63,27 +64,33 @@ def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None
     ledger_df.to_csv(ledger_path, index=False)
 
 
-def _load_run_manifest(run_dir: Path) -> dict[str, object]:
-    manifest_path = run_dir / "run_manifest.json"
+def _load_json_manifest(manifest_path: Path, description: str) -> dict[str, object]:
     if not manifest_path.exists():
-        raise ValueError(
-            f"Missing run manifest: {manifest_path}. Submission requires current manifest-backed run artifacts."
-        )
-    return json.loads(manifest_path.read_text(encoding="utf-8"))
+        raise ValueError(f"Missing {description}: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError(f"{description.capitalize()} must be a JSON object: {manifest_path}")
+    return manifest
 
 
-def _require_manifest_value(manifest: dict[str, object], field_name: str) -> object:
+def _require_manifest_value(manifest: dict[str, object], field_name: str, description: str) -> object:
     field_value = manifest.get(field_name)
     if field_value is None:
-        raise ValueError(
-            f"Run manifest is missing required submission field '{field_name}'. "
-            "Submission requires current manifest-backed run artifacts."
-        )
+        raise ValueError(f"{description.capitalize()} is missing required field '{field_name}'.")
     return field_value
 
 
-def _load_manifest_models(manifest: dict[str, object]) -> list[dict[str, object]]:
-    manifest_models = manifest.get("models")
+def _parse_observed_label_pair(manifest: dict[str, object], description: str) -> tuple[object, object] | None:
+    observed_label_pair_raw = manifest.get("observed_label_pair")
+    if observed_label_pair_raw is None:
+        return None
+    if not isinstance(observed_label_pair_raw, list) or len(observed_label_pair_raw) != 2:
+        raise ValueError(f"{description.capitalize()} observed_label_pair must contain exactly two labels when present.")
+    return (observed_label_pair_raw[0], observed_label_pair_raw[1])
+
+
+def _load_manifest_models(run_manifest: dict[str, object]) -> list[dict[str, object]]:
+    manifest_models = run_manifest.get("models")
     if not isinstance(manifest_models, list) or not manifest_models:
         raise ValueError(
             "Run manifest must contain a non-empty 'models' list. "
@@ -94,11 +101,11 @@ def _load_manifest_models(manifest: dict[str, object]) -> list[dict[str, object]
     return manifest_models
 
 
-def _resolve_selected_model(
-    manifest: dict[str, object],
+def _resolve_selected_legacy_model(
+    run_manifest: dict[str, object],
     requested_model_id: str | None = None,
 ) -> tuple[str, dict[str, object]]:
-    manifest_models = _load_manifest_models(manifest)
+    manifest_models = _load_manifest_models(run_manifest)
     available_model_ids = [str(model["model_id"]) for model in manifest_models]
 
     if requested_model_id is not None:
@@ -109,7 +116,7 @@ def _resolve_selected_model(
                 f"Available model_ids: {available_model_ids}"
             )
     else:
-        best_model_id = manifest.get("best_model_id")
+        best_model_id = run_manifest.get("best_model_id")
         if best_model_id is None:
             raise ValueError(
                 "Run manifest is missing required submission field 'best_model_id'. "
@@ -133,47 +140,7 @@ def _resolve_selected_model(
     return selected_model_id, selected_model
 
 
-def _parse_observed_label_pair(manifest: dict[str, object]) -> tuple[object, object] | None:
-    observed_label_pair_raw = manifest.get("observed_label_pair")
-    if observed_label_pair_raw is not None:
-        if not isinstance(observed_label_pair_raw, list) or len(observed_label_pair_raw) != 2:
-            raise ValueError("Run manifest observed_label_pair must contain exactly two labels when present.")
-        return (observed_label_pair_raw[0], observed_label_pair_raw[1])
-    return None
-
-
-def _load_submission_context(
-    run_dir: Path,
-    model_id: str | None = None,
-) -> SubmissionContext:
-    manifest = _load_run_manifest(run_dir)
-    selected_model_id, selected_model = _resolve_selected_model(manifest, requested_model_id=model_id)
-    cv_summary = selected_model.get("cv_summary")
-    if not isinstance(cv_summary, dict):
-        raise ValueError("Run manifest model cv_summary must be a mapping.")
-    prediction_path = _resolve_prediction_path(run_dir=run_dir, model_id=selected_model_id)
-
-    return SubmissionContext(
-        run_id=str(_require_manifest_value(manifest, "run_id")),
-        competition_slug=str(_require_manifest_value(manifest, "competition_slug")),
-        task_type=str(_require_manifest_value(manifest, "task_type")),
-        primary_metric=str(_require_manifest_value(manifest, "primary_metric")),
-        model_id=selected_model_id,
-        model_name=str(selected_model["model_name"]),
-        metric_name=str(cv_summary["metric_name"]),
-        metric_mean=float(cv_summary["metric_mean"]),
-        id_column=str(_require_manifest_value(manifest, "id_column")),
-        label_column=str(_require_manifest_value(manifest, "label_column")),
-        observed_label_pair=_parse_observed_label_pair(manifest),
-        config_fingerprint=manifest.get("config_fingerprint"),
-        prediction_path=prediction_path,
-    )
-
-
-def _resolve_prediction_path(
-    run_dir: Path,
-    model_id: str,
-) -> Path:
+def _resolve_legacy_prediction_path(run_dir: Path, model_id: str) -> Path:
     prediction_path = run_dir / model_id / "test_predictions.csv"
     if prediction_path.exists():
         return prediction_path
@@ -181,6 +148,94 @@ def _resolve_prediction_path(
         "Missing test predictions file for submission. "
         f"Expected current per-model artifact at {prediction_path}"
     )
+
+
+def _load_legacy_submission_context(
+    run_dir: Path,
+    model_id: str | None = None,
+) -> SubmissionContext:
+    run_manifest = _load_json_manifest(
+        manifest_path=run_dir / "run_manifest.json",
+        description="run manifest",
+    )
+    selected_model_id, selected_model = _resolve_selected_legacy_model(run_manifest, requested_model_id=model_id)
+    cv_summary = selected_model.get("cv_summary")
+    if not isinstance(cv_summary, dict):
+        raise ValueError("Run manifest model cv_summary must be a mapping.")
+    prediction_path = _resolve_legacy_prediction_path(run_dir=run_dir, model_id=selected_model_id)
+
+    return SubmissionContext(
+        artifact_kind="run",
+        artifact_id=str(_require_manifest_value(run_manifest, "run_id", "run manifest")),
+        competition_slug=str(_require_manifest_value(run_manifest, "competition_slug", "run manifest")),
+        task_type=str(_require_manifest_value(run_manifest, "task_type", "run manifest")),
+        primary_metric=str(_require_manifest_value(run_manifest, "primary_metric", "run manifest")),
+        model_id=selected_model_id,
+        model_name=str(selected_model["model_name"]),
+        metric_name=str(cv_summary["metric_name"]),
+        metric_mean=float(cv_summary["metric_mean"]),
+        id_column=str(_require_manifest_value(run_manifest, "id_column", "run manifest")),
+        label_column=str(_require_manifest_value(run_manifest, "label_column", "run manifest")),
+        observed_label_pair=_parse_observed_label_pair(run_manifest, "run manifest"),
+        config_fingerprint=run_manifest.get("config_fingerprint"),
+        prediction_path=prediction_path,
+    )
+
+
+def _resolve_candidate_prediction_path(candidate_dir: Path) -> Path:
+    prediction_path = candidate_dir / "test_predictions.csv"
+    if prediction_path.exists():
+        return prediction_path
+    raise ValueError(
+        "Missing test predictions file for submission. "
+        f"Expected current candidate artifact at {prediction_path}"
+    )
+
+
+def _load_candidate_submission_context(
+    candidate_dir: Path,
+    model_id: str | None = None,
+) -> SubmissionContext:
+    candidate_manifest = _load_json_manifest(
+        manifest_path=candidate_dir / "candidate.json",
+        description="candidate manifest",
+    )
+    selected_model_id = str(_require_manifest_value(candidate_manifest, "model_id", "candidate manifest"))
+    if model_id is not None and model_id != selected_model_id:
+        raise ValueError(
+            "Candidate artifacts contain exactly one model. "
+            f"Requested model_id '{model_id}', available model_id '{selected_model_id}'."
+        )
+
+    cv_summary = candidate_manifest.get("cv_summary")
+    if not isinstance(cv_summary, dict):
+        raise ValueError("Candidate manifest cv_summary must be a mapping.")
+    prediction_path = _resolve_candidate_prediction_path(candidate_dir)
+    return SubmissionContext(
+        artifact_kind="candidate",
+        artifact_id=str(_require_manifest_value(candidate_manifest, "candidate_id", "candidate manifest")),
+        competition_slug=str(_require_manifest_value(candidate_manifest, "competition_slug", "candidate manifest")),
+        task_type=str(_require_manifest_value(candidate_manifest, "task_type", "candidate manifest")),
+        primary_metric=str(_require_manifest_value(candidate_manifest, "primary_metric", "candidate manifest")),
+        model_id=selected_model_id,
+        model_name=str(_require_manifest_value(candidate_manifest, "model_name", "candidate manifest")),
+        metric_name=str(cv_summary["metric_name"]),
+        metric_mean=float(cv_summary["metric_mean"]),
+        id_column=str(_require_manifest_value(candidate_manifest, "id_column", "candidate manifest")),
+        label_column=str(_require_manifest_value(candidate_manifest, "label_column", "candidate manifest")),
+        observed_label_pair=_parse_observed_label_pair(candidate_manifest, "candidate manifest"),
+        config_fingerprint=candidate_manifest.get("config_fingerprint"),
+        prediction_path=prediction_path,
+    )
+
+
+def _load_submission_context(
+    artifact_dir: Path,
+    model_id: str | None = None,
+) -> SubmissionContext:
+    if (artifact_dir / "candidate.json").exists():
+        return _load_candidate_submission_context(candidate_dir=artifact_dir, model_id=model_id)
+    return _load_legacy_submission_context(run_dir=artifact_dir, model_id=model_id)
 
 
 def _validate_submission_ids(
@@ -255,7 +310,7 @@ def _validate_binary_label_predictions(
 ) -> None:
     if observed_label_pair is None:
         raise ValueError(
-            "Binary label submissions require observed_label_pair metadata in the run manifest."
+            "Binary label submissions require observed_label_pair metadata in the artifact manifest."
         )
     if not prediction_values.map(pd.notna).all():
         raise ValueError("Binary label submissions contain missing values.")
@@ -281,7 +336,6 @@ def _prepare_submission_file_from_context(submission_context: SubmissionContext)
 
     expected_columns = [submission_context.id_column, submission_context.label_column]
     actual_columns = prediction_df.columns.tolist()
-
     if actual_columns != expected_columns:
         raise ValueError(
             "Submission columns do not match sample_submission.csv. "
@@ -292,6 +346,7 @@ def _prepare_submission_file_from_context(submission_context: SubmissionContext)
             "Submission row count does not match sample_submission.csv. "
             f"Expected {sample_submission_df.shape[0]}, got {prediction_df.shape[0]}"
         )
+
     if submission_context.task_type == "binary":
         prediction_values = prediction_df[submission_context.label_column]
         binary_prediction_kind = get_binary_prediction_kind(submission_context.primary_metric)
@@ -302,6 +357,7 @@ def _prepare_submission_file_from_context(submission_context: SubmissionContext)
                 prediction_values=prediction_values,
                 observed_label_pair=submission_context.observed_label_pair,
             )
+
     _validate_submission_ids(
         prediction_df=prediction_df,
         sample_submission_df=sample_submission_df,
@@ -314,10 +370,10 @@ def _prepare_submission_file_from_context(submission_context: SubmissionContext)
 
 
 def prepare_submission_file(
-    run_dir: Path,
+    artifact_dir: Path,
     model_id: str | None = None,
 ) -> Path:
-    submission_context = _load_submission_context(run_dir=run_dir, model_id=model_id)
+    submission_context = _load_submission_context(artifact_dir=artifact_dir, model_id=model_id)
     return _prepare_submission_file_from_context(submission_context)
 
 
@@ -328,27 +384,27 @@ def _build_submission_message_from_context(
     message_parts = []
     if submit_message_prefix:
         message_parts.append(submit_message_prefix.strip())
-    message_parts.append(f"run={submission_context.run_id}")
+    message_parts.append(f"{submission_context.artifact_kind}={submission_context.artifact_id}")
     message_parts.append(f"model={submission_context.model_id}")
     message_parts.append(f"{submission_context.metric_name}={submission_context.metric_mean:.6f}")
     return " | ".join(message_parts)
 
 
 def build_submission_message(
-    run_dir: Path,
+    artifact_dir: Path,
     submit_message_prefix: str | None = None,
     model_id: str | None = None,
 ) -> str:
-    submission_context = _load_submission_context(run_dir=run_dir, model_id=model_id)
+    submission_context = _load_submission_context(artifact_dir=artifact_dir, model_id=model_id)
     return _build_submission_message_from_context(submission_context, submit_message_prefix=submit_message_prefix)
 
 
 def run_submission(
     config: AppConfig,
-    run_dir: Path,
+    artifact_dir: Path,
     model_id: str | None = None,
 ) -> tuple[Path, str]:
-    submission_context = _load_submission_context(run_dir=run_dir, model_id=model_id)
+    submission_context = _load_submission_context(artifact_dir=artifact_dir, model_id=model_id)
     submission_path = _prepare_submission_file_from_context(submission_context)
     message = _build_submission_message_from_context(
         submission_context,
@@ -384,7 +440,7 @@ def run_submission(
     ledger_row = {
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
         "competition_slug": submission_context.competition_slug,
-        "run_id": submission_context.run_id,
+        "run_id": submission_context.artifact_id,
         "model_id": submission_context.model_id,
         "model_name": submission_context.model_name,
         "config_fingerprint": submission_context.config_fingerprint,
@@ -395,5 +451,4 @@ def run_submission(
     }
     ledger_path = Path("artifacts") / submission_context.competition_slug / "train" / "submissions.csv"
     _append_submission_ledger(ledger_path=ledger_path, row=ledger_row)
-
     return submission_path, status

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -1,6 +1,6 @@
 import hashlib
 import json
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -13,35 +13,6 @@ from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, sco
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
-
-RUN_LEDGER_COLUMNS = [
-    "run_id",
-    "timestamp_utc",
-    "competition_slug",
-    "task_type",
-    "primary_metric",
-    "best_model_id",
-    "best_model_name",
-    "cv_mean",
-    "cv_std",
-    "higher_is_better",
-    "model_count",
-    "cv_n_splits",
-    "cv_shuffle",
-    "cv_random_state",
-    "config_fingerprint",
-    "target_mean",
-    "target_std",
-    "target_min",
-    "target_max",
-    "positive_count",
-    "negative_count",
-    "target_prevalence",
-    "positive_label",
-    "observed_label_1",
-    "observed_label_2",
-    "negative_label",
-]
 
 
 @dataclass(frozen=True)
@@ -67,39 +38,17 @@ class ModelRunResult:
     preprocessing_scheme_id: str
     model_params: dict[str, object]
     cv_summary: CvSummary
-    rank: int | None = None
-    is_best_model: bool = False
 
-    def require_rank(self) -> int:
-        if self.rank is None:
-            raise ValueError("Model run result must be ranked before writing run-level artifacts.")
-        return self.rank
-
-    def to_model_summary_row(self) -> dict[str, object]:
-        return {
-            "model_id": self.model_id,
-            "model_name": self.model_name,
-            "preprocessing_scheme_id": self.preprocessing_scheme_id,
-            "metric_name": self.cv_summary.metric_name,
-            "cv_mean": self.cv_summary.metric_mean,
-            "cv_std": self.cv_summary.metric_std,
-            "higher_is_better": self.cv_summary.higher_is_better,
-            "rank": self.require_rank(),
-            "is_best_model": self.is_best_model,
-        }
-
-    def to_manifest_model_entry(self) -> dict[str, object]:
+    def to_manifest_entry(self) -> dict[str, object]:
         return {
             "model_id": self.model_id,
             "model_name": self.model_name,
             "preprocessing_scheme_id": self.preprocessing_scheme_id,
             "model_params": self.model_params,
             "cv_summary": self.cv_summary.to_dict(),
-            "rank": self.require_rank(),
-            "is_best_model": self.is_best_model,
         }
 
-    def to_fingerprint_model_entry(self) -> dict[str, object]:
+    def to_fingerprint_entry(self) -> dict[str, object]:
         return {
             "model_id": self.model_id,
             "model_params": self.model_params,
@@ -120,33 +69,6 @@ class ModelEvaluationArtifacts:
     final_test_predictions: np.ndarray
 
 
-@dataclass(frozen=True)
-class TrainingRunContext:
-    run_id: str
-    generated_at_utc: str
-    competition_slug: str
-    task_type: str
-    primary_metric: str
-    config_snapshot: dict[str, object]
-    config_fingerprint: str
-    model_results: list[ModelRunResult]
-    best_model_result: ModelRunResult
-    observed_label_pair: tuple[object, object] | None
-    negative_label: object | None
-    positive_label: object | None
-    id_column: str
-    label_column: str
-    target_summary: dict[str, object]
-    train_rows: int
-    train_cols: int
-    test_rows: int
-    test_cols: int
-    cv_n_splits: int
-    cv_shuffle: bool
-    cv_random_state: int
-    tuning_provenance: dict[str, object] | None = None
-
-
 def _json_ready(value: object) -> object:
     if isinstance(value, dict):
         return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
@@ -159,72 +81,16 @@ def _json_ready(value: object) -> object:
     return value
 
 
-def _make_run_id() -> str:
-    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-
-
-def _resolve_training_model_specs(
+def _resolve_training_model_spec(
     config: AppConfig,
-    model_specs: list[TrainingModelSpec] | None = None,
-) -> list[TrainingModelSpec]:
-    if model_specs is not None:
-        if not model_specs:
-            raise ValueError("Training requires at least one model specification.")
-        return model_specs
-    return [
-        TrainingModelSpec(
-            model_id=model_id,
-            parameter_overrides=config.model_parameter_overrides,
-        )
-        for model_id in config.model_ids
-    ]
-
-
-def _read_run_ledger(ledger_path: Path) -> pd.DataFrame:
-    ledger_df = pd.read_csv(ledger_path)
-    if "best_model_id" not in ledger_df.columns:
-        legacy_model_id = ledger_df["model_id"] if "model_id" in ledger_df.columns else pd.Series("", index=ledger_df.index)
-        ledger_df["best_model_id"] = legacy_model_id
-    if "best_model_name" not in ledger_df.columns:
-        legacy_model_name = (
-            ledger_df["model_name"] if "model_name" in ledger_df.columns else pd.Series("", index=ledger_df.index)
-        )
-        ledger_df["best_model_name"] = legacy_model_name
-    if "model_count" not in ledger_df.columns:
-        ledger_df["model_count"] = 1
-    return ledger_df
-
-
-def _resolve_run_ledger_output_columns(
-    existing_columns: list[str],
-    row_columns: list[str],
-) -> list[str]:
-    extra_columns: list[str] = []
-    seen_extra_columns: set[str] = set()
-    for columns in (existing_columns, row_columns):
-        for column in columns:
-            if column in RUN_LEDGER_COLUMNS or column in seen_extra_columns:
-                continue
-            seen_extra_columns.add(column)
-            extra_columns.append(column)
-    return [*RUN_LEDGER_COLUMNS, *extra_columns]
-
-
-def _append_run_ledger(ledger_path: Path, row: dict[str, object]) -> None:
-    ledger_df = pd.DataFrame([row])
-    if ledger_path.exists():
-        existing_df = _read_run_ledger(ledger_path)
-        output_columns = _resolve_run_ledger_output_columns(
-            existing_columns=existing_df.columns.tolist(),
-            row_columns=ledger_df.columns.tolist(),
-        )
-        merged_df = pd.concat([existing_df, ledger_df], ignore_index=True, sort=False)
-        merged_df = merged_df.reindex(columns=output_columns)
-        merged_df.to_csv(ledger_path, index=False)
-        return
-    output_columns = _resolve_run_ledger_output_columns(existing_columns=[], row_columns=ledger_df.columns.tolist())
-    ledger_df = ledger_df.reindex(columns=output_columns)
-    ledger_df.to_csv(ledger_path, index=False)
+    model_spec: TrainingModelSpec | None = None,
+) -> TrainingModelSpec:
+    if model_spec is not None:
+        return model_spec
+    return TrainingModelSpec(
+        model_id=config.resolved_model_id,
+        parameter_overrides=config.model_parameter_overrides,
+    )
 
 
 def _build_target_summary(
@@ -259,96 +125,6 @@ def _build_target_summary(
         }
 
     raise ValueError(f"Unsupported task_type for target summary: {task_type}")
-
-
-def _build_diagnostic_rows(
-    task_type: str,
-    fold_index: int,
-    split_name: str,
-    y_values: pd.Series,
-    positive_label: object | None = None,
-) -> list[dict[str, object]]:
-    row = {
-        "task_type": task_type,
-        "fold": fold_index,
-        "split": split_name,
-        "row_count": int(y_values.shape[0]),
-        "target_mean": np.nan,
-        "target_std": np.nan,
-        "target_min": np.nan,
-        "target_max": np.nan,
-        "positive_count": np.nan,
-        "negative_count": np.nan,
-        "positive_rate": np.nan,
-    }
-
-    if task_type == "regression":
-        row.update(
-            {
-                "diagnostic_type": "target_distribution",
-                "target_mean": float(y_values.mean()),
-                "target_std": float(y_values.std(ddof=0)),
-                "target_min": float(y_values.min()),
-                "target_max": float(y_values.max()),
-            }
-        )
-        return [row]
-
-    if task_type == "binary":
-        if positive_label is None:
-            raise ValueError("Binary diagnostics require positive_label.")
-        positive_count = int((y_values == positive_label).sum())
-        negative_count = int(y_values.shape[0] - positive_count)
-        row.update(
-            {
-                "diagnostic_type": "class_balance",
-                "positive_label": str(positive_label),
-                "positive_count": positive_count,
-                "negative_count": negative_count,
-                "positive_rate": float(positive_count / y_values.shape[0]),
-            }
-        )
-        return [row]
-
-    raise ValueError(f"Unsupported task_type for diagnostics: {task_type}")
-
-
-def _build_run_diagnostics(
-    task_type: str,
-    y_train: pd.Series,
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-    positive_label: object | None = None,
-) -> pd.DataFrame:
-    run_diagnostics: list[dict[str, object]] = []
-    run_diagnostics.extend(
-        _build_diagnostic_rows(
-            task_type=task_type,
-            fold_index=0,
-            split_name="all",
-            y_values=y_train,
-            positive_label=positive_label,
-        )
-    )
-    for fold_index, train_idx, valid_idx in split_indices:
-        run_diagnostics.extend(
-            _build_diagnostic_rows(
-                task_type=task_type,
-                fold_index=fold_index,
-                split_name="train",
-                y_values=y_train.iloc[train_idx],
-                positive_label=positive_label,
-            )
-        )
-        run_diagnostics.extend(
-            _build_diagnostic_rows(
-                task_type=task_type,
-                fold_index=fold_index,
-                split_name="valid",
-                y_values=y_train.iloc[valid_idx],
-                positive_label=positive_label,
-            )
-        )
-    return pd.DataFrame(run_diagnostics)
 
 
 def _evaluate_model_spec(
@@ -444,8 +220,6 @@ def _evaluate_model_spec(
         test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
         fold_metrics.append(
             {
-                "model_id": resolved_model_id,
-                "model_name": model_name,
                 "fold": fold_index,
                 "metric_name": primary_metric,
                 "metric_value": fold_score,
@@ -484,171 +258,13 @@ def _evaluate_model_spec(
     )
 
 
-def _train_single_model(
-    task_type: str,
-    primary_metric: str,
-    model_spec: TrainingModelSpec,
-    x_train_raw: pd.DataFrame,
-    x_test_raw: pd.DataFrame,
-    y_train: pd.Series,
-    test_ids: pd.Series,
-    id_column: str,
-    label_column: str,
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-    fold_assignments: np.ndarray,
-    run_dir: Path,
-    force_categorical: list[str] | None,
-    force_numeric: list[str] | None,
-    low_cardinality_int_threshold: int | None,
-    cv_random_state: int,
-    positive_label: object | None,
-    negative_label: object | None,
-) -> ModelRunResult:
-    evaluation_artifacts = _evaluate_model_spec(
-        task_type=task_type,
-        primary_metric=primary_metric,
-        model_spec=model_spec,
-        x_train_raw=x_train_raw,
-        x_test_raw=x_test_raw,
-        y_train=y_train,
-        split_indices=split_indices,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        low_cardinality_int_threshold=low_cardinality_int_threshold,
-        cv_random_state=cv_random_state,
-        positive_label=positive_label,
-        negative_label=negative_label,
-    )
-    model_result = evaluation_artifacts.model_result
-
-    model_dir = run_dir / model_result.model_id
-    model_dir.mkdir(parents=True, exist_ok=True)
-    evaluation_artifacts.fold_metrics_df.to_csv(model_dir / "fold_metrics.csv", index=False)
-
-    oof_df = pd.DataFrame(
-        {
-            "row_idx": np.arange(x_train_raw.shape[0], dtype=int),
-            "y_true": y_train.to_numpy(),
-            "y_pred": evaluation_artifacts.oof_predictions,
-            "fold": fold_assignments,
-            "model_id": model_result.model_id,
-            "model_name": model_result.model_name,
-        }
-    )
-    oof_df.to_csv(model_dir / "oof_predictions.csv", index=False)
-
-    test_predictions_df = pd.DataFrame(
-        {
-            id_column: test_ids.to_numpy(),
-            label_column: evaluation_artifacts.final_test_predictions,
-        }
-    )
-    test_predictions_df.to_csv(model_dir / "test_predictions.csv", index=False)
-
-    return model_result
-
-
-def _rank_model_results(
-    model_results: list[ModelRunResult],
-    configured_model_ids: list[str],
-) -> tuple[list[ModelRunResult], ModelRunResult]:
-    model_order = {model_id: index for index, model_id in enumerate(configured_model_ids)}
-
-    sorted_results = sorted(
-        model_results,
-        key=lambda result: (
-            -result.cv_summary.metric_mean if result.cv_summary.higher_is_better else result.cv_summary.metric_mean,
-            model_order[result.model_id],
-        ),
-    )
-
-    ranked_results_by_model_id: dict[str, ModelRunResult] = {}
-    for rank, result in enumerate(sorted_results, start=1):
-        ranked_results_by_model_id[result.model_id] = replace(
-            result,
-            rank=rank,
-            is_best_model=rank == 1,
-        )
-
-    ranked_results = [ranked_results_by_model_id[result.model_id] for result in model_results]
-    best_model_result = ranked_results_by_model_id[sorted_results[0].model_id]
-    return ranked_results, best_model_result
-
-
-def _build_model_summary_rows(
-    model_results: list[ModelRunResult],
-) -> list[dict[str, object]]:
-    ranked_results = sorted(model_results, key=lambda result: result.require_rank())
-    return [result.to_model_summary_row() for result in ranked_results]
-
-
-def _build_run_manifest(
-    run_context: TrainingRunContext,
-) -> dict[str, object]:
-    model_ids = [result.model_id for result in run_context.model_results]
-    models = [result.to_manifest_model_entry() for result in run_context.model_results]
-    run_manifest = {
-        "run_id": run_context.run_id,
-        "generated_at_utc": run_context.generated_at_utc,
-        "competition_slug": run_context.competition_slug,
-        "task_type": run_context.task_type,
-        "primary_metric": run_context.primary_metric,
-        "config_fingerprint": run_context.config_fingerprint,
-        "config_snapshot": run_context.config_snapshot,
-        "model_ids": model_ids,
-        "best_model_id": run_context.best_model_result.model_id,
-        "models": models,
-        "observed_label_pair": list(run_context.observed_label_pair) if run_context.observed_label_pair is not None else None,
-        "negative_label": run_context.negative_label,
-        "positive_label": run_context.positive_label,
-        "id_column": run_context.id_column,
-        "label_column": run_context.label_column,
-        "target_summary": run_context.target_summary,
-        "train_rows": run_context.train_rows,
-        "train_cols": run_context.train_cols,
-        "test_rows": run_context.test_rows,
-        "test_cols": run_context.test_cols,
-        "tuning_provenance": run_context.tuning_provenance,
-    }
-
-    if len(models) == 1:
-        single_model = models[0]
-        run_manifest["model_id"] = single_model["model_id"]
-        run_manifest["model_name"] = single_model["model_name"]
-        run_manifest["preprocessing_scheme_id"] = single_model["preprocessing_scheme_id"]
-        run_manifest["model_params"] = single_model["model_params"]
-        run_manifest["cv_summary"] = single_model["cv_summary"]
-
-    return run_manifest
-
-
-def _build_run_ledger_row(
-    run_context: TrainingRunContext,
-) -> dict[str, object]:
-    ledger_row = {
-        "run_id": run_context.run_id,
-        "timestamp_utc": run_context.generated_at_utc,
-        "competition_slug": run_context.competition_slug,
-        "task_type": run_context.task_type,
-        "primary_metric": run_context.primary_metric,
-        "best_model_id": run_context.best_model_result.model_id,
-        "best_model_name": run_context.best_model_result.model_name,
-        "cv_mean": run_context.best_model_result.cv_summary.metric_mean,
-        "cv_std": run_context.best_model_result.cv_summary.metric_std,
-        "higher_is_better": run_context.best_model_result.cv_summary.higher_is_better,
-        "model_count": len(run_context.model_results),
-        "cv_n_splits": run_context.cv_n_splits,
-        "cv_shuffle": run_context.cv_shuffle,
-        "cv_random_state": run_context.cv_random_state,
-        "config_fingerprint": run_context.config_fingerprint,
-    }
-    ledger_row.update(run_context.target_summary)
-    return ledger_row
+def _candidate_dir(competition_slug: str, candidate_id: str) -> Path:
+    return Path("artifacts") / competition_slug / "candidates" / candidate_id
 
 
 def _build_config_snapshot(
     config: AppConfig,
-    model_specs: list[TrainingModelSpec],
+    model_spec: TrainingModelSpec,
     positive_label: object | None,
     id_column: str,
     label_column: str,
@@ -663,15 +279,10 @@ def _build_config_snapshot(
             "label_column": label_column,
         },
         "experiment": config.experiment.model_dump(mode="python"),
-        "resolved_model_ids": [model_spec.model_id for model_spec in model_specs],
+        "resolved_model_id": model_spec.model_id,
     }
-    parameter_overrides = {
-        model_spec.model_id: model_spec.parameter_overrides
-        for model_spec in model_specs
-        if model_spec.parameter_overrides
-    }
-    if parameter_overrides:
-        config_snapshot["resolved_model_parameter_overrides"] = parameter_overrides
+    if model_spec.parameter_overrides:
+        config_snapshot["resolved_model_parameter_overrides"] = model_spec.parameter_overrides
     if tuning_provenance is not None:
         config_snapshot["tuning_provenance"] = tuning_provenance
     return config_snapshot
@@ -679,28 +290,117 @@ def _build_config_snapshot(
 
 def _build_config_fingerprint(
     config_snapshot: dict[str, object],
-    model_results: list[ModelRunResult],
+    model_result: ModelRunResult,
 ) -> str:
     fingerprint_payload = {
         "config_snapshot": config_snapshot,
-        "models": [result.to_fingerprint_model_entry() for result in model_results],
+        "model": model_result.to_fingerprint_entry(),
     }
-    config_snapshot_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
-    return hashlib.sha256(config_snapshot_json.encode("utf-8")).hexdigest()[:12]
+    fingerprint_payload_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
+    return hashlib.sha256(fingerprint_payload_json.encode("utf-8")).hexdigest()[:12]
+
+
+def _build_candidate_manifest(
+    config: AppConfig,
+    generated_at_utc: str,
+    model_result: ModelRunResult,
+    config_snapshot: dict[str, object],
+    config_fingerprint: str,
+    observed_label_pair: tuple[object, object] | None,
+    negative_label: object | None,
+    positive_label: object | None,
+    id_column: str,
+    label_column: str,
+    target_summary: dict[str, object],
+    train_rows: int,
+    train_cols: int,
+    test_rows: int,
+    test_cols: int,
+    tuning_provenance: dict[str, object] | None,
+) -> dict[str, object]:
+    return {
+        "artifact_type": "candidate",
+        "candidate_id": config.candidate_id,
+        "candidate_type": config.candidate_type,
+        "generated_at_utc": generated_at_utc,
+        "competition_slug": config.competition_slug,
+        "task_type": config.task_type,
+        "primary_metric": config.primary_metric,
+        "config_fingerprint": config_fingerprint,
+        "config_snapshot": config_snapshot,
+        "model_family": config.model_family,
+        "preprocessor": config.preprocessor,
+        "model_id": model_result.model_id,
+        "model_name": model_result.model_name,
+        "preprocessing_scheme_id": model_result.preprocessing_scheme_id,
+        "model_params": model_result.model_params,
+        "cv_summary": model_result.cv_summary.to_dict(),
+        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
+        "negative_label": negative_label,
+        "positive_label": positive_label,
+        "id_column": id_column,
+        "label_column": label_column,
+        "target_summary": target_summary,
+        "train_rows": train_rows,
+        "train_cols": train_cols,
+        "test_rows": test_rows,
+        "test_cols": test_cols,
+        "tuning_provenance": tuning_provenance,
+    }
+
+
+def _write_candidate_artifacts(
+    candidate_dir: Path,
+    manifest: dict[str, object],
+    evaluation_artifacts: ModelEvaluationArtifacts,
+    y_train: pd.Series,
+    fold_assignments: np.ndarray,
+    test_ids: pd.Series,
+    id_column: str,
+    label_column: str,
+) -> None:
+    (candidate_dir / "candidate.json").write_text(
+        json.dumps(_json_ready(manifest), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    evaluation_artifacts.fold_metrics_df.to_csv(candidate_dir / "fold_metrics.csv", index=False)
+
+    oof_df = pd.DataFrame(
+        {
+            "row_idx": np.arange(y_train.shape[0], dtype=int),
+            "y_true": y_train.to_numpy(),
+            "y_pred": evaluation_artifacts.oof_predictions,
+            "fold": fold_assignments,
+        }
+    )
+    oof_df.to_csv(candidate_dir / "oof_predictions.csv", index=False)
+
+    test_predictions_df = pd.DataFrame(
+        {
+            id_column: test_ids.to_numpy(),
+            label_column: evaluation_artifacts.final_test_predictions,
+        }
+    )
+    test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
 
 
 def run_training(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
-    model_specs: list[TrainingModelSpec] | None = None,
+    model_spec: TrainingModelSpec | None = None,
     tuning_provenance: dict[str, object] | None = None,
 ) -> Path:
-    competition_slug = config.competition_slug
+    resolved_model_spec = _resolve_training_model_spec(config=config, model_spec=model_spec)
+    candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
+    if candidate_dir.exists():
+        raise ValueError(
+            "Candidate artifacts already exist for this candidate_id. "
+            f"Choose a new experiment.candidate.candidate_id or remove {candidate_dir}"
+        )
+
     task_type = config.task_type
     primary_metric = config.primary_metric
     positive_label = config.positive_label
-    resolved_model_specs = _resolve_training_model_specs(config=config, model_specs=model_specs)
-    configured_model_ids = [model_spec.model_id for model_spec in resolved_model_specs]
 
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
@@ -732,12 +432,6 @@ def run_training(
     )
     split_indices = prepared_context.split_indices
     fold_assignments = prepared_context.fold_assignments
-    run_diagnostics_df = _build_run_diagnostics(
-        task_type=task_type,
-        y_train=y_train,
-        split_indices=split_indices,
-        positive_label=positive_label,
-    )
     target_summary = _build_target_summary(
         task_type=task_type,
         y_train=y_train,
@@ -746,49 +440,33 @@ def run_training(
         observed_label_pair=observed_label_pair,
     )
 
-    run_id = _make_run_id()
-    run_dir = Path("artifacts") / competition_slug / "train" / run_id
-    run_dir.mkdir(parents=True, exist_ok=False)
-    run_diagnostics_df.to_csv(run_dir / "run_diagnostics.csv", index=False)
-
-    model_results: list[ModelRunResult] = []
-    for model_spec in resolved_model_specs:
-        model_result = _train_single_model(
-            task_type=task_type,
-            primary_metric=primary_metric,
-            model_spec=model_spec,
-            x_train_raw=x_train_raw,
-            x_test_raw=x_test_raw,
-            y_train=y_train,
-            test_ids=test_df[id_column],
-            id_column=id_column,
-            label_column=label_column,
-            split_indices=split_indices,
-            fold_assignments=fold_assignments,
-            run_dir=run_dir,
-            force_categorical=config.force_categorical,
-            force_numeric=config.force_numeric,
-            low_cardinality_int_threshold=config.low_cardinality_int_threshold,
-            cv_random_state=config.cv_random_state,
-            positive_label=positive_label,
-            negative_label=negative_label,
-        )
-        model_results.append(model_result)
-        print(
-            f"Training model: {model_result.model_id} ({model_result.model_name}) | "
-            f"preprocessing={model_result.preprocessing_scheme_id} | "
-            f"CV {primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
-            f"std={model_result.cv_summary.metric_std:.6f}"
-        )
-
-    model_results, best_model_result = _rank_model_results(model_results, configured_model_ids)
-    model_summary_rows = _build_model_summary_rows(model_results)
-    model_summary_df = pd.DataFrame(model_summary_rows)
-    model_summary_df.to_csv(run_dir / "model_summary.csv", index=False)
+    evaluation_artifacts = _evaluate_model_spec(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        model_spec=resolved_model_spec,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+        y_train=y_train,
+        split_indices=split_indices,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+        cv_random_state=config.cv_random_state,
+        positive_label=positive_label,
+        negative_label=negative_label,
+    )
+    model_result = evaluation_artifacts.model_result
+    print(
+        f"Training candidate: {config.candidate_id} | "
+        f"model={model_result.model_id} ({model_result.model_name}) | "
+        f"preprocessing={model_result.preprocessing_scheme_id} | "
+        f"CV {primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
+        f"std={model_result.cv_summary.metric_std:.6f}"
+    )
 
     config_snapshot = _build_config_snapshot(
         config=config,
-        model_specs=resolved_model_specs,
+        model_spec=resolved_model_spec,
         positive_label=positive_label,
         id_column=id_column,
         label_column=label_column,
@@ -796,20 +474,15 @@ def run_training(
     )
     config_fingerprint = _build_config_fingerprint(
         config_snapshot=config_snapshot,
-        model_results=model_results,
+        model_result=model_result,
     )
-
     generated_at_utc = datetime.now(timezone.utc).isoformat()
-    run_context = TrainingRunContext(
-        run_id=run_id,
+    candidate_manifest = _build_candidate_manifest(
+        config=config,
         generated_at_utc=generated_at_utc,
-        competition_slug=competition_slug,
-        task_type=task_type,
-        primary_metric=primary_metric,
+        model_result=model_result,
         config_snapshot=config_snapshot,
         config_fingerprint=config_fingerprint,
-        model_results=model_results,
-        best_model_result=best_model_result,
         observed_label_pair=observed_label_pair,
         negative_label=negative_label,
         positive_label=positive_label,
@@ -820,23 +493,19 @@ def run_training(
         train_cols=int(x_train_raw.shape[1]),
         test_rows=int(x_test_raw.shape[0]),
         test_cols=int(x_test_raw.shape[1]),
-        cv_n_splits=config.cv_n_splits,
-        cv_shuffle=config.cv_shuffle,
-        cv_random_state=config.cv_random_state,
         tuning_provenance=tuning_provenance,
     )
-    run_manifest = _build_run_manifest(run_context)
-    run_manifest_json = json.dumps(_json_ready(run_manifest), indent=2)
-    (run_dir / "run_manifest.json").write_text(run_manifest_json, encoding="utf-8")
 
-    ledger_row = _build_run_ledger_row(run_context)
-    ledger_path = Path("artifacts") / competition_slug / "train" / "runs.csv"
-    _append_run_ledger(ledger_path, ledger_row)
-
-    print(
-        f"Best model: {best_model_result.model_id} ({best_model_result.model_name}) | "
-        f"CV {primary_metric}: mean={best_model_result.cv_summary.metric_mean:.6f}, "
-        f"std={best_model_result.cv_summary.metric_std:.6f}"
+    candidate_dir.parent.mkdir(parents=True, exist_ok=True)
+    candidate_dir.mkdir(parents=False, exist_ok=False)
+    _write_candidate_artifacts(
+        candidate_dir=candidate_dir,
+        manifest=candidate_manifest,
+        evaluation_artifacts=evaluation_artifacts,
+        y_train=y_train,
+        fold_assignments=fold_assignments,
+        test_ids=test_df[id_column],
+        id_column=id_column,
+        label_column=label_column,
     )
-
-    return run_dir
+    return candidate_dir

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -24,7 +24,7 @@ from tabular_shenanigans.train import (
 @dataclass(frozen=True)
 class TuningResult:
     study_dir: Path
-    train_dir: Path
+    candidate_dir: Path
 
 
 def _make_study_id() -> str:
@@ -47,7 +47,7 @@ def _build_study_config_snapshot(
             "label_column": label_column,
         },
         "experiment": config.experiment.model_dump(mode="python"),
-        "resolved_model_ids": [tuning_model_spec.model_id],
+        "resolved_model_id": tuning_model_spec.model_id,
     }
 
 
@@ -82,7 +82,7 @@ def _build_study_manifest(
     model_name: str,
     preprocessing_scheme_id: str,
     target_summary: dict[str, object],
-    train_dir: Path | None = None,
+    candidate_dir: Path | None = None,
 ) -> dict[str, object]:
     best_trial = study.best_trial
     return {
@@ -103,8 +103,8 @@ def _build_study_manifest(
         "best_params": best_trial.params,
         "best_model_params": best_trial.user_attrs.get("model_params"),
         "target_summary": target_summary,
-        "train_run_id": train_dir.name if train_dir is not None else None,
-        "train_run_dir": str(train_dir) if train_dir is not None else None,
+        "train_candidate_id": candidate_dir.name if candidate_dir is not None else None,
+        "train_candidate_dir": str(candidate_dir) if candidate_dir is not None else None,
     }
 
 
@@ -129,7 +129,7 @@ def _write_tuning_artifacts(
                 "completed_trial_count": study_manifest["completed_trial_count"],
                 "best_trial_number": study_manifest["best_trial_number"],
                 "best_value": study_manifest["best_value"],
-                "train_run_id": study_manifest["train_run_id"],
+                "train_candidate_id": study_manifest["train_candidate_id"],
             }
         ]
     )
@@ -271,15 +271,13 @@ def run_tuning(
         "base_model_id": tuning_model_spec.model_id,
         "parameter_overrides": best_parameter_overrides,
     }
-    train_dir = run_training(
+    candidate_dir = run_training(
         config=config,
         dataset_context=dataset_context,
-        model_specs=[
-            TrainingModelSpec(
-                model_id=tuning_model_spec.model_id,
-                parameter_overrides=best_parameter_overrides,
-            )
-        ],
+        model_spec=TrainingModelSpec(
+            model_id=tuning_model_spec.model_id,
+            parameter_overrides=best_parameter_overrides,
+        ),
         tuning_provenance=tuning_provenance,
     )
 
@@ -292,11 +290,11 @@ def run_tuning(
         model_name=model_definition.model_name,
         preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
         target_summary=target_summary,
-        train_dir=train_dir,
+        candidate_dir=candidate_dir,
     )
     _write_tuning_artifacts(study_dir=study_dir, study_manifest=updated_study_manifest, trials_df=trials_df)
     print(
         f"Tuning complete: best_trial={study.best_trial.number}, "
-        f"best_{primary_metric}={study.best_value:.6f}, train_run={train_dir.name}"
+        f"best_{primary_metric}={study.best_value:.6f}, candidate={candidate_dir.name}"
     )
-    return TuningResult(study_dir=study_dir, train_dir=train_dir)
+    return TuningResult(study_dir=study_dir, candidate_dir=candidate_dir)


### PR DESCRIPTION
Closes #74

Summary
- rewrite training to produce one immutable candidate artifact directory at artifacts/<competition_slug>/candidates/<candidate_id>
- replace run-level training metadata with candidate.json plus fold_metrics.csv, oof_predictions.csv, and test_predictions.csv
- update tune so best-trial retrains land in the same candidate artifact layout
- add submit compatibility for current candidate artifacts while preserving legacy run artifact support
- update README and the technical guide for the candidate-centric training contract

Verification
- uv run python main.py train with a temporary smoke-binary-canonical config and candidate_id smoke_logreg_issue74_v1
- confirmed artifacts/smoke-binary-canonical/candidates/smoke_logreg_issue74_v1/{candidate.json,fold_metrics.csv,oof_predictions.csv,test_predictions.csv}
- reran uv run python main.py train with the same candidate_id and confirmed it fails fast because the candidate directory already exists
- uv run python main.py submit --run-dir artifacts/smoke-binary-canonical/candidates/smoke_logreg_issue74_v1
- uv run python main.py submit --run-dir artifacts/smoke-binary-canonical/train/20260310T135722606689Z to verify legacy run submit compatibility
- uv run python main.py tune with candidate_id smoke_logreg_issue74_tuned_v1 and 2 Optuna trials
- confirmed tuned retrain wrote artifacts/smoke-binary-canonical/candidates/smoke_logreg_issue74_tuned_v1/candidate.json with tuning_provenance
- PYTHONPATH=src .venv/bin/python -m compileall main.py src/tabular_shenanigans
