### PR TITLE
Rewrite submission around explicit candidate_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Train one cross-validated model candidate at a time using config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
 - Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
 - Write tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, including `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`.
-- Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact or an explicit legacy run artifact.
+- Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact selected by `candidate_id`.
 
 ## Tooling
 - Python for orchestration
@@ -68,8 +68,8 @@ Available stage-specific commands:
 - `uv run python main.py preprocess`
 - `uv run python main.py train`
 - `uv run python main.py tune`
-- `uv run python main.py submit --run-dir artifacts/<competition_slug>/candidates/<candidate_id>`
-- `uv run python main.py submit --run-id <run_id>`
+- `uv run python main.py submit`
+- `uv run python main.py submit --candidate-id <candidate_id>`
 
 Stage behavior:
 - `fetch`: ensures competition data is present locally
@@ -78,15 +78,14 @@ Stage behavior:
 - `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
 - `train`: fetches if needed, prepares competition context when it is missing, then trains and writes one candidate artifact directory on the frozen folds
 - `tune`: fetches if needed, prepares competition context when it is missing, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true` on the frozen folds, writes tuning artifacts, then retrains the best trial into the normal candidate artifact layout
-- `submit`: requires an explicit existing artifact directory and never retrains implicitly
+- `submit`: resolves one candidate artifact by `candidate_id` and never retrains implicitly
 
 The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
 - `preprocess_summary.csv`
 - `preprocess_features.csv`
 - `preprocess_models.csv`
 
-`submit` can take an optional `--model-id` only when targeting a legacy multi-model run artifact.
-The default submit path supports current candidate artifacts and legacy manifest-backed run artifacts. Older local artifact layouts are unsupported and fail with direct errors.
+`submit` defaults to `config.candidate_id`. Use `--candidate-id` only when you want to submit another existing candidate for the same competition.
 
 ## Config Overview
 Tracked example configs:
@@ -181,6 +180,7 @@ Manual verification for each target:
 - confirm the pipeline infers `id_column` and `label_column` without overrides
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written for the resolved internal model artifact
+- run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
@@ -206,7 +206,7 @@ Manual verification for tuning:
   - includes `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
   - `candidate.json` is the canonical training metadata source
   - tuned retrain candidates also record `tuning_provenance`
-- Submission ledger: `artifacts/<competition_slug>/train/submissions.csv` as an append-only submission event table
+- Submission ledger: `artifacts/<competition_slug>/submissions.csv` as an append-only submission event table keyed by `candidate_id`
 
 ## Current Assumptions
 - Kaggle CLI is installed, authenticated, and has access to the configured competition.
@@ -217,10 +217,11 @@ Manual verification for tuning:
 - The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` and `tune` consume that frozen context and auto-run `prepare` only when it is missing.
 - The `tune` stage uses the current experiment candidate only, and the tuned best-trial retrain writes a standard single-candidate artifact with `tuning_provenance`.
-- Submission uses `candidate.json` for current artifacts and `run_manifest.json` for legacy run artifacts as the schema/task source of truth.
+- Submission uses `candidate.json` as the schema/task source of truth.
+- Submission defaults to `config.candidate_id`; `submit --candidate-id <candidate_id>` overrides that selection explicitly.
 - Submission metadata includes the selected `model_id`; current candidate artifacts contain exactly one `model_id`.
 - Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
-- Submission supports the current candidate artifact layout under `artifacts/<competition_slug>/candidates/<candidate_id>/` and legacy run artifacts under `artifacts/<competition_slug>/train/<run_id>/<model_id>/`.
+- Submission requires the current candidate artifact layout under `artifacts/<competition_slug>/candidates/<candidate_id>/`.
 - Binary classification supports any two-class labels accepted by scikit-learn.
 - For binary `roc_auc` and `log_loss`, prediction artifacts use probabilities aligned to the resolved positive class.
 - For binary `accuracy`, prediction artifacts use class labels from the observed binary label set.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -19,7 +19,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
    - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
    - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
 9. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
