### PR TITLE
Add experiment-scoped feature recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Freeze CV assignments once per prepared competition context and reuse them across `train`.
 - Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `train`, and submit-only flows.
-- Train one cross-validated model candidate at a time using config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
+- Train one cross-validated model candidate at a time using an optional config-selected feature recipe plus config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
 - Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
 - When `experiment.candidate.optimization.enabled=true`, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact selected by `candidate_id`.
@@ -120,6 +120,7 @@ Required top-level sections:
 Current `experiment.candidate` contract:
 - `candidate_type`: currently only `model` is supported
 - `candidate_id`
+- optional `feature_recipe_id`: tracked deterministic feature recipe applied after raw feature extraction and before preprocessing/model fitting; defaults to `identity`
 - `preprocessor`: `onehot`, `ordinal`, `native`, or `frequency`
 - `model_family`
   - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
@@ -135,6 +136,12 @@ Current `experiment.candidate` contract:
 Supported `model_family + preprocessor` combinations:
 - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
 - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
+
+Built-in `feature_recipe_id` values:
+- `identity`: default pass-through recipe for new competitions
+- `s6e3_v1`: a first competition-specific feature set for `playground-series-s6e3`
+
+Feature recipes live in tracked Python modules under `src/tabular_shenanigans/feature_recipes/`. They are intended for deterministic, leakage-safe competition-specific feature transforms. New competitions should start with `identity`; add a tracked recipe module only when the generic baseline plateaus.
 
 `frequency` encodes each categorical value as its fold-local relative frequency in the training fold. Unseen categories at transform time map to `0.0`.
 
@@ -169,6 +176,7 @@ Manual verification for each target:
 - confirm `artifacts/<competition_slug>/competition.json` and `artifacts/<competition_slug>/folds.csv` are written
 - confirm the pipeline infers `id_column` and `label_column` without overrides
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written
+- confirm `candidate.json` records the selected `feature_recipe_id`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written for the resolved internal model artifact
 - run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
@@ -191,7 +199,7 @@ Manual verification for optimization:
 - EDA reports: `reports/<competition_slug>/`
 - Candidate artifacts: `artifacts/<competition_slug>/candidates/<candidate_id>/`
   - includes `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
-  - `candidate.json` is the canonical training metadata source
+  - `candidate.json` is the canonical training metadata source and records the selected `feature_recipe_id` plus engineered `feature_columns`
   - tuned retrain candidates also record `tuning_provenance`
   - optimized candidates also include `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`
 - Submission ledger: `artifacts/<competition_slug>/submissions.csv` as an append-only submission event table keyed by `candidate_id`
@@ -203,8 +211,10 @@ Manual verification for optimization:
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
 - The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
+- `experiment.candidate.feature_recipe_id` defaults to `identity`; feature recipes are tracked Python modules rather than runtime scripts or YAML transform blocks.
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` consumes that frozen context and auto-runs `prepare` only when it is missing.
 - Enabled optimization is part of `train`, uses the current experiment candidate only, and writes candidate-local metadata alongside the tuned artifact with `tuning_provenance`.
+- Feature recipes are deterministic and leakage-safe; fold-learned transforms still belong in preprocessing, not in the recipe layer.
 - Submission uses `candidate.json` as the schema/task source of truth.
 - Submission defaults to `config.candidate_id`; `submit --candidate-id <candidate_id>` overrides that selection explicitly.
 - Submission metadata includes the selected `model_id`; current candidate artifacts contain exactly one `model_id`.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -35,9 +35,13 @@ experiment:
   candidate:
     candidate_type: model
     candidate_id: baseline_logreg_v1
+    feature_recipe_id: identity
     preprocessor: onehot
     model_family: logistic_regression
     model_params: {}
+
+    # Keep identity for new competitions, then switch to a tracked code recipe
+    # such as s6e3_v1 only when you need competition-specific features.
 
     # Alternative binary model candidates:
     # preprocessor: ordinal
@@ -45,7 +49,7 @@ experiment:
     # preprocessor: native
     # model_family: catboost
 
-    # Optional tuning settings for `uv run python main.py tune`.
+    # Optional tuning settings for `uv run python main.py train`.
     optimization:
       enabled: false
       # method: optuna

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -31,9 +31,13 @@ experiment:
   candidate:
     candidate_type: model
     candidate_id: baseline_elasticnet_v1
