### PR TITLE
Remove obsolete run-centric and stage-centric workflow paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ The repository is developed and manually verified primarily against these Playgr
   - `label_column` as the only column shared by `train.csv` and `sample_submission.csv` but not `test.csv`
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
-- Freeze CV assignments once per prepared competition context and reuse them across `train` and `tune`.
-- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `preprocess`, `train`, and submit-only flows against explicit artifact directories.
-- Run an explicit `tune` stage that evaluates Optuna trials for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes study artifacts, and retrains the best trial into the standard training artifact layout.
+- Freeze CV assignments once per prepared competition context and reuse them across `train`.
+- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `train`, and submit-only flows.
 - Train one cross-validated model candidate at a time using config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
 - Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
-- Write tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, including `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`.
+- When `experiment.candidate.optimization.enabled=true`, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact selected by `candidate_id`.
 
 ## Tooling
@@ -65,9 +64,7 @@ Available stage-specific commands:
 - `uv run python main.py fetch`
 - `uv run python main.py prepare`
 - `uv run python main.py eda`
-- `uv run python main.py preprocess`
 - `uv run python main.py train`
-- `uv run python main.py tune`
 - `uv run python main.py submit`
 - `uv run python main.py submit --candidate-id <candidate_id>`
 
@@ -75,15 +72,8 @@ Stage behavior:
 - `fetch`: ensures competition data is present locally
 - `prepare`: fetches if needed, writes EDA report CSVs, persists `competition.json`, and freezes `folds.csv`
 - `eda`: fetches if needed, then writes EDA report CSVs
-- `preprocess`: fetches if needed, then writes preprocessing diagnostics under `reports/<competition_slug>/`
-- `train`: fetches if needed, prepares competition context when it is missing, then trains and writes one candidate artifact directory on the frozen folds
-- `tune`: fetches if needed, prepares competition context when it is missing, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true` on the frozen folds, writes tuning artifacts, then retrains the best trial into the normal candidate artifact layout
+- `train`: fetches if needed, prepares competition context when it is missing, then trains and writes one candidate artifact directory on the frozen folds; when optimization is enabled, `train` first runs Optuna for the current experiment candidate and stores optimization metadata inside that candidate directory
 - `submit`: resolves one candidate artifact by `candidate_id` and never retrains implicitly
-
-The `preprocess` stage is a diagnostic/export path, not a separate required step in the normal runtime contract. It writes:
-- `preprocess_summary.csv`
-- `preprocess_features.csv`
-- `preprocess_models.csv`
 
 `submit` defaults to `config.candidate_id`. Use `--candidate-id` only when you want to submit another existing candidate for the same competition.
 
@@ -156,9 +146,7 @@ Binary prediction artifact contract:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `candidate.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected artifact manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id` so the existing train, tune, and submit paths can continue working during the transition to the broader candidate-centric workflow.
-
-`tune` uses the current experiment candidate only. When `experiment.candidate.optimization.enabled=true`, the tune stage evaluates that candidate, writes study artifacts, and retrains the best trial into the normal single-model training artifact layout.
+The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id`.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -184,13 +172,13 @@ Manual verification for each target:
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
-Manual verification for tuning:
-- run `uv run python main.py tune` with `experiment.candidate.optimization.enabled: true` and at least one stopping condition
+Manual verification for optimization:
+- run `uv run python main.py train` with `experiment.candidate.optimization.enabled: true` and at least one stopping condition
 - supported tunable combinations are:
   - binary: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
   - regression: `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
-- confirm `artifacts/<competition_slug>/tune/<study_id>/study_manifest.json` is written
-- confirm `artifacts/<competition_slug>/tune/<study_id>/trials.csv` records trial state, score, and params
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/optimization_summary.json` is written
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/optimization_trials.csv` records trial state, score, and params
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` records `tuning_provenance`
 
 ## Outputs
@@ -199,13 +187,11 @@ Manual verification for tuning:
   - `competition.json`
   - `folds.csv`
 - EDA reports: `reports/<competition_slug>/`