-10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` for current candidate artifacts or `run_manifest.json` for legacy run artifacts, apply metric-aware binary prediction validation, write `submission.csv` in the selected artifact directory, and optionally submit to Kaggle.
+10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
 
 When the explicit `tune` stage is selected, the workflow additionally loads the frozen fold assignments from `folds.csv`, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard candidate artifact layout with `tuning_provenance` recorded in `candidate.json`.
 
@@ -31,12 +31,12 @@ When the explicit `tune` stage is selected, the workflow additionally loads the 
 - `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
 - `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, and write one candidate artifact directory on the frozen folds
 - `uv run python main.py tune`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into a normal candidate artifact directory on the frozen folds
-- `uv run python main.py submit --run-dir artifacts/.../candidates/<candidate_id>`: prepare or submit from an explicit current candidate artifact
-- `uv run python main.py submit --run-id <run_id>`: resolve the run under `artifacts/<competition_slug>/train/<run_id>` using the configured competition slug
+- `uv run python main.py submit`: prepare or submit the configured `candidate_id`
+- `uv run python main.py submit --candidate-id <candidate_id>`: prepare or submit another existing candidate for the configured competition
 
 The `preprocess` stage is intentionally diagnostic. It is not part of the default runtime contract and it does not create a second training artifact layout.
 
-The default `submit` path supports current candidate artifacts plus legacy manifest-backed run artifacts. Unsupported older local artifact layouts fail directly.
+The default `submit` path supports current candidate artifacts only. Unsupported or missing candidate artifacts fail directly.
 
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, preprocess diagnostics, training, tuning, and submission.
@@ -49,7 +49,7 @@ The default `submit` path supports current candidate artifacts plus legacy manif
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, candidate artifact writing, and candidate manifest generation.
 - `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate on the frozen fold assignments, study artifact writing, and best-trial retraining into the standard candidate artifact layout.
-- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate-or-legacy-artifact selection, submission message creation, Kaggle submission, and submission ledger updates.
+- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
 Input:
@@ -125,6 +125,7 @@ Manual verification steps for each target:
 - confirm inferred `id_column` and `label_column`
 - confirm `candidate.json` is generated in the candidate directory
 - confirm `test_predictions.csv` is generated in the candidate directory
+- run `uv run python main.py submit`
 - confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected candidate directory
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 - when tuning is enabled, run `uv run python main.py tune` and confirm `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json` are generated under `artifacts/<competition_slug>/tune/<study_id>/`
@@ -162,7 +163,7 @@ Manual verification steps for each target:
   - `study_summary.csv`
   - `trials.csv`
   - `best_params.json`
-- Append-only submission ledger at `artifacts/<competition_slug>/train/submissions.csv` with submission event metadata only
+- Append-only submission ledger at `artifacts/<competition_slug>/submissions.csv` keyed by `candidate_id`
 
 ## Runtime Invariants And Failure Behavior
 - One runtime config source only: local repository-root `config.yaml`
@@ -179,7 +180,7 @@ Manual verification steps for each target:
 - rerunning an existing `candidate_id` must fail instead of mutating an existing artifact directory
 - the `tune` stage requires `experiment.candidate.optimization.enabled=true`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
-- Submit-time `model_id` remains relevant only for legacy multi-model run artifacts
+- `submit` must resolve one candidate by `candidate_id`, defaulting to `config.candidate_id`
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
@@ -191,11 +192,10 @@ Manual verification steps for each target:
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
-- Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `candidate.json` for current artifacts and `run_manifest.json` for legacy artifacts rather than re-inferring them from raw train/test data
-- Legacy multi-model submission must default to `best_model_id` unless a specific `model_id` is requested explicitly
+- Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `candidate.json` rather than re-inferring them from raw train/test data
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
 - The selected model artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
-- Submission requires the current candidate prediction layout at `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` or the legacy per-model run layout at `artifacts/<competition_slug>/train/<run_id>/<model_id>/test_predictions.csv`
+- Submission requires the current candidate prediction layout at `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv`
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
@@ -231,8 +231,8 @@ Hard-error cases include:
 - Any CV/training fit or scoring failure -> hard error
 - Fold assignment gaps in OOF generation -> hard error
 - Candidate artifact directory already exists for the configured `candidate_id` -> hard error
-- Requested submission `model_id` not present in the legacy run manifest -> hard error
-- Missing or unsupported submit artifacts outside the current candidate contract or legacy run-manifest contract -> hard error
+- Missing configured candidate artifacts at submit time -> hard error
+- Requested `candidate_id` with no matching candidate artifact directory -> hard error
 - Submission schema or ID mismatch against `sample_submission.csv` -> hard error
 - Binary probability artifact outside `[0, 1]` for `roc_auc` or `log_loss` -> hard error
 - Binary label artifact containing values outside the observed label pair for `accuracy` -> hard error

--- a/main.py
+++ b/main.py
@@ -27,20 +27,10 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("train", help="Train the current candidate only.")
     subparsers.add_parser("tune", help="Run Optuna tuning and retrain the best trial.")
 