+    feature_recipe_id: identity
     preprocessor: onehot
     model_family: elasticnet
     model_params: {}
+
+    # Keep identity for new competitions, then switch to a tracked code recipe
+    # only when you need competition-specific features.
 
     # Alternative regression model candidates:
     # preprocessor: ordinal
@@ -41,7 +45,7 @@ experiment:
     # preprocessor: native
     # model_family: catboost
 
-    # Optional tuning settings for `uv run python main.py tune`.
+    # Optional tuning settings for `uv run python main.py train`.
     optimization:
       enabled: false
       # method: optuna

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -11,17 +11,18 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 4. Load one shared dataset context from `train.csv`, `test.csv`, and `sample_submission.csv`.
 5. Run `prepare` to write report CSVs under `reports/<competition_slug>/`, persist `artifacts/<competition_slug>/competition.json`, and freeze `artifacts/<competition_slug>/folds.csv`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
-7. During training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected model recipe:
+7. During training and tuning, apply the selected deterministic feature recipe to the raw feature frames. The default `identity` recipe leaves the features unchanged.
+8. During training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected model recipe:
    - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
    - `ordinal`: numeric median imputation; categorical most-frequent imputation + `OrdinalEncoder`
    - `native`: numeric median imputation inside a pandas frame; categorical missing-value fill with native categorical columns preserved for CatBoost
    - `frequency`: numeric median imputation; categorical values replaced by fold-local relative frequencies, with unseen categories mapped to `0.0`
-8. Resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
+9. Resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
    - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
    - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-9. When `experiment.candidate.optimization.enabled=true`, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
-10. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional optimization metadata files.
-11. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
+10. When `experiment.candidate.optimization.enabled=true`, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
+11. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional optimization metadata files.
+12. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
 
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `prepare` -> `train` -> `submit`)
@@ -40,6 +41,7 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, and runtime contract validation.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
+- `src/tabular_shenanigans/feature_recipes/*`: deterministic experiment-scoped feature transforms, including the `identity` default and tracked competition-specific recipe modules.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
@@ -80,6 +82,7 @@ Input:
 - Current `experiment.candidate` keys:
   - `candidate_type` (currently only `model`)
   - `candidate_id`
+  - `feature_recipe_id` (string, default `identity`; resolves to a tracked deterministic feature recipe applied before preprocessing)
   - `preprocessor` (`onehot`, `ordinal`, `native`, or `frequency`)
   - `model_family`
     - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
@@ -102,6 +105,7 @@ Binary prediction artifact contract:
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
 The old flat config layout is unsupported and fails fast.
+The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe; built-in recipe IDs are `identity` and `s6e3_v1`.
 The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id`.
 optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.
 enabled optimization is consumed by `train` and uses the current experiment candidate only.
@@ -149,7 +153,7 @@ Manual verification steps for each target:
   - `oof_predictions.csv`
   - `test_predictions.csv`
   - `submission.csv` when prepared or submitted
-- `candidate.json` is the canonical current training metadata source
+- `candidate.json` is the canonical current training metadata source and records `feature_recipe_id` plus the engineered `feature_columns`
 - optimized candidates record `tuning_provenance` in `candidate.json`
 - optimized candidates also include:
   - `optimization_summary.json`
@@ -167,7 +171,10 @@ Manual verification steps for each target:
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`
 - `train` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
 - the current runtime supports one `experiment.candidate` of type `model`