-  - when `preprocess` stage is run, also includes `preprocess_summary.csv`, `preprocess_features.csv`, and `preprocess_models.csv`
-- Tuning artifacts: `artifacts/<competition_slug>/tune/<study_id>/`
-  - includes `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json`
 - Candidate artifacts: `artifacts/<competition_slug>/candidates/<candidate_id>/`
   - includes `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
   - `candidate.json` is the canonical training metadata source
   - tuned retrain candidates also record `tuning_provenance`
+  - optimized candidates also include `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`
 - Submission ledger: `artifacts/<competition_slug>/submissions.csv` as an append-only submission event table keyed by `candidate_id`
 
 ## Current Assumptions
@@ -215,8 +201,8 @@ Manual verification for tuning:
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
 - The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
-- `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` and `tune` consume that frozen context and auto-run `prepare` only when it is missing.
-- The `tune` stage uses the current experiment candidate only, and the tuned best-trial retrain writes a standard single-candidate artifact with `tuning_provenance`.
+- `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` consumes that frozen context and auto-runs `prepare` only when it is missing.
+- Enabled optimization is part of `train`, uses the current experiment candidate only, and writes candidate-local metadata alongside the tuned artifact with `tuning_provenance`.
 - Submission uses `candidate.json` as the schema/task source of truth.
 - Submission defaults to `config.candidate_id`; `submit --candidate-id <candidate_id>` overrides that selection explicitly.
 - Submission metadata includes the selected `model_id`; current candidate artifacts contain exactly one `model_id`.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -18,37 +18,32 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 8. Resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
    - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
    - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `lightgbm + ordinal`, `catboost + native`, `xgboost + ordinal`
-9. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
-10. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
-
-When the explicit `tune` stage is selected, the workflow additionally loads the frozen fold assignments from `folds.csv`, runs an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, writes tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`, and retrains the best trial into the standard candidate artifact layout with `tuning_provenance` recorded in `candidate.json`.
+9. When `experiment.candidate.optimization.enabled=true`, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
+10. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional optimization metadata files.
+11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
 
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `prepare` -> `train` -> `submit`)
 - `uv run python main.py fetch`: ensure competition data is present
 - `uv run python main.py prepare`: fetch if needed, load the shared dataset context, write EDA reports, persist competition metadata, and freeze folds
 - `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
-- `uv run python main.py preprocess`: fetch if needed, load the shared dataset context, validate model-specific preprocessing paths, and write preprocessing diagnostics
-- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, and write one candidate artifact directory on the frozen folds
-- `uv run python main.py tune`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, run an Optuna study for the current experiment candidate when `experiment.candidate.optimization.enabled=true`, write tuning artifacts, and retrain the best trial into a normal candidate artifact directory on the frozen folds
+- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, write one candidate artifact directory on the frozen folds, and when optimization is enabled run Optuna plus candidate-local optimization artifact writing before the final retrain
 - `uv run python main.py submit`: prepare or submit the configured `candidate_id`
 - `uv run python main.py submit --candidate-id <candidate_id>`: prepare or submit another existing candidate for the configured competition
-
-The `preprocess` stage is intentionally diagnostic. It is not part of the default runtime contract and it does not create a second training artifact layout.
 
 The default `submit` path supports current candidate artifacts only. Unsupported or missing candidate artifacts fail directly.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, preprocess diagnostics, training, tuning, and submission.
+- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, training, and submission.
 - `src/tabular_shenanigans/competition.py`: competition-level preparation, `competition.json` persistence, `folds.csv` persistence, prepared-context validation, and split reconstruction from frozen folds.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
-- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, native-frame support for CatBoost, and preprocess-stage diagnostics.
+- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, candidate artifact writing, and candidate manifest generation.
-- `src/tabular_shenanigans/tune.py`: Optuna study execution for the current experiment candidate on the frozen fold assignments, study artifact writing, and best-trial retraining into the standard candidate artifact layout.
+- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, candidate artifact writing, candidate manifest generation, and optimization-aware training orchestration.
+- `src/tabular_shenanigans/tune.py`: internal Optuna helper used by `train` when candidate optimization is enabled.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates.
 
 ## Configuration Contract
@@ -108,7 +103,7 @@ Configured metrics are normalized to the internal metric names during config val
 The old flat config layout is unsupported and fails fast.
 The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id`.
 optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.
-the `tune` stage uses the current experiment candidate only.
+enabled optimization is consumed by `train` and uses the current experiment candidate only.
 LightGBM, CatBoost, and XGBoost require the optional booster dependencies installed via `uv sync --extra boosters`.
 
 ## Preferred Verification Targets