-    submit_parser = subparsers.add_parser("submit", help="Prepare or submit from an existing artifact directory.")
-    run_selection = submit_parser.add_mutually_exclusive_group(required=True)
-    run_selection.add_argument(
-        "--run-dir",
-        type=Path,
-        help="Explicit artifact directory such as artifacts/<competition_slug>/candidates/<candidate_id>.",
-    )
-    run_selection.add_argument(
-        "--run-id",
-        help="Legacy run identifier resolved under artifacts/<competition_slug>/train/<run_id> using config.competition_slug.",
-    )
+    submit_parser = subparsers.add_parser("submit", help="Prepare or submit from a candidate artifact.")
     submit_parser.add_argument(
-        "--model-id",
-        help="Optional model_id for legacy multi-model run artifacts; ignored for current single-candidate artifacts.",
+        "--candidate-id",
+        help="Optional candidate_id resolved under artifacts/<competition_slug>/candidates/<candidate_id>. Defaults to config.candidate_id.",
     )
 
     return parser
@@ -69,12 +59,6 @@ def _load_shared_dataset_context(config: AppConfig):
     )
 
 
-def _resolve_artifact_dir(config: AppConfig, args: argparse.Namespace) -> Path:
-    if args.run_dir is not None:
-        return args.run_dir
-    return Path("artifacts") / config.competition_slug / "train" / str(args.run_id)
-
-
 def _prepare_competition_stage(config: AppConfig):
     _ensure_data_ready(config)
     dataset_context = _load_shared_dataset_context(config)
@@ -89,7 +73,7 @@ def _run_full_pipeline(config: AppConfig) -> None:
     dataset_context, _ = _prepare_competition_stage(config)
     candidate_dir = run_training(config=config, dataset_context=dataset_context)
     print(f"Candidate artifacts ready: {candidate_dir}")
-    submission_path, submission_status = run_submission(config=config, artifact_dir=candidate_dir)
+    submission_path, submission_status = run_submission(config=config)
     print(f"Submission file ready: {submission_path} ({submission_status})")
 
 
@@ -123,12 +107,11 @@ def _run_tune_stage(config: AppConfig) -> None:
 
 
 def _run_submit_stage(config: AppConfig, args: argparse.Namespace) -> None:
-    artifact_dir = _resolve_artifact_dir(config, args)
-    print(f"Using artifact_dir: {artifact_dir}")
+    resolved_candidate_id = args.candidate_id or config.candidate_id
+    print(f"Using candidate_id: {resolved_candidate_id}")
     submission_path, submission_status = run_submission(
         config=config,
-        artifact_dir=artifact_dir,
-        model_id=args.model_id,
+        candidate_id=resolved_candidate_id,
     )
     print(f"Submission file ready: {submission_path} ({submission_status})")
 

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -13,7 +13,7 @@ from tabular_shenanigans.data import get_binary_prediction_kind, load_sample_sub
 SUBMISSION_LEDGER_COLUMNS = [
     "timestamp_utc",
     "competition_slug",
-    "run_id",
+    "candidate_id",
     "model_id",
     "model_name",
     "config_fingerprint",
@@ -26,8 +26,7 @@ SUBMISSION_LEDGER_COLUMNS = [
 
 @dataclass(frozen=True)
 class SubmissionContext:
-    artifact_kind: str
-    artifact_id: str
+    candidate_id: str
     competition_slug: str
     task_type: str
     primary_metric: str
@@ -40,6 +39,14 @@ class SubmissionContext:
     observed_label_pair: tuple[object, object] | None
     config_fingerprint: str | None
     prediction_path: Path
+
+
+def _candidate_dir(competition_slug: str, candidate_id: str) -> Path:
+    return Path("artifacts") / competition_slug / "candidates" / candidate_id
+
+
+def _submission_ledger_path(competition_slug: str) -> Path:
+    return Path("artifacts") / competition_slug / "submissions.csv"
 
 
 def _read_submission_ledger(ledger_path: Path) -> pd.DataFrame:
@@ -64,125 +71,35 @@ def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None
     ledger_df.to_csv(ledger_path, index=False)
 
 
-def _load_json_manifest(manifest_path: Path, description: str) -> dict[str, object]:
+def _load_candidate_manifest(candidate_dir: Path) -> dict[str, object]:
+    manifest_path = candidate_dir / "candidate.json"
     if not manifest_path.exists():
-        raise ValueError(f"Missing {description}: {manifest_path}")
+        raise ValueError(
+            f"Missing candidate manifest: {manifest_path}. Submission requires current candidate artifacts."
+        )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     if not isinstance(manifest, dict):
-        raise ValueError(f"{description.capitalize()} must be a JSON object: {manifest_path}")
+        raise ValueError(f"Candidate manifest must be a JSON object: {manifest_path}")
     return manifest
 
 
-def _require_manifest_value(manifest: dict[str, object], field_name: str, description: str) -> object:
+def _require_manifest_value(manifest: dict[str, object], field_name: str) -> object:
     field_value = manifest.get(field_name)
     if field_value is None:
-        raise ValueError(f"{description.capitalize()} is missing required field '{field_name}'.")
+        raise ValueError(f"Candidate manifest is missing required field '{field_name}'.")
     return field_value
 
 
-def _parse_observed_label_pair(manifest: dict[str, object], description: str) -> tuple[object, object] | None:
+def _parse_observed_label_pair(manifest: dict[str, object]) -> tuple[object, object] | None:
     observed_label_pair_raw = manifest.get("observed_label_pair")
     if observed_label_pair_raw is None:
         return None
     if not isinstance(observed_label_pair_raw, list) or len(observed_label_pair_raw) != 2:
-        raise ValueError(f"{description.capitalize()} observed_label_pair must contain exactly two labels when present.")
+        raise ValueError("Candidate manifest observed_label_pair must contain exactly two labels when present.")
     return (observed_label_pair_raw[0], observed_label_pair_raw[1])
 
 
-def _load_manifest_models(run_manifest: dict[str, object]) -> list[dict[str, object]]:
-    manifest_models = run_manifest.get("models")
-    if not isinstance(manifest_models, list) or not manifest_models:
-        raise ValueError(
-            "Run manifest must contain a non-empty 'models' list. "
-            "Submission requires current multi-model-aware run artifacts."
-        )
-    if not all(isinstance(model, dict) for model in manifest_models):
-        raise ValueError("Run manifest models must be a list of mappings.")
-    return manifest_models
-
-
-def _resolve_selected_legacy_model(
-    run_manifest: dict[str, object],
-    requested_model_id: str | None = None,
-) -> tuple[str, dict[str, object]]:
-    manifest_models = _load_manifest_models(run_manifest)
-    available_model_ids = [str(model["model_id"]) for model in manifest_models]
-
-    if requested_model_id is not None:
-        selected_model_id = requested_model_id
-        if selected_model_id not in available_model_ids:
-            raise ValueError(
-                f"Requested model_id '{selected_model_id}' is not present in the run manifest. "
-                f"Available model_ids: {available_model_ids}"
-            )
-    else:
-        best_model_id = run_manifest.get("best_model_id")
-        if best_model_id is None:
-            raise ValueError(
-                "Run manifest is missing required submission field 'best_model_id'. "
-                f"Available model_ids: {available_model_ids}"
-            )
-        selected_model_id = str(best_model_id)
-        if selected_model_id not in available_model_ids:
-            raise ValueError(
-                "Run manifest best_model_id must match one of the available model entries. "
-                f"Available model_ids: {available_model_ids}"
-            )
-
-    selected_model = next(
-        (model for model in manifest_models if str(model["model_id"]) == selected_model_id),
-        None,
-    )
-    if selected_model is None:
-        raise ValueError(
-            f"Requested model_id '{selected_model_id}' is missing from the run manifest model entries."
-        )
-    return selected_model_id, selected_model
-
-
-def _resolve_legacy_prediction_path(run_dir: Path, model_id: str) -> Path:
-    prediction_path = run_dir / model_id / "test_predictions.csv"
-    if prediction_path.exists():
-        return prediction_path
-    raise ValueError(
-        "Missing test predictions file for submission. "
-        f"Expected current per-model artifact at {prediction_path}"
-    )
-
-
-def _load_legacy_submission_context(
-    run_dir: Path,
-    model_id: str | None = None,
-) -> SubmissionContext:
-    run_manifest = _load_json_manifest(
-        manifest_path=run_dir / "run_manifest.json",
-        description="run manifest",
-    )
-    selected_model_id, selected_model = _resolve_selected_legacy_model(run_manifest, requested_model_id=model_id)
-    cv_summary = selected_model.get("cv_summary")
-    if not isinstance(cv_summary, dict):
-        raise ValueError("Run manifest model cv_summary must be a mapping.")
-    prediction_path = _resolve_legacy_prediction_path(run_dir=run_dir, model_id=selected_model_id)
-
-    return SubmissionContext(
-        artifact_kind="run",
-        artifact_id=str(_require_manifest_value(run_manifest, "run_id", "run manifest")),
-        competition_slug=str(_require_manifest_value(run_manifest, "competition_slug", "run manifest")),
-        task_type=str(_require_manifest_value(run_manifest, "task_type", "run manifest")),
-        primary_metric=str(_require_manifest_value(run_manifest, "primary_metric", "run manifest")),
-        model_id=selected_model_id,
-        model_name=str(selected_model["model_name"]),
-        metric_name=str(cv_summary["metric_name"]),
-        metric_mean=float(cv_summary["metric_mean"]),
-        id_column=str(_require_manifest_value(run_manifest, "id_column", "run manifest")),
-        label_column=str(_require_manifest_value(run_manifest, "label_column", "run manifest")),
-        observed_label_pair=_parse_observed_label_pair(run_manifest, "run manifest"),
-        config_fingerprint=run_manifest.get("config_fingerprint"),
-        prediction_path=prediction_path,
-    )
-
-
-def _resolve_candidate_prediction_path(candidate_dir: Path) -> Path:
+def _resolve_prediction_path(candidate_dir: Path) -> Path:
     prediction_path = candidate_dir / "test_predictions.csv"
     if prediction_path.exists():
         return prediction_path
@@ -192,50 +109,31 @@ def _resolve_candidate_prediction_path(candidate_dir: Path) -> Path:
     )
 
 
-def _load_candidate_submission_context(
-    candidate_dir: Path,
-    model_id: str | None = None,
+def _load_submission_context(
+    competition_slug: str,
+    candidate_id: str,
 ) -> SubmissionContext:
-    candidate_manifest = _load_json_manifest(
-        manifest_path=candidate_dir / "candidate.json",
-        description="candidate manifest",
-    )
-    selected_model_id = str(_require_manifest_value(candidate_manifest, "model_id", "candidate manifest"))
-    if model_id is not None and model_id != selected_model_id:
-        raise ValueError(
-            "Candidate artifacts contain exactly one model. "
-            f"Requested model_id '{model_id}', available model_id '{selected_model_id}'."
-        )
-
+    candidate_dir = _candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
+    candidate_manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
     cv_summary = candidate_manifest.get("cv_summary")
     if not isinstance(cv_summary, dict):
         raise ValueError("Candidate manifest cv_summary must be a mapping.")
-    prediction_path = _resolve_candidate_prediction_path(candidate_dir)
+
     return SubmissionContext(
-        artifact_kind="candidate",
-        artifact_id=str(_require_manifest_value(candidate_manifest, "candidate_id", "candidate manifest")),
-        competition_slug=str(_require_manifest_value(candidate_manifest, "competition_slug", "candidate manifest")),
-        task_type=str(_require_manifest_value(candidate_manifest, "task_type", "candidate manifest")),
-        primary_metric=str(_require_manifest_value(candidate_manifest, "primary_metric", "candidate manifest")),
-        model_id=selected_model_id,
-        model_name=str(_require_manifest_value(candidate_manifest, "model_name", "candidate manifest")),
+        candidate_id=str(_require_manifest_value(candidate_manifest, "candidate_id")),
+        competition_slug=str(_require_manifest_value(candidate_manifest, "competition_slug")),
+        task_type=str(_require_manifest_value(candidate_manifest, "task_type")),
+        primary_metric=str(_require_manifest_value(candidate_manifest, "primary_metric")),
+        model_id=str(_require_manifest_value(candidate_manifest, "model_id")),
+        model_name=str(_require_manifest_value(candidate_manifest, "model_name")),
         metric_name=str(cv_summary["metric_name"]),
         metric_mean=float(cv_summary["metric_mean"]),
-        id_column=str(_require_manifest_value(candidate_manifest, "id_column", "candidate manifest")),
-        label_column=str(_require_manifest_value(candidate_manifest, "label_column", "candidate manifest")),
-        observed_label_pair=_parse_observed_label_pair(candidate_manifest, "candidate manifest"),
+        id_column=str(_require_manifest_value(candidate_manifest, "id_column")),
+        label_column=str(_require_manifest_value(candidate_manifest, "label_column")),
+        observed_label_pair=_parse_observed_label_pair(candidate_manifest),
         config_fingerprint=candidate_manifest.get("config_fingerprint"),
-        prediction_path=prediction_path,
+        prediction_path=_resolve_prediction_path(candidate_dir),
     )
-
-
-def _load_submission_context(
-    artifact_dir: Path,
-    model_id: str | None = None,
-) -> SubmissionContext:
-    if (artifact_dir / "candidate.json").exists():
-        return _load_candidate_submission_context(candidate_dir=artifact_dir, model_id=model_id)
-    return _load_legacy_submission_context(run_dir=artifact_dir, model_id=model_id)
 
 
 def _validate_submission_ids(
@@ -310,7 +208,7 @@ def _validate_binary_label_predictions(
 ) -> None:
     if observed_label_pair is None:
         raise ValueError(
-            "Binary label submissions require observed_label_pair metadata in the artifact manifest."
+            "Binary label submissions require observed_label_pair metadata in the candidate manifest."
         )
     if not prediction_values.map(pd.notna).all():
         raise ValueError("Binary label submissions contain missing values.")
@@ -370,10 +268,13 @@ def _prepare_submission_file_from_context(submission_context: SubmissionContext)
 
 
 def prepare_submission_file(
-    artifact_dir: Path,
-    model_id: str | None = None,
+    competition_slug: str,
+    candidate_id: str,
 ) -> Path:
-    submission_context = _load_submission_context(artifact_dir=artifact_dir, model_id=model_id)
+    submission_context = _load_submission_context(
+        competition_slug=competition_slug,
+        candidate_id=candidate_id,
+    )
     return _prepare_submission_file_from_context(submission_context)
 
 
@@ -384,27 +285,33 @@ def _build_submission_message_from_context(
     message_parts = []
     if submit_message_prefix:
         message_parts.append(submit_message_prefix.strip())
-    message_parts.append(f"{submission_context.artifact_kind}={submission_context.artifact_id}")
+    message_parts.append(f"candidate={submission_context.candidate_id}")
     message_parts.append(f"model={submission_context.model_id}")
     message_parts.append(f"{submission_context.metric_name}={submission_context.metric_mean:.6f}")
     return " | ".join(message_parts)
 
 
 def build_submission_message(
-    artifact_dir: Path,
+    competition_slug: str,
+    candidate_id: str,
     submit_message_prefix: str | None = None,
-    model_id: str | None = None,
 ) -> str:
-    submission_context = _load_submission_context(artifact_dir=artifact_dir, model_id=model_id)
+    submission_context = _load_submission_context(
+        competition_slug=competition_slug,
+        candidate_id=candidate_id,
+    )
     return _build_submission_message_from_context(submission_context, submit_message_prefix=submit_message_prefix)
 
 
 def run_submission(
     config: AppConfig,
-    artifact_dir: Path,
-    model_id: str | None = None,
+    candidate_id: str | None = None,
 ) -> tuple[Path, str]:
-    submission_context = _load_submission_context(artifact_dir=artifact_dir, model_id=model_id)
+    resolved_candidate_id = candidate_id or config.candidate_id
+    submission_context = _load_submission_context(
+        competition_slug=config.competition_slug,
+        candidate_id=resolved_candidate_id,
+    )
     submission_path = _prepare_submission_file_from_context(submission_context)
     message = _build_submission_message_from_context(
         submission_context,
@@ -440,7 +347,7 @@ def run_submission(
     ledger_row = {
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
         "competition_slug": submission_context.competition_slug,
-        "run_id": submission_context.artifact_id,
+        "candidate_id": submission_context.candidate_id,
         "model_id": submission_context.model_id,
         "model_name": submission_context.model_name,
         "config_fingerprint": submission_context.config_fingerprint,
@@ -449,6 +356,6 @@ def run_submission(
         "status": status,
         "message": message,
     }
-    ledger_path = Path("artifacts") / submission_context.competition_slug / "train" / "submissions.csv"
+    ledger_path = _submission_ledger_path(submission_context.competition_slug)
     _append_submission_ledger(ledger_path=ledger_path, row=ledger_row)
     return submission_path, status


### PR DESCRIPTION
Closes #75

## Summary
- make submit candidate-native and remove legacy run-based selection flags
- load only candidate artifacts and write the submission ledger to artifacts/<competition_slug>/submissions.csv
- update README and technical guide for the candidate-based submit workflow

## Verification
- uv run python main.py train with a smoke config for candidate smoke_logreg_issue75_v1
- uv run python main.py submit
- uv run python main.py submit --candidate-id smoke_logreg_issue74_v1
- PYTHONPATH=src .venv/bin/python -m compileall main.py src/tabular_shenanigans