+- `experiment.candidate.feature_recipe_id` must resolve to one supported tracked recipe; `identity` is the default path for new competitions
 - `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
+- feature recipes are experiment-scoped, deterministic, leakage-safe transforms applied after raw feature extraction and before preprocessing
+- feature recipes must preserve row counts and row order and must produce identical train/test feature columns
 - training must write exactly one candidate artifact directory keyed by `candidate_id`
 - rerunning an existing `candidate_id` must fail instead of mutating an existing artifact directory
 - enabled optimization is part of `train`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal candidate artifact layout
@@ -205,6 +212,7 @@ Hard-error cases include:
 - Missing required top-level `competition` or `experiment` sections -> hard error
 - Any use of the old flat config layout -> hard error
 - Unsupported `experiment.candidate.candidate_type` -> hard error
+- Unknown `experiment.candidate.feature_recipe_id` -> hard error
 - Invalid configured `experiment.candidate.model_family + preprocessor` combination for the configured task -> hard error
 - enabled optimization without `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds` -> hard error
 - enabled optimization for an unsupported candidate combination -> hard error
@@ -217,6 +225,7 @@ Hard-error cases include:
 - Unknown columns in `force_categorical`, `force_numeric`, or `drop_columns` -> hard error
 - Any overlap between `force_categorical` and `force_numeric` -> hard error
 - No modeled feature columns remaining after excluding `id_column` and applying `drop_columns` -> hard error
+- Feature recipe output that changes row counts, row order, or train/test feature-column alignment -> hard error
 - Preprocessing fit/transform failure -> hard error
 - Unsupported task type for CV/model selection -> hard error
 - Unsupported metric for chosen task -> hard error
@@ -245,5 +254,6 @@ Hard-error cases include:
 - If the user-facing config workflow changes, update `config.binary.example.yaml` and `config.regression.example.yaml` alongside the docs.
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
 - New model families should be introduced in `models.py` with explicit task compatibility, canonical recipe IDs, and matching artifact outputs.
+- New feature recipes should be added under `src/tabular_shenanigans/feature_recipes/`, registered explicitly, and kept deterministic plus leakage-safe.
 - New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract or the preprocessing-first recipe naming convention.
 - New candidate or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.

--- a/main.py
+++ b/main.py
@@ -36,7 +36,8 @@ def _print_resolved_setup(config: AppConfig) -> None:
     print(
         "Resolved competition setup: "
         f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
-        f"candidate_id={config.candidate_id}, model_family={config.model_family}, "
+        f"candidate_id={config.candidate_id}, feature_recipe={config.feature_recipe_id}, "
+        f"model_family={config.model_family}, "
         f"preprocessor={config.preprocessor}, model_id={config.resolved_model_id}"
     )
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -5,6 +5,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
+from tabular_shenanigans.feature_recipes import resolve_feature_recipe_id
 from tabular_shenanigans.models import (
     get_tunable_candidate_model_specs,
     is_model_tunable,
@@ -61,6 +62,7 @@ class ModelCandidateConfig(BaseModel):
 
     candidate_type: Literal["model"] = "model"
     candidate_id: str = Field(min_length=1)
+    feature_recipe_id: str = Field(default="identity", min_length=1)
     preprocessor: Literal["onehot", "ordinal", "native", "frequency"]
     model_family: Literal[
         "ridge",
@@ -125,6 +127,10 @@ class AppConfig(BaseModel):
 
         if self.competition.task_type != "binary" and self.competition.positive_label is not None:
             raise ValueError("competition.positive_label is only supported for binary task_type.")
+
+        self.experiment.candidate.feature_recipe_id = resolve_feature_recipe_id(
+            self.experiment.candidate.feature_recipe_id
+        )
 
         resolved_model_id = self.resolved_model_id
         optimization = self.experiment.candidate.optimization
@@ -210,6 +216,10 @@ class AppConfig(BaseModel):
     @property
     def model_family(self) -> str:
         return self.experiment.candidate.model_family
+
+    @property
+    def feature_recipe_id(self) -> str:
+        return self.experiment.candidate.feature_recipe_id
 
     @property
     def preprocessor(self) -> str:

--- a/src/tabular_shenanigans/feature_recipes/__init__.py
+++ b/src/tabular_shenanigans/feature_recipes/__init__.py
@@ -1,0 +1,15 @@
+from tabular_shenanigans.feature_recipes.base import FeatureRecipeDefinition
+from tabular_shenanigans.feature_recipes.registry import (
+    apply_feature_recipe,
+    get_feature_recipe_definition,
+    get_supported_feature_recipe_ids,
+    resolve_feature_recipe_id,
+)
+
+__all__ = [
+    "FeatureRecipeDefinition",
+    "apply_feature_recipe",
+    "get_feature_recipe_definition",
+    "get_supported_feature_recipe_ids",
+    "resolve_feature_recipe_id",
+]

--- a/src/tabular_shenanigans/feature_recipes/base.py
+++ b/src/tabular_shenanigans/feature_recipes/base.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Callable
+
+import pandas as pd
+
+FeatureRecipeTransform = Callable[[pd.DataFrame, pd.DataFrame], tuple[pd.DataFrame, pd.DataFrame]]
+
+
+@dataclass(frozen=True)
+class FeatureRecipeDefinition:
+    recipe_id: str
+    recipe_name: str
+    transform: FeatureRecipeTransform

--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pandas as pd
+
+from tabular_shenanigans.feature_recipes.base import FeatureRecipeDefinition
+
+REQUIRED_COLUMNS = [
+    "SeniorCitizen",
+    "Partner",
+    "Dependents",
+    "tenure",
+    "MultipleLines",
+    "InternetService",
+    "OnlineSecurity",
+    "OnlineBackup",
+    "DeviceProtection",
+    "TechSupport",
+    "StreamingTV",
+    "StreamingMovies",
+    "Contract",
+    "PaperlessBilling",
+    "PaymentMethod",
+    "MonthlyCharges",
+    "TotalCharges",
+]
+
+SERVICE_ADDON_COLUMNS = [
+    "OnlineSecurity",
+    "OnlineBackup",
+    "DeviceProtection",
+    "TechSupport",
+    "StreamingTV",
+    "StreamingMovies",
+]
+
+STREAMING_COLUMNS = ["StreamingTV", "StreamingMovies"]
+SUPPORT_COLUMNS = ["OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"]
+
+
+def _require_columns(frame: pd.DataFrame, dataset_name: str) -> None:
+    missing_columns = [column for column in REQUIRED_COLUMNS if column not in frame.columns]
+    if missing_columns:
+        raise ValueError(
+            "Feature recipe 's6e3_v1' requires the Telco churn columns used by "
+            f"playground-series-s6e3. Missing columns in {dataset_name}: {missing_columns}"
+        )
+
+
+def _yes_flag(series: pd.Series) -> pd.Series:
+    return series.astype(str).eq("Yes").astype(int)
+
+
+def _build_service_count(frame: pd.DataFrame, columns: list[str]) -> pd.Series:
+    return pd.concat([_yes_flag(frame[column]) for column in columns], axis=1).sum(axis=1)
+
+
+def _build_tenure_bucket(series: pd.Series) -> pd.Series:
+    buckets = pd.cut(
+        series.astype(float),
+        bins=[-1.0, 12.0, 24.0, 48.0, np.inf],
+        labels=["tenure_00_12", "tenure_13_24", "tenure_25_48", "tenure_49_plus"],
+        include_lowest=True,
+    )
+    return buckets.astype(str)
+
+
+def _transform_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    transformed = frame.copy()
+
+    tenure = transformed["tenure"].astype(float)
+    monthly_charges = transformed["MonthlyCharges"].astype(float)
+    total_charges = transformed["TotalCharges"].astype(float)
+    safe_tenure = tenure.clip(lower=1.0)
+
+    transformed["has_internet_service"] = transformed["InternetService"].astype(str).ne("No").astype(int)
+    transformed["service_addon_count"] = _build_service_count(transformed, SERVICE_ADDON_COLUMNS)
+    transformed["streaming_count"] = _build_service_count(transformed, STREAMING_COLUMNS)
+    transformed["support_count"] = _build_service_count(transformed, SUPPORT_COLUMNS)
+    transformed["charges_per_month"] = total_charges / safe_tenure
+    transformed["charges_gap"] = total_charges - (tenure * monthly_charges)
+    transformed["tenure_monthlycharges_interaction"] = tenure * monthly_charges
+    transformed["tenure_bucket"] = _build_tenure_bucket(tenure)
+    transformed["tenure_contract"] = transformed["tenure_bucket"] + "__" + transformed["Contract"].astype(str)
+    transformed["internet_payment_profile"] = (
+        transformed["InternetService"].astype(str) + "__" + transformed["PaymentMethod"].astype(str)
+    )
+    transformed["household_profile"] = transformed["Partner"].astype(str) + "__" + transformed["Dependents"].astype(str)
+    transformed["senior_household_profile"] = (
+        transformed["SeniorCitizen"].astype(str) + "__" + transformed["Partner"].astype(str)
+    )
+    transformed["paperless_payment_profile"] = (
+        transformed["PaperlessBilling"].astype(str) + "__" + transformed["PaymentMethod"].astype(str)
+    )
+    return transformed
+
+
+def build_s6e3_v1_features(
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    _require_columns(x_train_raw, dataset_name="train features")
+    _require_columns(x_test_raw, dataset_name="test features")
+    return _transform_frame(x_train_raw), _transform_frame(x_test_raw)
+
+
+S6E3_V1_FEATURE_RECIPE = FeatureRecipeDefinition(
+    recipe_id="s6e3_v1",
+    recipe_name="S6E3FeatureSetV1",
+    transform=build_s6e3_v1_features,
+)

--- a/src/tabular_shenanigans/feature_recipes/registry.py
+++ b/src/tabular_shenanigans/feature_recipes/registry.py
@@ -1,0 +1,88 @@
+import pandas as pd
+
+from tabular_shenanigans.feature_recipes.base import FeatureRecipeDefinition
+from tabular_shenanigans.feature_recipes.playground_series_s6e3 import S6E3_V1_FEATURE_RECIPE
+
+
+def _identity_recipe(
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    return x_train_raw.copy(), x_test_raw.copy()
+
+
+FEATURE_RECIPE_REGISTRY = {
+    "identity": FeatureRecipeDefinition(
+        recipe_id="identity",
+        recipe_name="Identity",
+        transform=_identity_recipe,
+    ),
+    S6E3_V1_FEATURE_RECIPE.recipe_id: S6E3_V1_FEATURE_RECIPE,
+}
+
+
+def get_supported_feature_recipe_ids() -> list[str]:
+    return sorted(FEATURE_RECIPE_REGISTRY)
+
+
+def resolve_feature_recipe_id(recipe_id: str) -> str:
+    if recipe_id in FEATURE_RECIPE_REGISTRY:
+        return recipe_id
+
+    supported_recipe_ids = get_supported_feature_recipe_ids()
+    raise ValueError(
+        f"Feature recipe id '{recipe_id}' is not supported. Supported values: {supported_recipe_ids}"
+    )
+
+
+def get_feature_recipe_definition(recipe_id: str) -> FeatureRecipeDefinition:
+    resolved_recipe_id = resolve_feature_recipe_id(recipe_id)
+    return FEATURE_RECIPE_REGISTRY[resolved_recipe_id]
+
+
+def _validate_transformed_frames(
+    recipe_id: str,
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+    transformed_train: pd.DataFrame,
+    transformed_test: pd.DataFrame,
+) -> None:
+    if not isinstance(transformed_train, pd.DataFrame) or not isinstance(transformed_test, pd.DataFrame):
+        raise ValueError(f"Feature recipe '{recipe_id}' must return pandas DataFrame objects for train and test.")
+    if transformed_train.shape[0] != x_train_raw.shape[0]:
+        raise ValueError(f"Feature recipe '{recipe_id}' changed the train row count.")
+    if transformed_test.shape[0] != x_test_raw.shape[0]:
+        raise ValueError(f"Feature recipe '{recipe_id}' changed the test row count.")
+    if not transformed_train.index.equals(x_train_raw.index):
+        raise ValueError(f"Feature recipe '{recipe_id}' changed the train row index.")
+    if not transformed_test.index.equals(x_test_raw.index):
+        raise ValueError(f"Feature recipe '{recipe_id}' changed the test row index.")
+    if transformed_train.columns.tolist() != transformed_test.columns.tolist():
+        raise ValueError(
+            f"Feature recipe '{recipe_id}' must produce the same feature columns for train and test."
+        )
+    if transformed_train.columns.duplicated().any():
+        duplicate_columns = transformed_train.columns[transformed_train.columns.duplicated()].tolist()
+        raise ValueError(f"Feature recipe '{recipe_id}' produced duplicate feature columns: {duplicate_columns}")
+    if transformed_train.shape[1] == 0:
+        raise ValueError(f"Feature recipe '{recipe_id}' produced zero feature columns.")
+
+
+def apply_feature_recipe(
+    recipe_id: str,
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    definition = get_feature_recipe_definition(recipe_id)
+    transformed_train, transformed_test = definition.transform(
+        x_train_raw=x_train_raw.copy(),
+        x_test_raw=x_test_raw.copy(),
+    )
+    _validate_transformed_frames(
+        recipe_id=definition.recipe_id,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+        transformed_train=transformed_train,
+        transformed_test=transformed_test,
+    )
+    return transformed_train, transformed_test

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -11,6 +11,7 @@ from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
+from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
@@ -317,6 +318,8 @@ def _build_candidate_manifest(
     positive_label: object | None,
     id_column: str,
     label_column: str,
+    feature_recipe_id: str,
+    feature_columns: list[str],
     target_summary: dict[str, object],
     train_rows: int,
     train_cols: int,
@@ -335,6 +338,8 @@ def _build_candidate_manifest(
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
         "model_family": config.model_family,
+        "feature_recipe_id": feature_recipe_id,
+        "feature_columns": feature_columns,
         "preprocessor": config.preprocessor,
         "model_id": model_result.model_id,
         "model_name": model_result.model_name,
@@ -456,6 +461,11 @@ def run_training(
     )
     split_indices = prepared_context.split_indices
     fold_assignments = prepared_context.fold_assignments
+    x_train_features, x_test_features = apply_feature_recipe(
+        recipe_id=config.feature_recipe_id,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+    )
     target_summary = _build_target_summary(
         task_type=task_type,
         y_train=y_train,
@@ -468,8 +478,8 @@ def run_training(
         task_type=task_type,
         primary_metric=primary_metric,
         model_spec=resolved_model_spec,
-        x_train_raw=x_train_raw,
-        x_test_raw=x_test_raw,
+        x_train_raw=x_train_features,
+        x_test_raw=x_test_features,
         y_train=y_train,
         split_indices=split_indices,
         force_categorical=config.force_categorical,
@@ -482,8 +492,10 @@ def run_training(
     model_result = evaluation_artifacts.model_result
     print(
         f"Training candidate: {config.candidate_id} | "
+        f"feature_recipe={config.feature_recipe_id} | "
         f"model={model_result.model_id} ({model_result.model_name}) | "
         f"preprocessing={model_result.preprocessing_scheme_id} | "
+        f"features={x_train_features.shape[1]} | "
         f"CV {primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
         f"std={model_result.cv_summary.metric_std:.6f}"
     )
@@ -512,11 +524,13 @@ def run_training(
         positive_label=positive_label,
         id_column=id_column,
         label_column=label_column,
+        feature_recipe_id=config.feature_recipe_id,
+        feature_columns=x_train_features.columns.tolist(),
         target_summary=target_summary,
-        train_rows=int(x_train_raw.shape[0]),
-        train_cols=int(x_train_raw.shape[1]),
-        test_rows=int(x_test_raw.shape[0]),
-        test_cols=int(x_test_raw.shape[1]),
+        train_rows=int(x_train_features.shape[0]),
+        train_cols=int(x_train_features.shape[1]),
+        test_rows=int(x_test_features.shape[0]),
+        test_cols=int(x_test_features.shape[1]),
         tuning_provenance=tuning_provenance,
     )
 

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -9,6 +9,7 @@ from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label
 from tabular_shenanigans.data import CompetitionDatasetContext
+from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.models import build_tuning_space, get_model_definition
 from tabular_shenanigans.preprocess import prepare_feature_frames
 from tabular_shenanigans.train import (
@@ -153,6 +154,11 @@ def run_optimization(
         expected_feature_columns=x_train_raw.columns.tolist(),
     )
     split_indices = prepared_context.split_indices
+    x_train_features, x_test_features = apply_feature_recipe(
+        recipe_id=config.feature_recipe_id,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+    )
     target_summary = _build_target_summary(
         task_type=task_type,
         y_train=y_train,
@@ -184,8 +190,8 @@ def run_optimization(
                 model_id=tuning_model_spec.model_id,
                 parameter_overrides=parameter_overrides,
             ),
-            x_train_raw=x_train_raw,
-            x_test_raw=x_test_raw,
+            x_train_raw=x_train_features,
+            x_test_raw=x_test_features,
             y_train=y_train,
             split_indices=split_indices,
             force_categorical=config.force_categorical,


### PR DESCRIPTION
Closes #85

## Summary
- add an experiment-scoped feature recipe layer with an identity default and a first s6e3 recipe
- apply the selected feature recipe during training and tuning, and persist recipe metadata in candidate artifacts
- document the new workflow and update tracked example configs

## Verification
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python - <<'PY' ...` to validate both example configs, confirm the identity default, and run `s6e3_v1` through the real model-evaluation path on a subset of the s6e3 data