@@ -128,8 +123,8 @@ Manual verification steps for each target:
 - run `uv run python main.py submit`
 - confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected candidate directory
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
-- when tuning is enabled, run `uv run python main.py tune` and confirm `study_manifest.json`, `study_summary.csv`, `trials.csv`, and `best_params.json` are generated under `artifacts/<competition_slug>/tune/<study_id>/`
-- when tuning is enabled, confirm the best-trial retrain writes a standard candidate artifact and records `tuning_provenance` in `candidate.json`
+- when optimization is enabled, run `uv run python main.py train` and confirm `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json` are generated in the candidate directory
+- when optimization is enabled, confirm the best-trial retrain writes a standard candidate artifact and records `tuning_provenance` in `candidate.json`
 
 ## Artifact Contract
 - A validated in-memory config object from Pydantic
@@ -146,10 +141,6 @@ Manual verification steps for each target:
   - `target_summary.csv`
   - `feature_type_counts.csv`
   - `run_summary.csv`
-  - when the `preprocess` stage is run:
-    - `preprocess_summary.csv`
-    - `preprocess_features.csv`
-    - `preprocess_models.csv`
 - Candidate artifacts under `artifacts/<competition_slug>/candidates/<candidate_id>/`:
   - `candidate.json`
   - `fold_metrics.csv`
@@ -157,12 +148,11 @@ Manual verification steps for each target:
   - `test_predictions.csv`
   - `submission.csv` when prepared or submitted
 - `candidate.json` is the canonical current training metadata source
-- tuned retrain candidates record `tuning_provenance` in `candidate.json`
-- Tuning artifacts under `artifacts/<competition_slug>/tune/<study_id>/`:
-  - `study_manifest.json`
-  - `study_summary.csv`
-  - `trials.csv`
-  - `best_params.json`
+- optimized candidates record `tuning_provenance` in `candidate.json`
+- optimized candidates also include:
+  - `optimization_summary.json`
+  - `optimization_trials.csv`
+  - `optimization_best_params.json`
 - Append-only submission ledger at `artifacts/<competition_slug>/submissions.csv` keyed by `candidate_id`
 
 ## Runtime Invariants And Failure Behavior
@@ -173,12 +163,12 @@ Manual verification steps for each target:
 - the old flat config layout is unsupported
 - `competition.task_type` and `competition.primary_metric` must be present in config for every run
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`
-- `train` and `tune` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
+- `train` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
 - the current runtime supports one `experiment.candidate` of type `model`
 - `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
 - training must write exactly one candidate artifact directory keyed by `candidate_id`
 - rerunning an existing `candidate_id` must fail instead of mutating an existing artifact directory
-- the `tune` stage requires `experiment.candidate.optimization.enabled=true`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal candidate artifact layout
+- enabled optimization is part of `train`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
 - `submit` must resolve one candidate by `candidate_id`, defaulting to `config.candidate_id`
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
@@ -217,7 +207,7 @@ Hard-error cases include:
 - enabled optimization without `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds` -> hard error
 - enabled optimization for an unsupported candidate combination -> hard error
 - Missing/invalid competition zip contents -> hard error
-- Missing `competition.json` or `folds.csv` during `train`/`tune` -> auto-run `prepare`
+- Missing `competition.json` or `folds.csv` during `train` -> auto-run `prepare`
 - Prepared competition context that no longer matches the current config or resolved dataset schema -> hard error
 - `id_column` inference not exactly one column -> hard error
 - `label_column` inference not exactly one column -> hard error
@@ -254,4 +244,4 @@ Hard-error cases include:
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
 - New model families should be introduced in `models.py` with explicit task compatibility, canonical recipe IDs, and matching artifact outputs.
 - New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract or the preprocessing-first recipe naming convention.
-- New run or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.
+- New candidate or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.

--- a/main.py
+++ b/main.py
@@ -8,10 +8,8 @@ from tabular_shenanigans.competition import prepare_competition
 from tabular_shenanigans.config import AppConfig, load_config
 from tabular_shenanigans.data import fetch_competition_data, load_competition_dataset_context
 from tabular_shenanigans.eda import run_eda
-from tabular_shenanigans.preprocess import run_preprocess
 from tabular_shenanigans.submit import run_submission
-from tabular_shenanigans.tune import run_tuning
-from tabular_shenanigans.train import run_training
+from tabular_shenanigans.train import run_training_workflow
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -23,9 +21,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("fetch", help="Download competition data if it is missing.")
     subparsers.add_parser("prepare", help="Persist EDA reports, competition metadata, and frozen folds.")
     subparsers.add_parser("eda", help="Run EDA reports only.")
-    subparsers.add_parser("preprocess", help="Write preprocessing diagnostics only.")
-    subparsers.add_parser("train", help="Train the current candidate only.")
-    subparsers.add_parser("tune", help="Run Optuna tuning and retrain the best trial.")
+    subparsers.add_parser("train", help="Train the current candidate, with optional optimization.")
 
     submit_parser = subparsers.add_parser("submit", help="Prepare or submit from a candidate artifact.")
     submit_parser.add_argument(
@@ -71,7 +67,7 @@ def _prepare_competition_stage(config: AppConfig):
 
 def _run_full_pipeline(config: AppConfig) -> None:
     dataset_context, _ = _prepare_competition_stage(config)
-    candidate_dir = run_training(config=config, dataset_context=dataset_context)
+    candidate_dir = run_training_workflow(config=config, dataset_context=dataset_context)
     print(f"Candidate artifacts ready: {candidate_dir}")
     submission_path, submission_status = run_submission(config=config)
     print(f"Submission file ready: {submission_path} ({submission_status})")
@@ -84,26 +80,11 @@ def _run_eda_stage(config: AppConfig) -> None:
     print(f"EDA reports ready: {report_dir}")
 
 
-def _run_preprocess_stage(config: AppConfig) -> None:
-    _ensure_data_ready(config)
-    dataset_context = _load_shared_dataset_context(config)
-    report_dir = run_preprocess(config=config, dataset_context=dataset_context)
-    print(f"Preprocess reports ready: {report_dir}")
-
-
 def _run_train_stage(config: AppConfig) -> None:
     _ensure_data_ready(config)
     dataset_context = _load_shared_dataset_context(config)
-    candidate_dir = run_training(config=config, dataset_context=dataset_context)
+    candidate_dir = run_training_workflow(config=config, dataset_context=dataset_context)
     print(f"Candidate artifacts ready: {candidate_dir}")
-
-
-def _run_tune_stage(config: AppConfig) -> None:
-    _ensure_data_ready(config)
-    dataset_context = _load_shared_dataset_context(config)
-    tuning_result = run_tuning(config=config, dataset_context=dataset_context)
-    print(f"Tuning artifacts ready: {tuning_result.study_dir}")
-    print(f"Best-trial candidate artifacts ready: {tuning_result.candidate_dir}")
 
 
 def _run_submit_stage(config: AppConfig, args: argparse.Namespace) -> None:
@@ -138,16 +119,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_eda_stage(config)
         return
 
-    if args.stage == "preprocess":
-        _run_preprocess_stage(config)
-        return
-
     if args.stage == "train":
         _run_train_stage(config)
-        return
-
-    if args.stage == "tune":
-        _run_tune_stage(config)
         return
 
     if args.stage == "submit":

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -16,16 +16,6 @@ class ConfigError(ValueError):
     pass
 
 
-class TuningConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    enabled: bool = False
-    model_id: str | None = None
-    n_trials: int | None = Field(default=None, ge=1)
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    random_state: int = 42
-
-
 class CompetitionCvConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -234,27 +224,10 @@ class AppConfig(BaseModel):
         )
 
     @property
-    def model_ids(self) -> list[str]:
-        return [self.resolved_model_id]
-
-    @property
     def model_parameter_overrides(self) -> dict[str, object] | None:
         if not self.experiment.candidate.model_params:
             return None
         return dict(self.experiment.candidate.model_params)
-
-    @property
-    def tuning(self) -> TuningConfig | None:
-        optimization = self.experiment.candidate.optimization
-        if not optimization.enabled:
-            return None
-        return TuningConfig(
-            enabled=True,
-            model_id=self.resolved_model_id,
-            n_trials=optimization.n_trials,
-            timeout_seconds=optimization.timeout_seconds,
-            random_state=optimization.random_state,
-        )
 
     @property
     def submit_enabled(self) -> bool:

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timezone
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable
 
 import numpy as np
@@ -9,10 +7,6 @@ from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer, OneHotEncoder, OrdinalEncoder, StandardScaler
-
-from tabular_shenanigans.config import AppConfig
-from tabular_shenanigans.data import CompetitionDatasetContext
-from tabular_shenanigans.models import get_model_definition
 
 PreprocessorBuilder = Callable[[list[str], list[str], list[str]], object]
 
@@ -316,125 +310,3 @@ def summarize_feature_types(
             {"feature_type": "total", "feature_count": int(x_train_raw.shape[1])},
         ]
     )
-
-
-def _transformed_column_count(transformed_values: object) -> int:
-    if isinstance(transformed_values, pd.DataFrame):
-        return int(transformed_values.shape[1])
-    return int(np.asarray(transformed_values).shape[1])
-
-
-def _transformed_output_kind(transformed_values: object) -> str:
-    if isinstance(transformed_values, pd.DataFrame):
-        return "dataframe"
-    if isinstance(transformed_values, np.ndarray):
-        return "ndarray"
-    return type(transformed_values).__name__
-
-
-def run_preprocess(
-    config: AppConfig,
-    dataset_context: CompetitionDatasetContext,
-) -> Path:
-    train_df = dataset_context.train_df
-    test_df = dataset_context.test_df
-    id_column = dataset_context.id_column
-    label_column = dataset_context.label_column
-
-    x_train_raw, x_test_raw, _ = prepare_feature_frames(
-        train_df=train_df,
-        test_df=test_df,
-        id_column=id_column,
-        label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
-    )
-    numeric_columns, categorical_columns = resolve_feature_types(
-        x_train_raw=x_train_raw,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
-    )
-
-    report_dir = Path("reports") / config.competition_slug
-    report_dir.mkdir(parents=True, exist_ok=True)
-
-    feature_rows: list[dict[str, object]] = []
-    forced_categorical = set(config.force_categorical)
-    forced_numeric = set(config.force_numeric)
-    numeric_column_set = set(numeric_columns)
-    for column in x_train_raw.columns:
-        forced_feature_type = ""
-        if column in forced_categorical:
-            forced_feature_type = "categorical"
-        elif column in forced_numeric:
-            forced_feature_type = "numeric"
-        inferred_feature_type = "numeric" if column in numeric_column_set else "categorical"
-        feature_rows.append(
-            {
-                "feature_name": column,
-                "train_dtype": str(x_train_raw[column].dtype),
-                "test_dtype": str(x_test_raw[column].dtype),
-                "train_null_pct": float(x_train_raw[column].isna().mean()),
-                "test_null_pct": float(x_test_raw[column].isna().mean()),
-                "train_nunique": int(x_train_raw[column].nunique(dropna=False)),
-                "forced_feature_type": forced_feature_type,
-                "inferred_feature_type": inferred_feature_type,
-            }
-        )
-    feature_details_df = pd.DataFrame(feature_rows)
-    feature_details_df.to_csv(report_dir / "preprocess_features.csv", index=False)
-
-    model_rows: list[dict[str, object]] = []
-    for model_id in config.model_ids:
-        model_definition = get_model_definition(config.task_type, model_id)
-        preprocessing_definition = get_preprocessing_definition(model_definition.preprocessing_scheme_id)
-        preprocessor, model_numeric_columns, model_categorical_columns = build_preprocessor(
-            scheme_id=model_definition.preprocessing_scheme_id,
-            x_train_raw=x_train_raw,
-            force_categorical=config.force_categorical,
-            force_numeric=config.force_numeric,
-            low_cardinality_int_threshold=config.low_cardinality_int_threshold,
-        )
-        if model_definition.model_name.startswith("LGBM") and hasattr(preprocessor, "set_output"):
-            preprocessor.set_output(transform="pandas")
-        x_train_processed = preprocessor.fit_transform(x_train_raw)
-        x_test_processed = preprocessor.transform(x_test_raw)
-        model_rows.append(
-            {
-                "model_id": model_definition.model_id,
-                "model_name": model_definition.model_name,
-                "preprocessing_scheme_id": preprocessing_definition.scheme_id,
-                "preprocessing_scheme_name": preprocessing_definition.scheme_name,
-                "numeric_feature_count": len(model_numeric_columns),
-                "categorical_feature_count": len(model_categorical_columns),
-                "processed_train_rows": int(x_train_raw.shape[0]),
-                "processed_train_cols": _transformed_column_count(x_train_processed),
-                "processed_test_rows": int(x_test_raw.shape[0]),
-                "processed_test_cols": _transformed_column_count(x_test_processed),
-                "output_kind": _transformed_output_kind(x_train_processed),
-            }
-        )
-    model_preprocess_df = pd.DataFrame(model_rows)
-    model_preprocess_df.to_csv(report_dir / "preprocess_models.csv", index=False)
-
-    summary_df = pd.DataFrame(
-        [
-            {"metric": "generated_at_utc", "value": datetime.now(timezone.utc).isoformat()},
-            {"metric": "id_column", "value": id_column},
-            {"metric": "label_column", "value": label_column},
-            {"metric": "model_count", "value": len(config.model_ids)},
-            {"metric": "modeled_feature_count", "value": int(x_train_raw.shape[1])},
-            {"metric": "numeric_feature_count", "value": len(numeric_columns)},
-            {"metric": "categorical_feature_count", "value": len(categorical_columns)},
-        ]
-    )
-    summary_df.to_csv(report_dir / "preprocess_summary.csv", index=False)
-
-    print(f"Preprocess feature count: {int(x_train_raw.shape[1])}")
-    print(f"Numeric features: {len(numeric_columns)}")
-    print(f"Categorical features: {len(categorical_columns)}")
-    print(f"Model-specific preprocess summaries: {len(model_rows)}")
-
-    return report_dir

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -69,6 +69,12 @@ class ModelEvaluationArtifacts:
     final_test_predictions: np.ndarray
 
 
+@dataclass(frozen=True)
+class OptimizationArtifacts:
+    summary: dict[str, object]
+    trials_df: pd.DataFrame
+
+
 def _json_ready(value: object) -> object:
     if isinstance(value, dict):
         return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
@@ -384,6 +390,24 @@ def _write_candidate_artifacts(
     test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
 
 
+def _write_optimization_artifacts(
+    candidate_dir: Path,
+    optimization_artifacts: OptimizationArtifacts,
+) -> None:
+    (candidate_dir / "optimization_summary.json").write_text(
+        json.dumps(_json_ready(optimization_artifacts.summary), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    optimization_artifacts.trials_df.to_csv(candidate_dir / "optimization_trials.csv", index=False)
+
+    best_params = optimization_artifacts.summary.get("best_params")
+    if isinstance(best_params, dict):
+        (candidate_dir / "optimization_best_params.json").write_text(
+            json.dumps(_json_ready(best_params), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+
 def run_training(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
@@ -507,5 +531,44 @@ def run_training(
         test_ids=test_df[id_column],
         id_column=id_column,
         label_column=label_column,
+    )
+    return candidate_dir
+
+
+def run_training_workflow(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+) -> Path:
+    candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
+    if candidate_dir.exists():
+        raise ValueError(
+            "Candidate artifacts already exist for this candidate_id. "
+            f"Choose a new experiment.candidate.candidate_id or remove {candidate_dir}"
+        )
+
+    optimization = config.experiment.candidate.optimization
+    if not optimization.enabled:
+        return run_training(config=config, dataset_context=dataset_context)
+
+    from tabular_shenanigans.tune import run_optimization
+
+    optimization_result = run_optimization(config=config, dataset_context=dataset_context)
+    candidate_dir = run_training(
+        config=config,
+        dataset_context=dataset_context,
+        model_spec=optimization_result.best_model_spec,
+        tuning_provenance=optimization_result.tuning_provenance,
+    )
+    _write_optimization_artifacts(
+        candidate_dir=candidate_dir,
+        optimization_artifacts=OptimizationArtifacts(
+            summary=optimization_result.optimization_summary,
+            trials_df=optimization_result.trials_df,
+        ),
+    )
+    print(
+        f"Optimization complete: best_trial={optimization_result.best_trial_number}, "
+        f"best_{config.primary_metric}={optimization_result.best_value:.6f}, "
+        f"candidate={candidate_dir.name}"
     )
     return candidate_dir

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -1,7 +1,6 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 
 import optuna
 import pandas as pd
@@ -17,21 +16,24 @@ from tabular_shenanigans.train import (
     _build_target_summary,
     _evaluate_model_spec,
     _json_ready,
-    run_training,
 )
 
 
 @dataclass(frozen=True)
-class TuningResult:
-    study_dir: Path
-    candidate_dir: Path
+class OptimizationResult:
+    best_model_spec: TrainingModelSpec
+    tuning_provenance: dict[str, object]
+    optimization_summary: dict[str, object]
+    trials_df: pd.DataFrame
+    best_trial_number: int
+    best_value: float
 
 
 def _make_study_id() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
 
 
-def _build_study_config_snapshot(
+def _build_optimization_config_snapshot(
     config: AppConfig,
     tuning_model_spec: TrainingModelSpec,
     positive_label: object | None,
@@ -73,26 +75,28 @@ def _build_trials_df(study: optuna.Study, metric_name: str) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def _build_study_manifest(
+def _build_optimization_summary(
     config: AppConfig,
     study: optuna.Study,
     study_id: str,
-    study_config_snapshot: dict[str, object],
+    optimization_config_snapshot: dict[str, object],
     tuning_model_spec: TrainingModelSpec,
     model_name: str,
     preprocessing_scheme_id: str,
     target_summary: dict[str, object],
-    candidate_dir: Path | None = None,
 ) -> dict[str, object]:
     best_trial = study.best_trial
     return {
+        "artifact_type": "candidate_optimization",
         "study_id": study_id,
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
         "competition_slug": config.competition_slug,
+        "candidate_id": config.candidate_id,
         "task_type": config.task_type,
         "primary_metric": config.primary_metric,
+        "optimization_method": config.experiment.candidate.optimization.method,
         "optimization_direction": study.direction.name.lower(),
-        "config_snapshot": study_config_snapshot,
+        "config_snapshot": optimization_config_snapshot,
         "model_id": tuning_model_spec.model_id,
         "model_name": model_name,
         "preprocessing_scheme_id": preprocessing_scheme_id,
@@ -103,60 +107,20 @@ def _build_study_manifest(
         "best_params": best_trial.params,
         "best_model_params": best_trial.user_attrs.get("model_params"),
         "target_summary": target_summary,
-        "train_candidate_id": candidate_dir.name if candidate_dir is not None else None,
-        "train_candidate_dir": str(candidate_dir) if candidate_dir is not None else None,
     }
 
 
-def _write_tuning_artifacts(
-    study_dir: Path,
-    study_manifest: dict[str, object],
-    trials_df: pd.DataFrame,
-) -> None:
-    best_params = study_manifest["best_params"]
-    study_summary = pd.DataFrame(
-        [
-            {
-                "study_id": study_manifest["study_id"],
-                "competition_slug": study_manifest["competition_slug"],
-                "task_type": study_manifest["task_type"],
-                "primary_metric": study_manifest["primary_metric"],
-                "optimization_direction": study_manifest["optimization_direction"],
-                "model_id": study_manifest["model_id"],
-                "model_name": study_manifest["model_name"],
-                "preprocessing_scheme_id": study_manifest["preprocessing_scheme_id"],
-                "trial_count": study_manifest["trial_count"],
-                "completed_trial_count": study_manifest["completed_trial_count"],
-                "best_trial_number": study_manifest["best_trial_number"],
-                "best_value": study_manifest["best_value"],
-                "train_candidate_id": study_manifest["train_candidate_id"],
-            }
-        ]
-    )
-    study_summary.to_csv(study_dir / "study_summary.csv", index=False)
-    trials_df.to_csv(study_dir / "trials.csv", index=False)
-    (study_dir / "best_params.json").write_text(
-        json.dumps(_json_ready(best_params), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    (study_dir / "study_manifest.json").write_text(
-        json.dumps(_json_ready(study_manifest), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-
-
-def run_tuning(
+def run_optimization(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
-) -> TuningResult:
-    if config.tuning is None or not config.tuning.enabled:
-        raise ValueError("The tune stage requires tuning.enabled=true in config.yaml.")
-    if config.tuning.model_id is None:
-        raise ValueError("The tune stage requires tuning.model_id.")
+) -> OptimizationResult:
+    optimization = config.experiment.candidate.optimization
+    if not optimization.enabled:
+        raise ValueError("Optimization requires experiment.candidate.optimization.enabled=true in config.yaml.")
 
     task_type = config.task_type
     primary_metric = config.primary_metric
-    tuning_model_spec = TrainingModelSpec(model_id=config.tuning.model_id)
+    tuning_model_spec = TrainingModelSpec(model_id=config.resolved_model_id)
     model_definition = get_model_definition(task_type, tuning_model_spec.model_id)
 
     train_df = dataset_context.train_df
@@ -198,9 +162,7 @@ def run_tuning(
     )
 
     study_id = _make_study_id()
-    study_dir = Path("artifacts") / config.competition_slug / "tune" / study_id
-    study_dir.mkdir(parents=True, exist_ok=True)
-    study_config_snapshot = _build_study_config_snapshot(
+    optimization_config_snapshot = _build_optimization_config_snapshot(
         config=config,
         tuning_model_spec=tuning_model_spec,
         positive_label=positive_label,
@@ -210,7 +172,7 @@ def run_tuning(
 
     direction = "maximize" if is_higher_better(primary_metric) else "minimize"
     optuna.logging.set_verbosity(optuna.logging.WARNING)
-    sampler = optuna.samplers.TPESampler(seed=config.tuning.random_state)
+    sampler = optuna.samplers.TPESampler(seed=optimization.random_state)
     study = optuna.create_study(direction=direction, sampler=sampler, study_name=study_id)
 
     def objective(trial: optuna.Trial) -> float:
@@ -245,56 +207,38 @@ def run_tuning(
 
     study.optimize(
         objective,
-        n_trials=config.tuning.n_trials,
-        timeout=config.tuning.timeout_seconds,
+        n_trials=optimization.n_trials,
+        timeout=optimization.timeout_seconds,
         gc_after_trial=True,
     )
-
-    trials_df = _build_trials_df(study=study, metric_name=primary_metric)
-    study_manifest = _build_study_manifest(
-        config=config,
-        study=study,
-        study_id=study_id,
-        study_config_snapshot=study_config_snapshot,
-        tuning_model_spec=tuning_model_spec,
-        model_name=model_definition.model_name,
-        preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
-        target_summary=target_summary,
-    )
-    _write_tuning_artifacts(study_dir=study_dir, study_manifest=study_manifest, trials_df=trials_df)
 
     best_parameter_overrides = dict(study.best_trial.params)
     tuning_provenance = {
         "study_id": study_id,
-        "study_dir": str(study_dir),
+        "optimization_method": optimization.method,
         "trial_number": study.best_trial.number,
         "base_model_id": tuning_model_spec.model_id,
         "parameter_overrides": best_parameter_overrides,
+        "best_value": study.best_trial.value,
     }
-    candidate_dir = run_training(
-        config=config,
-        dataset_context=dataset_context,
-        model_spec=TrainingModelSpec(
-            model_id=tuning_model_spec.model_id,
-            parameter_overrides=best_parameter_overrides,
-        ),
-        tuning_provenance=tuning_provenance,
-    )
-
-    updated_study_manifest = _build_study_manifest(
+    optimization_summary = _build_optimization_summary(
         config=config,
         study=study,
         study_id=study_id,
-        study_config_snapshot=study_config_snapshot,
+        optimization_config_snapshot=optimization_config_snapshot,
         tuning_model_spec=tuning_model_spec,
         model_name=model_definition.model_name,
         preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
         target_summary=target_summary,
-        candidate_dir=candidate_dir,
     )
-    _write_tuning_artifacts(study_dir=study_dir, study_manifest=updated_study_manifest, trials_df=trials_df)
-    print(
-        f"Tuning complete: best_trial={study.best_trial.number}, "
-        f"best_{primary_metric}={study.best_value:.6f}, candidate={candidate_dir.name}"
+    return OptimizationResult(
+        best_model_spec=TrainingModelSpec(
+            model_id=tuning_model_spec.model_id,
+            parameter_overrides=best_parameter_overrides,
+        ),
+        tuning_provenance=tuning_provenance,
+        optimization_summary=optimization_summary,
+        trials_df=_build_trials_df(study=study, metric_name=primary_metric),
+        best_trial_number=study.best_trial.number,
+        best_value=study.best_trial.value,
     )
-    return TuningResult(study_dir=study_dir, candidate_dir=candidate_dir)


### PR DESCRIPTION
Closes #76

## Summary
- remove the standalone preprocess and tune CLI stages so train is the only model-building command
- keep optimization metadata but write it inside the candidate directory instead of under a separate tune artifact tree
- remove dead config and preprocess-stage compatibility seams and update the docs to describe only the supported workflow

## Verification
- uv run python main.py --help
- uv run python main.py train with smoke candidate smoke_logreg_issue76_plain_v1
- uv run python main.py train with smoke candidate smoke_logreg_issue76_opt_v1 and experiment.candidate.optimization.enabled=true
- uv run python main.py submit --candidate-id smoke_logreg_issue76_opt_v1
- uv run python main.py tune (expected invalid choice)
- uv run python main.py preprocess (expected invalid choice)
- PYTHONPYCACHEPREFIX=/tmp/pycache_issue76 PYTHONPATH=src .venv/bin/python -m compileall main.py src/tabular_shenanigans