### PR TITLE
Add blend candidate artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ The repository is developed and manually verified primarily against these Playgr
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Freeze CV assignments once per prepared competition context and reuse them across `train`.
 - Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `train`, and submit-only flows.
-- Train one cross-validated model candidate at a time using an optional config-selected feature recipe plus config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs.
-- Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`.
-- When `experiment.candidate.optimization.enabled=true`, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
+- Materialize one explicit experiment candidate at a time:
+  - train one cross-validated model candidate using an optional config-selected feature recipe plus config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs
+  - or build one blend candidate from existing compatible candidate artifacts under the same prepared competition context
+- Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`, plus optional candidate-type-specific metadata such as `blend_summary.csv` or optimization files.
+- When `experiment.candidate.optimization.enabled=true` for a model candidate, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact selected by `candidate_id`.
 
 ## Tooling
@@ -72,7 +74,7 @@ Stage behavior:
 - `fetch`: ensures competition data is present locally
 - `prepare`: fetches if needed, writes EDA report CSVs, persists `competition.json`, and freezes `folds.csv`
 - `eda`: fetches if needed, then writes EDA report CSVs
-- `train`: fetches if needed, prepares competition context when it is missing, then trains and writes one candidate artifact directory on the frozen folds; when optimization is enabled, `train` first runs Optuna for the current experiment candidate and stores optimization metadata inside that candidate directory
+- `train`: fetches if needed, prepares competition context when it is missing, then writes one candidate artifact directory on the frozen folds; model candidates train on raw data plus preprocessing, while blend candidates combine existing compatible candidate artifacts without retraining base models; when optimization is enabled for a model candidate, `train` first runs Optuna and stores optimization metadata inside that candidate directory
 - `submit`: resolves one candidate artifact by `candidate_id` and never retrains implicitly
 
 `submit` defaults to `config.candidate_id`. Use `--candidate-id` only when you want to submit another existing candidate for the same competition.
@@ -118,26 +120,33 @@ Required top-level sections:
 - optional `submit` block
 
 Current `experiment.candidate` contract:
-- `candidate_type`: currently only `model` is supported
-- `candidate_id`
-- optional `feature_recipe_id`: tracked deterministic feature recipe applied after raw feature extraction and before preprocessing/model fitting; defaults to `identity`
-- `preprocessor`: `onehot`, `ordinal`, `native`, or `frequency`
-- `model_family`
-  - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
-  - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
-- optional `model_params`
-- optional `optimization`:
-  - `enabled`
-  - `method`: currently only `optuna`
-  - `n_trials`
-  - `timeout_seconds`
-  - `random_state`
+- shared keys:
+  - `candidate_type`: `model` or `blend`
+  - `candidate_id`
+- model candidate keys:
+  - optional `feature_recipe_id`: tracked deterministic feature recipe applied after raw feature extraction and before preprocessing/model fitting; defaults to `identity`
+  - `preprocessor`: `onehot`, `ordinal`, `native`, or `frequency`
+  - `model_family`
+    - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+    - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+  - optional `model_params`
+  - optional `optimization`:
+    - `enabled`
+    - `method`: currently only `optuna`
+    - `n_trials`
+    - `timeout_seconds`
+    - `random_state`
+- blend candidate keys:
+  - `base_candidate_ids`: list of at least two existing compatible candidate IDs under the same competition
+  - optional `weights`: positive numeric weights with equal-weight default
 
-Supported `model_family + preprocessor` combinations:
+Blend candidates validate that all base candidates share the same competition slug, task type, primary metric, resolved schema, frozen fold assignments, OOF row order, and test ID order.
+
+Supported `model_family + preprocessor` combinations for model candidates:
 - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
 - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
 
-Built-in `feature_recipe_id` values:
+Built-in `feature_recipe_id` values for model candidates:
 - `identity`: default pass-through recipe for new competitions
 - `s6e3_v1`: a first competition-specific feature set for `playground-series-s6e3`
 
@@ -155,7 +164,7 @@ Binary prediction artifact contract:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `candidate.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected artifact manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id`.
+The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id` for model candidates. Blend candidates materialize a synthetic `blend_weighted_average` artifact model ID and use their component candidate metadata as provenance.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -176,8 +185,8 @@ Manual verification for each target:
 - confirm `artifacts/<competition_slug>/competition.json` and `artifacts/<competition_slug>/folds.csv` are written
 - confirm the pipeline infers `id_column` and `label_column` without overrides
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written
-- confirm `candidate.json` records the selected `feature_recipe_id`
-- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written for the resolved internal model artifact
+- for model candidates, confirm `candidate.json` records the selected `feature_recipe_id`
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written for the selected candidate artifact
 - run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
@@ -191,6 +200,16 @@ Manual verification for optimization:
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/optimization_trials.csv` records trial state, score, and params
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` records `tuning_provenance`
 
+Manual verification for blend candidates:
+- ensure at least two compatible base candidates already exist under `artifacts/<competition_slug>/candidates/`
+- configure `experiment.candidate.candidate_type: blend` with `base_candidate_ids` and optional `weights`
+- run `uv run python main.py train`
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written with `candidate_type: blend` and component provenance
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/blend_summary.csv` records component candidate IDs, weights, component CV scores, and OOF correlation hints
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written without retraining the base candidates
+- run `uv run python main.py submit`
+- confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`
+
 ## Outputs
 - Competition data: `data/<competition_slug>/`
 - Competition context artifacts: `artifacts/<competition_slug>/`
@@ -199,9 +218,9 @@ Manual verification for optimization:
 - EDA reports: `reports/<competition_slug>/`
 - Candidate artifacts: `artifacts/<competition_slug>/candidates/<candidate_id>/`
   - includes `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
-  - `candidate.json` is the canonical training metadata source and records the selected `feature_recipe_id` plus engineered `feature_columns`
-  - tuned retrain candidates also record `tuning_provenance`
-  - optimized candidates also include `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`
+  - model candidates record the selected `feature_recipe_id`, engineered `feature_columns`, and optional `tuning_provenance`
+  - blend candidates also include `blend_summary.csv` and record their component candidates plus normalized weights in `candidate.json`
+  - optimized model candidates also include `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`
 - Submission ledger: `artifacts/<competition_slug>/submissions.csv` as an append-only submission event table keyed by `candidate_id`
 
 ## Current Assumptions
@@ -210,15 +229,17 @@ Manual verification for optimization:
 - The competition follows a simple two-column Playground submission contract: `sample_submission.csv` must be exactly `[id_column, label_column]`.
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
-- The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
-- `experiment.candidate.feature_recipe_id` defaults to `identity`; feature recipes are tracked Python modules rather than runtime scripts or YAML transform blocks.
+- The current runtime supports `experiment.candidate.candidate_type: model` and `experiment.candidate.candidate_type: blend`.
+- Model candidates resolve `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
+- Model candidates default `experiment.candidate.feature_recipe_id` to `identity`; feature recipes are tracked Python modules rather than runtime scripts or YAML transform blocks.
+- Blend candidates consume existing compatible candidate artifacts and write one new blend candidate artifact without retraining the base candidates.
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` consumes that frozen context and auto-runs `prepare` only when it is missing.
-- Enabled optimization is part of `train`, uses the current experiment candidate only, and writes candidate-local metadata alongside the tuned artifact with `tuning_provenance`.
+- Enabled optimization is part of `train`, applies to model candidates only, and writes candidate-local metadata alongside the tuned artifact with `tuning_provenance`.
 - Feature recipes are deterministic and leakage-safe; fold-learned transforms still belong in preprocessing, not in the recipe layer.
 - Submission uses `candidate.json` as the schema/task source of truth.
 - Submission defaults to `config.candidate_id`; `submit --candidate-id <candidate_id>` overrides that selection explicitly.
 - Submission metadata includes the selected `model_id`; current candidate artifacts contain exactly one `model_id`.
-- Submission validation requires the selected model artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
+- Submission validation requires the selected candidate artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Submission requires the current candidate artifact layout under `artifacts/<competition_slug>/candidates/<candidate_id>/`.
 - Binary classification supports any two-class labels accepted by scikit-learn.
 - For binary `roc_auc` and `log_loss`, prediction artifacts use probabilities aligned to the resolved positive class.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -49,6 +49,16 @@ experiment:
     # preprocessor: native
     # model_family: catboost
 
+    # Alternative blend candidate shape:
+    # candidate_type: blend
+    # candidate_id: binary_blend_v1
+    # base_candidate_ids:
+    #   - existing_candidate_a
+    #   - existing_candidate_b
+    # weights:
+    #   - 0.5
+    #   - 0.5
+
     # Optional tuning settings for `uv run python main.py train`.
     optimization:
       enabled: false

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -45,6 +45,16 @@ experiment:
     # preprocessor: native
     # model_family: catboost
 
+    # Alternative blend candidate shape:
+    # candidate_type: blend
+    # candidate_id: regression_blend_v1
+    # base_candidate_ids:
+    #   - existing_candidate_a
+    #   - existing_candidate_b
+    # weights:
+    #   - 0.5
+    #   - 0.5
+
     # Optional tuning settings for `uv run python main.py train`.
     optimization:
       enabled: false

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -11,25 +11,26 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 4. Load one shared dataset context from `train.csv`, `test.csv`, and `sample_submission.csv`.
 5. Run `prepare` to write report CSVs under `reports/<competition_slug>/`, persist `artifacts/<competition_slug>/competition.json`, and freeze `artifacts/<competition_slug>/folds.csv`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
-7. During training and tuning, apply the selected deterministic feature recipe to the raw feature frames. The default `identity` recipe leaves the features unchanged.
-8. During training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected model recipe:
+7. For model candidates during training and tuning, apply the selected deterministic feature recipe to the raw feature frames. The default `identity` recipe leaves the features unchanged.
+8. For model candidates during training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected model recipe:
    - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
    - `ordinal`: numeric median imputation; categorical most-frequent imputation + `OrdinalEncoder`
    - `native`: numeric median imputation inside a pandas frame; categorical missing-value fill with native categorical columns preserved for CatBoost
    - `frequency`: numeric median imputation; categorical values replaced by fold-local relative frequencies, with unseen categories mapped to `0.0`
-9. Resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
-   - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-   - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-10. When `experiment.candidate.optimization.enabled=true`, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
-11. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional optimization metadata files.
-12. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
+9. For model candidates, resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
+  - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
+  - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
+10. For blend candidates, load compatible base candidate artifacts from `artifacts/<competition_slug>/candidates/<base_candidate_id>/`, validate shared schema plus frozen-fold alignment, and materialize blended OOF plus test predictions without retraining the base candidates.
+11. When `experiment.candidate.optimization.enabled=true` for a model candidate, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
+12. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional candidate-type-specific files such as `blend_summary.csv` or optimization metadata.
+13. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
 
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `prepare` -> `train` -> `submit`)
 - `uv run python main.py fetch`: ensure competition data is present
 - `uv run python main.py prepare`: fetch if needed, load the shared dataset context, write EDA reports, persist competition metadata, and freeze folds
 - `uv run python main.py eda`: fetch if needed, load the shared dataset context, and write EDA reports
-- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, write one candidate artifact directory on the frozen folds, and when optimization is enabled run Optuna plus candidate-local optimization artifact writing before the final retrain
+- `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, then either train one model candidate or materialize one blend candidate on the frozen folds; when optimization is enabled for a model candidate, run Optuna plus candidate-local optimization artifact writing before the final retrain
 - `uv run python main.py submit`: prepare or submit the configured `candidate_id`
 - `uv run python main.py submit --candidate-id <candidate_id>`: prepare or submit another existing candidate for the configured competition
 
@@ -45,6 +46,7 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
+- `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact loading, weighted prediction combination, and `blend_summary.csv` writing.
 - `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, candidate artifact writing, candidate manifest generation, and optimization-aware training orchestration.
 - `src/tabular_shenanigans/tune.py`: internal Optuna helper used by `train` when candidate optimization is enabled.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates.
@@ -80,20 +82,25 @@ Input:
   - required `candidate`
   - optional `submit`
 - Current `experiment.candidate` keys:
-  - `candidate_type` (currently only `model`)
-  - `candidate_id`
-  - `feature_recipe_id` (string, default `identity`; resolves to a tracked deterministic feature recipe applied before preprocessing)
-  - `preprocessor` (`onehot`, `ordinal`, `native`, or `frequency`)
-  - `model_family`
-    - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
-    - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
-  - optional `model_params`
-  - optional `optimization`:
-    - `enabled` (boolean, default false)
-    - `method` (currently only `optuna`)
-    - `n_trials` (integer >= 1, optional)
-    - `timeout_seconds` (integer >= 1, optional)
-    - `random_state` (integer, default 42)
+  - shared:
+    - `candidate_type` (`model` or `blend`)
+    - `candidate_id`
+  - model candidate:
+    - `feature_recipe_id` (string, default `identity`; resolves to a tracked deterministic feature recipe applied before preprocessing)
+    - `preprocessor` (`onehot`, `ordinal`, `native`, or `frequency`)
+    - `model_family`
+      - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+      - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+    - optional `model_params`
+    - optional `optimization`:
+      - `enabled` (boolean, default false)
+      - `method` (currently only `optuna`)
+      - `n_trials` (integer >= 1, optional)
+      - `timeout_seconds` (integer >= 1, optional)
+      - `random_state` (integer, default 42)
+  - blend candidate:
+    - `base_candidate_ids` (list of at least two existing compatible candidate IDs)
+    - optional `weights` (positive numeric weights with equal-weight default)
 - Current `experiment.submit` keys:
   - `enabled` (boolean, default false)
   - `message_prefix` (string, optional)
@@ -105,10 +112,11 @@ Binary prediction artifact contract:
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
 The old flat config layout is unsupported and fails fast.
-The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe; built-in recipe IDs are `identity` and `s6e3_v1`.
-The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id`.
+The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe for model candidates; built-in recipe IDs are `identity` and `s6e3_v1`.
+The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id` for model candidates.
+Blend candidates consume compatible existing candidate artifacts and materialize a synthetic `blend_weighted_average` artifact model ID.
 optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.
-enabled optimization is consumed by `train` and uses the current experiment candidate only.
+enabled optimization is consumed by `train` and applies to model candidates only.
 Frequency encoding is fold-local and maps unseen categorical values to `0.0`.
 LightGBM, CatBoost, and XGBoost require the optional booster dependencies installed via `uv sync --extra boosters`.
 
@@ -153,8 +161,9 @@ Manual verification steps for each target:
   - `oof_predictions.csv`
   - `test_predictions.csv`
   - `submission.csv` when prepared or submitted
-- `candidate.json` is the canonical current training metadata source and records `feature_recipe_id` plus the engineered `feature_columns`
-- optimized candidates record `tuning_provenance` in `candidate.json`
+- model candidates also record `feature_recipe_id` plus the engineered `feature_columns`
+- blend candidates also include `blend_summary.csv` and record component candidate provenance plus normalized weights in `candidate.json`
+- optimized model candidates record `tuning_provenance` in `candidate.json`
 - optimized candidates also include:
   - `optimization_summary.json`
   - `optimization_trials.csv`
@@ -170,14 +179,15 @@ Manual verification steps for each target:
 - `competition.task_type` and `competition.primary_metric` must be present in config for every run
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`
 - `train` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
-- the current runtime supports one `experiment.candidate` of type `model`
-- `experiment.candidate.feature_recipe_id` must resolve to one supported tracked recipe; `identity` is the default path for new competitions
-- `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
+- the current runtime supports one `experiment.candidate` of type `model` or `blend`
+- model candidates: `experiment.candidate.feature_recipe_id` must resolve to one supported tracked recipe; `identity` is the default path for new competitions
+- model candidates: `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
+- blend candidates: `experiment.candidate.base_candidate_ids` must resolve to existing compatible candidate artifacts for the same competition context
 - feature recipes are experiment-scoped, deterministic, leakage-safe transforms applied after raw feature extraction and before preprocessing
 - feature recipes must preserve row counts and row order and must produce identical train/test feature columns
 - training must write exactly one candidate artifact directory keyed by `candidate_id`
 - rerunning an existing `candidate_id` must fail instead of mutating an existing artifact directory
-- enabled optimization is part of `train`, uses the current experiment candidate only, and retrains exactly one tuned candidate into the normal candidate artifact layout
+- enabled optimization is part of `train`, applies to model candidates only, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
 - `submit` must resolve one candidate by `candidate_id`, defaulting to `config.candidate_id`
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
@@ -193,7 +203,7 @@ Manual verification steps for each target:
 - `label_column` inference must resolve to exactly one column present in `train.csv` and `sample_submission.csv` but not `test.csv`
 - Submission must resolve `competition_slug`, `task_type`, `id_column`, and `label_column` from `candidate.json` rather than re-inferring them from raw train/test data
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
-- The selected model artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
+- The selected candidate artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
 - Submission requires the current candidate prediction layout at `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv`
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
@@ -212,10 +222,10 @@ Hard-error cases include:
 - Missing required top-level `competition` or `experiment` sections -> hard error
 - Any use of the old flat config layout -> hard error
 - Unsupported `experiment.candidate.candidate_type` -> hard error
-- Unknown `experiment.candidate.feature_recipe_id` -> hard error
-- Invalid configured `experiment.candidate.model_family + preprocessor` combination for the configured task -> hard error
+- Unknown `experiment.candidate.feature_recipe_id` for a model candidate -> hard error
+- Invalid configured `experiment.candidate.model_family + preprocessor` combination for a model candidate -> hard error
 - enabled optimization without `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds` -> hard error
-- enabled optimization for an unsupported candidate combination -> hard error
+- enabled optimization for an unsupported model candidate combination -> hard error
 - Missing/invalid competition zip contents -> hard error
 - Missing `competition.json` or `folds.csv` during `train` -> auto-run `prepare`
 - Prepared competition context that no longer matches the current config or resolved dataset schema -> hard error
@@ -230,6 +240,8 @@ Hard-error cases include:
 - Unsupported task type for CV/model selection -> hard error
 - Unsupported metric for chosen task -> hard error
 - Any CV/training fit or scoring failure -> hard error
+- Blend base candidate artifact missing `candidate.json`, `oof_predictions.csv`, or `test_predictions.csv` -> hard error
+- Blend base candidate mismatch in competition slug, task type, primary metric, schema, OOF row order, fold assignments, or test ID order -> hard error
 - Fold assignment gaps in OOF generation -> hard error
 - Candidate artifact directory already exists for the configured `candidate_id` -> hard error
 - Missing configured candidate artifacts at submit time -> hard error

--- a/main.py
+++ b/main.py
@@ -33,11 +33,24 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _print_resolved_setup(config: AppConfig) -> None:
+    if config.is_blend_candidate:
+        blend_weights = config.blend_weights
+        weight_summary = "equal-weight"
+        if blend_weights is not None:
+            weight_summary = ",".join(str(weight) for weight in blend_weights)
+        print(
+            "Resolved competition setup: "
+            f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
+            f"candidate_id={config.candidate_id}, candidate_type=blend, "
+            f"base_candidates={config.base_candidate_ids}, weights={weight_summary}"
+        )
+        return
+
     print(
         "Resolved competition setup: "
         f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
-        f"candidate_id={config.candidate_id}, feature_recipe={config.feature_recipe_id}, "
-        f"model_family={config.model_family}, "
+        f"candidate_id={config.candidate_id}, candidate_type=model, "
+        f"feature_recipe={config.feature_recipe_id}, model_family={config.model_family}, "
         f"preprocessor={config.preprocessor}, model_id={config.resolved_model_id}"
     )
 

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -1,0 +1,711 @@
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from tabular_shenanigans.competition import ensure_prepared_competition_context
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
+from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
+from tabular_shenanigans.preprocess import prepare_feature_frames
+
+BLEND_MODEL_ID = "blend_weighted_average"
+BLEND_MODEL_NAME = "WeightedAverageBlend"
+BLEND_PREPROCESSING_SCHEME_ID = "blend"
+
+
+@dataclass(frozen=True)
+class BlendComponent:
+    candidate_id: str
+    candidate_type: str
+    config_fingerprint: str | None
+    model_id: str
+    model_name: str
+    feature_recipe_id: str | None
+    cv_metric_mean: float
+    cv_metric_std: float
+    oof_predictions: np.ndarray
+    test_predictions: np.ndarray
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _candidate_dir(competition_slug: str, candidate_id: str) -> Path:
+    return Path("artifacts") / competition_slug / "candidates" / candidate_id
+
+
+def _normalize_binary_label(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bool, np.bool_)):
+        return "True" if bool(value) else "False"
+    if isinstance(value, (int, np.integer)):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)) and float(value).is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _series_matches_expected(observed: pd.Series, expected: pd.Series) -> bool:
+    observed_reset = observed.reset_index(drop=True)
+    expected_reset = expected.reset_index(drop=True)
+
+    if pd.api.types.is_numeric_dtype(observed_reset) and pd.api.types.is_numeric_dtype(expected_reset):
+        observed_values = observed_reset.to_numpy(dtype=float)
+        expected_values = expected_reset.to_numpy(dtype=float)
+        return np.allclose(observed_values, expected_values, equal_nan=True)
+
+    observed_values = observed_reset.map(_normalize_binary_label)
+    expected_values = expected_reset.map(_normalize_binary_label)
+    return observed_values.equals(expected_values)
+
+
+def _load_candidate_manifest(candidate_dir: Path) -> dict[str, object]:
+    manifest_path = candidate_dir / "candidate.json"
+    if not manifest_path.exists():
+        raise ValueError(f"Missing candidate manifest required for blending: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError(f"Candidate manifest must be a JSON object: {manifest_path}")
+    return manifest
+
+
+def _load_oof_predictions(candidate_dir: Path) -> pd.DataFrame:
+    oof_path = candidate_dir / "oof_predictions.csv"
+    if not oof_path.exists():
+        raise ValueError(f"Missing OOF predictions required for blending: {oof_path}")
+    oof_df = pd.read_csv(oof_path)
+    expected_columns = ["row_idx", "y_true", "y_pred", "fold"]
+    if oof_df.columns.tolist() != expected_columns:
+        raise ValueError(
+            f"OOF predictions must have columns {expected_columns} for blending: {oof_path}"
+        )
+    return oof_df
+
+
+def _load_test_predictions(candidate_dir: Path, id_column: str, label_column: str) -> pd.DataFrame:
+    prediction_path = candidate_dir / "test_predictions.csv"
+    if not prediction_path.exists():
+        raise ValueError(f"Missing test predictions required for blending: {prediction_path}")
+    prediction_df = pd.read_csv(prediction_path)
+    expected_columns = [id_column, label_column]
+    if prediction_df.columns.tolist() != expected_columns:
+        raise ValueError(
+            "Blend base candidate test predictions do not match the resolved submission schema. "
+            f"Expected columns {expected_columns}, got {prediction_df.columns.tolist()} in {prediction_path}"
+        )
+    return prediction_df
+
+
+def _resolve_blend_weights(
+    base_candidate_ids: list[str],
+    configured_weights: list[float] | None,
+) -> list[float]:
+    if configured_weights is None:
+        equal_weight = 1.0 / len(base_candidate_ids)
+        return [equal_weight] * len(base_candidate_ids)
+
+    if not np.isfinite(np.asarray(configured_weights, dtype=float)).all():
+        raise ValueError("Blend candidate weights must be finite.")
+
+    weight_sum = float(sum(configured_weights))
+    if not np.isfinite(weight_sum) or weight_sum <= 0:
+        raise ValueError("Blend candidate weights must sum to a positive value.")
+    return [float(weight / weight_sum) for weight in configured_weights]
+
+
+def _build_target_summary(
+    task_type: str,
+    y_train: pd.Series,
+    positive_label: object | None = None,
+    negative_label: object | None = None,
+    observed_label_pair: tuple[object, object] | None = None,
+) -> dict[str, object]:
+    if task_type == "regression":
+        return {
+            "target_mean": float(y_train.mean()),
+            "target_std": float(y_train.std(ddof=0)),
+            "target_min": float(y_train.min()),
+            "target_max": float(y_train.max()),
+        }
+
+    if task_type == "binary":
+        if positive_label is None or negative_label is None or observed_label_pair is None:
+            raise ValueError("Binary target summary requires resolved label metadata.")
+        positive_count = int((y_train == positive_label).sum())
+        row_count = int(y_train.shape[0])
+        negative_count = row_count - positive_count
+        return {
+            "observed_label_1": str(observed_label_pair[0]),
+            "observed_label_2": str(observed_label_pair[1]),
+            "negative_label": str(negative_label),
+            "positive_label": str(positive_label),
+            "positive_count": positive_count,
+            "negative_count": negative_count,
+            "target_prevalence": float(positive_count / row_count),
+        }
+
+    raise ValueError(f"Unsupported task_type for target summary: {task_type}")
+
+
+def _encode_binary_test_labels(
+    prediction_values: pd.Series,
+    positive_label: object,
+    negative_label: object,
+    candidate_id: str,
+) -> np.ndarray:
+    normalized_positive_label = _normalize_binary_label(positive_label)
+    normalized_negative_label = _normalize_binary_label(negative_label)
+    normalized_predictions = prediction_values.map(_normalize_binary_label)
+    invalid_labels = sorted(
+        set(normalized_predictions) - {normalized_positive_label, normalized_negative_label}
+    )
+    if invalid_labels:
+        raise ValueError(
+            "Binary accuracy blends require base candidate test predictions to contain only the observed "
+            f"class labels. Candidate {candidate_id} had invalid labels: {invalid_labels[:10]}"
+        )
+    return normalized_predictions.map(
+        {
+            normalized_negative_label: 0.0,
+            normalized_positive_label: 1.0,
+        }
+    ).to_numpy(dtype=float)
+
+
+def _load_blend_component(
+    competition_slug: str,
+    candidate_id: str,
+    task_type: str,
+    primary_metric: str,
+    id_column: str,
+    label_column: str,
+    expected_y_train: pd.Series,
+    expected_fold_assignments: np.ndarray,
+    expected_test_ids: pd.Series,
+    positive_label: object | None,
+    negative_label: object | None,
+) -> BlendComponent:
+    candidate_dir = _candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
+    manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
+
+    manifest_competition_slug = manifest.get("competition_slug")
+    manifest_task_type = manifest.get("task_type")
+    manifest_primary_metric = manifest.get("primary_metric")
+    manifest_id_column = manifest.get("id_column")
+    manifest_label_column = manifest.get("label_column")
+    if manifest_competition_slug != competition_slug:
+        raise ValueError(
+            "Blend base candidate competition_slug does not match the configured competition. "
+            f"Candidate {candidate_id}: {manifest_competition_slug!r}"
+        )
+    if manifest_task_type != task_type:
+        raise ValueError(
+            "Blend base candidate task_type does not match the configured task. "
+            f"Candidate {candidate_id}: {manifest_task_type!r}"
+        )
+    if manifest_primary_metric != primary_metric:
+        raise ValueError(
+            "Blend base candidate primary_metric does not match the configured metric. "
+            f"Candidate {candidate_id}: {manifest_primary_metric!r}"
+        )
+    if manifest_id_column != id_column or manifest_label_column != label_column:
+        raise ValueError(
+            "Blend base candidate schema does not match the configured schema. "
+            f"Candidate {candidate_id}: id_column={manifest_id_column!r}, label_column={manifest_label_column!r}"
+        )
+
+    oof_df = _load_oof_predictions(candidate_dir=candidate_dir)
+    row_idx = oof_df["row_idx"].to_numpy(dtype=int)
+    expected_row_idx = np.arange(expected_fold_assignments.shape[0], dtype=int)
+    if not np.array_equal(row_idx, expected_row_idx):
+        raise ValueError(
+            "Blend base candidate OOF row_idx values must be sequential and aligned. "
+            f"Candidate {candidate_id} had unexpected row_idx values."
+        )
+    if not _series_matches_expected(oof_df["y_true"], expected_y_train):
+        raise ValueError(
+            "Blend base candidate OOF targets do not match the configured training target. "
+            f"Candidate {candidate_id} is not compatible."
+        )
+    observed_fold_assignments = oof_df["fold"].to_numpy(dtype=int)
+    if not np.array_equal(observed_fold_assignments, expected_fold_assignments):
+        raise ValueError(
+            "Blend base candidate fold assignments do not match the prepared competition folds. "
+            f"Candidate {candidate_id} is not compatible."
+        )
+
+    prediction_df = _load_test_predictions(
+        candidate_dir=candidate_dir,
+        id_column=id_column,
+        label_column=label_column,
+    )
+    if not _series_matches_expected(prediction_df[id_column], expected_test_ids):
+        raise ValueError(
+            "Blend base candidate test IDs do not match the configured competition test set. "
+            f"Candidate {candidate_id} is not compatible."
+        )
+
+    if task_type == "binary" and get_binary_prediction_kind(primary_metric) == "label":
+        if positive_label is None or negative_label is None:
+            raise ValueError("Binary accuracy blending requires resolved class metadata.")
+        test_predictions = _encode_binary_test_labels(
+            prediction_values=prediction_df[label_column],
+            positive_label=positive_label,
+            negative_label=negative_label,
+            candidate_id=candidate_id,
+        )
+    else:
+        if not pd.api.types.is_numeric_dtype(prediction_df[label_column]):
+            raise ValueError(
+                "Blend base candidate test predictions must be numeric for regression and binary "
+                f"probability metrics. Candidate {candidate_id} was not numeric."
+            )
+        test_predictions = prediction_df[label_column].to_numpy(dtype=float)
+
+    if task_type == "regression" or (
+        task_type == "binary" and get_binary_prediction_kind(primary_metric) == "probability"
+    ):
+        if not np.isfinite(test_predictions).all():
+            raise ValueError(
+                "Blend base candidate test predictions must be finite. "
+                f"Candidate {candidate_id} contained non-finite values."
+            )
+
+    cv_summary = manifest.get("cv_summary")
+    if not isinstance(cv_summary, dict):
+        raise ValueError(f"Blend base candidate manifest must contain cv_summary. Candidate: {candidate_id}")
+
+    return BlendComponent(
+        candidate_id=candidate_id,
+        candidate_type=str(manifest.get("candidate_type") or "model"),
+        config_fingerprint=manifest.get("config_fingerprint"),
+        model_id=str(manifest.get("model_id") or "candidate"),
+        model_name=str(manifest.get("model_name") or "Candidate"),
+        feature_recipe_id=manifest.get("feature_recipe_id"),
+        cv_metric_mean=float(cv_summary["metric_mean"]),
+        cv_metric_std=float(cv_summary["metric_std"]),
+        oof_predictions=oof_df["y_pred"].to_numpy(dtype=float),
+        test_predictions=test_predictions,
+    )
+
+
+def _build_fold_metrics(
+    task_type: str,
+    primary_metric: str,
+    y_train: pd.Series,
+    oof_predictions: np.ndarray,
+    fold_assignments: np.ndarray,
+    positive_label: object | None,
+) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    row_indices = np.arange(fold_assignments.shape[0], dtype=int)
+    for fold_index in sorted(int(fold) for fold in np.unique(fold_assignments).tolist()):
+        valid_idx = row_indices[fold_assignments == fold_index]
+        train_idx = row_indices[fold_assignments != fold_index]
+        fold_score = score_predictions(
+            task_type=task_type,
+            primary_metric=primary_metric,
+            y_true=y_train.iloc[valid_idx],
+            y_pred=oof_predictions[valid_idx],
+            positive_label=positive_label,
+        )
+        rows.append(
+            {
+                "fold": fold_index,
+                "metric_name": primary_metric,
+                "metric_value": fold_score,
+                "train_rows": int(train_idx.shape[0]),
+                "valid_rows": int(valid_idx.shape[0]),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_blend_summary(
+    candidate_id: str,
+    metric_name: str,
+    metric_mean: float,
+    metric_std: float,
+    components: list[BlendComponent],
+    normalized_weights: list[float],
+) -> pd.DataFrame:
+    if len(components) == 1:
+        correlation_matrix = np.ones((1, 1), dtype=float)
+    else:
+        component_predictions = np.vstack([component.oof_predictions for component in components])
+        correlation_matrix = np.corrcoef(component_predictions)
+
+    rows: list[dict[str, object]] = []
+    for component_index, component in enumerate(components):
+        other_correlations = [
+            float(correlation_matrix[component_index, other_index])
+            for other_index in range(len(components))
+            if other_index != component_index
+        ]
+        rows.append(
+            {
+                "blend_candidate_id": candidate_id,
+                "blend_model_id": BLEND_MODEL_ID,
+                "blend_metric_name": metric_name,
+                "blend_metric_mean": metric_mean,
+                "blend_metric_std": metric_std,
+                "component_rank": component_index + 1,
+                "component_candidate_id": component.candidate_id,
+                "component_candidate_type": component.candidate_type,
+                "component_model_id": component.model_id,
+                "component_model_name": component.model_name,
+                "component_feature_recipe_id": component.feature_recipe_id,
+                "component_config_fingerprint": component.config_fingerprint,
+                "component_weight": normalized_weights[component_index],
+                "component_cv_metric_mean": component.cv_metric_mean,
+                "component_cv_metric_std": component.cv_metric_std,
+                "avg_oof_correlation_to_others": (
+                    float(np.mean(other_correlations)) if other_correlations else None
+                ),
+                "min_oof_correlation_to_others": (
+                    float(np.min(other_correlations)) if other_correlations else None
+                ),
+                "max_oof_correlation_to_others": (
+                    float(np.max(other_correlations)) if other_correlations else None
+                ),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_config_snapshot(
+    config: AppConfig,
+    positive_label: object | None,
+    id_column: str,
+    label_column: str,
+    normalized_weights: list[float],
+) -> dict[str, object]:
+    return {
+        "competition": {
+            **config.competition.model_dump(mode="python"),
+            "primary_metric": config.primary_metric,
+            "positive_label": positive_label,
+            "id_column": id_column,
+            "label_column": label_column,
+        },
+        "experiment": config.experiment.model_dump(mode="python"),
+        "resolved_blend_components": [
+            {
+                "candidate_id": candidate_id,
+                "weight": weight,
+            }
+            for candidate_id, weight in zip(config.base_candidate_ids, normalized_weights, strict=True)
+        ],
+    }
+
+
+def _build_config_fingerprint(
+    config_snapshot: dict[str, object],
+    components: list[BlendComponent],
+    normalized_weights: list[float],
+) -> str:
+    fingerprint_payload = {
+        "config_snapshot": config_snapshot,
+        "blend_components": [
+            {
+                "candidate_id": component.candidate_id,
+                "config_fingerprint": component.config_fingerprint,
+                "weight": weight,
+            }
+            for component, weight in zip(components, normalized_weights, strict=True)
+        ],
+        "model_id": BLEND_MODEL_ID,
+    }
+    fingerprint_payload_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
+    return hashlib.sha256(fingerprint_payload_json.encode("utf-8")).hexdigest()[:12]
+
+
+def _build_candidate_manifest(
+    config: AppConfig,
+    generated_at_utc: str,
+    config_snapshot: dict[str, object],
+    config_fingerprint: str,
+    metric_mean: float,
+    metric_std: float,
+    observed_label_pair: tuple[object, object] | None,
+    negative_label: object | None,
+    positive_label: object | None,
+    id_column: str,
+    label_column: str,
+    target_summary: dict[str, object],
+    train_rows: int,
+    test_rows: int,
+    components: list[BlendComponent],
+    normalized_weights: list[float],
+) -> dict[str, object]:
+    return {
+        "artifact_type": "candidate",
+        "candidate_id": config.candidate_id,
+        "candidate_type": config.candidate_type,
+        "generated_at_utc": generated_at_utc,
+        "competition_slug": config.competition_slug,
+        "task_type": config.task_type,
+        "primary_metric": config.primary_metric,
+        "config_fingerprint": config_fingerprint,
+        "config_snapshot": config_snapshot,
+        "model_id": BLEND_MODEL_ID,
+        "model_name": BLEND_MODEL_NAME,
+        "preprocessing_scheme_id": BLEND_PREPROCESSING_SCHEME_ID,
+        "cv_summary": {
+            "metric_name": config.primary_metric,
+            "metric_mean": metric_mean,
+            "metric_std": metric_std,
+            "higher_is_better": is_higher_better(config.primary_metric),
+        },
+        "component_candidates": [
+            {
+                "candidate_id": component.candidate_id,
+                "candidate_type": component.candidate_type,
+                "config_fingerprint": component.config_fingerprint,
+                "model_id": component.model_id,
+                "model_name": component.model_name,
+                "feature_recipe_id": component.feature_recipe_id,
+                "weight": weight,
+                "cv_summary": {
+                    "metric_name": config.primary_metric,
+                    "metric_mean": component.cv_metric_mean,
+                    "metric_std": component.cv_metric_std,
+                    "higher_is_better": is_higher_better(config.primary_metric),
+                },
+            }
+            for component, weight in zip(components, normalized_weights, strict=True)
+        ],
+        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
+        "negative_label": negative_label,
+        "positive_label": positive_label,
+        "id_column": id_column,
+        "label_column": label_column,
+        "target_summary": target_summary,
+        "train_rows": train_rows,
+        "train_cols": None,
+        "test_rows": test_rows,
+        "test_cols": None,
+    }
+
+
+def _write_candidate_artifacts(
+    candidate_dir: Path,
+    manifest: dict[str, object],
+    fold_metrics_df: pd.DataFrame,
+    y_train: pd.Series,
+    oof_predictions: np.ndarray,
+    fold_assignments: np.ndarray,
+    test_ids: pd.Series,
+    test_predictions: np.ndarray,
+    id_column: str,
+    label_column: str,
+    blend_summary_df: pd.DataFrame,
+) -> None:
+    (candidate_dir / "candidate.json").write_text(
+        json.dumps(_json_ready(manifest), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    fold_metrics_df.to_csv(candidate_dir / "fold_metrics.csv", index=False)
+
+    oof_df = pd.DataFrame(
+        {
+            "row_idx": np.arange(y_train.shape[0], dtype=int),
+            "y_true": y_train.to_numpy(),
+            "y_pred": oof_predictions,
+            "fold": fold_assignments,
+        }
+    )
+    oof_df.to_csv(candidate_dir / "oof_predictions.csv", index=False)
+
+    test_predictions_df = pd.DataFrame(
+        {
+            id_column: test_ids.to_numpy(),
+            label_column: test_predictions,
+        }
+    )
+    test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
+    blend_summary_df.to_csv(candidate_dir / "blend_summary.csv", index=False)
+
+
+def run_blend_training(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+) -> Path:
+    if not config.is_blend_candidate:
+        raise ValueError("Blend training requires experiment.candidate.candidate_type=blend.")
+
+    candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
+    if candidate_dir.exists():
+        raise ValueError(
+            "Candidate artifacts already exist for this candidate_id. "
+            f"Choose a new experiment.candidate.candidate_id or remove {candidate_dir}"
+        )
+
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+    y_train = train_df[label_column].reset_index(drop=True)
+
+    x_train_raw, _, _ = prepare_feature_frames(
+        train_df=train_df,
+        test_df=test_df,
+        id_column=id_column,
+        label_column=label_column,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
+    )
+    prepared_context = ensure_prepared_competition_context(
+        config=config,
+        dataset_context=dataset_context,
+        expected_feature_columns=x_train_raw.columns.tolist(),
+    )
+    fold_assignments = prepared_context.fold_assignments
+
+    positive_label = config.positive_label
+    negative_label = None
+    observed_label_pair = None
+    if config.task_type == "binary":
+        negative_label, positive_label, observed_label_pair = resolve_positive_label(
+            y_values=y_train,
+            configured_positive_label=positive_label,
+        )
+
+    normalized_weights = _resolve_blend_weights(
+        base_candidate_ids=config.base_candidate_ids,
+        configured_weights=config.blend_weights,
+    )
+    components = [
+        _load_blend_component(
+            competition_slug=config.competition_slug,
+            candidate_id=base_candidate_id,
+            task_type=config.task_type,
+            primary_metric=config.primary_metric,
+            id_column=id_column,
+            label_column=label_column,
+            expected_y_train=y_train,
+            expected_fold_assignments=fold_assignments,
+            expected_test_ids=test_df[id_column],
+            positive_label=positive_label,
+            negative_label=negative_label,
+        )
+        for base_candidate_id in config.base_candidate_ids
+    ]
+
+    component_oof_predictions = np.vstack([component.oof_predictions for component in components])
+    component_test_predictions = np.vstack([component.test_predictions for component in components])
+    weight_array = np.asarray(normalized_weights, dtype=float)
+    blended_oof_predictions = np.average(component_oof_predictions, axis=0, weights=weight_array)
+    blended_test_predictions = np.average(component_test_predictions, axis=0, weights=weight_array)
+
+    if config.task_type == "regression":
+        final_test_predictions: np.ndarray | list[object] = blended_test_predictions
+        if config.primary_metric == "rmsle":
+            final_test_predictions = np.clip(blended_test_predictions, a_min=0.0, a_max=None)
+    elif get_binary_prediction_kind(config.primary_metric) == "label":
+        if positive_label is None or negative_label is None:
+            raise ValueError("Binary label blends require resolved class metadata.")
+        final_test_predictions = np.where(
+            blended_test_predictions >= 0.5,
+            positive_label,
+            negative_label,
+        )
+    else:
+        final_test_predictions = blended_test_predictions
+
+    fold_metrics_df = _build_fold_metrics(
+        task_type=config.task_type,
+        primary_metric=config.primary_metric,
+        y_train=y_train,
+        oof_predictions=blended_oof_predictions,
+        fold_assignments=fold_assignments,
+        positive_label=positive_label,
+    )
+    metric_mean = float(fold_metrics_df["metric_value"].mean())
+    metric_std = float(fold_metrics_df["metric_value"].std(ddof=0))
+    blend_summary_df = _build_blend_summary(
+        candidate_id=config.candidate_id,
+        metric_name=config.primary_metric,
+        metric_mean=metric_mean,
+        metric_std=metric_std,
+        components=components,
+        normalized_weights=normalized_weights,
+    )
+
+    target_summary = _build_target_summary(
+        task_type=config.task_type,
+        y_train=y_train,
+        positive_label=positive_label,
+        negative_label=negative_label,
+        observed_label_pair=observed_label_pair,
+    )
+    config_snapshot = _build_config_snapshot(
+        config=config,
+        positive_label=positive_label,
+        id_column=id_column,
+        label_column=label_column,
+        normalized_weights=normalized_weights,
+    )
+    config_fingerprint = _build_config_fingerprint(
+        config_snapshot=config_snapshot,
+        components=components,
+        normalized_weights=normalized_weights,
+    )
+    generated_at_utc = datetime.now(timezone.utc).isoformat()
+    candidate_manifest = _build_candidate_manifest(
+        config=config,
+        generated_at_utc=generated_at_utc,
+        config_snapshot=config_snapshot,
+        config_fingerprint=config_fingerprint,
+        metric_mean=metric_mean,
+        metric_std=metric_std,
+        observed_label_pair=observed_label_pair,
+        negative_label=negative_label,
+        positive_label=positive_label,
+        id_column=id_column,
+        label_column=label_column,
+        target_summary=target_summary,
+        train_rows=int(train_df.shape[0]),
+        test_rows=int(test_df.shape[0]),
+        components=components,
+        normalized_weights=normalized_weights,
+    )
+
+    candidate_dir.parent.mkdir(parents=True, exist_ok=True)
+    candidate_dir.mkdir(parents=False, exist_ok=False)
+    _write_candidate_artifacts(
+        candidate_dir=candidate_dir,
+        manifest=candidate_manifest,
+        fold_metrics_df=fold_metrics_df,
+        y_train=y_train,
+        oof_predictions=blended_oof_predictions,
+        fold_assignments=fold_assignments,
+        test_ids=test_df[id_column],
+        test_predictions=np.asarray(final_test_predictions),
+        id_column=id_column,
+        label_column=label_column,
+        blend_summary_df=blend_summary_df,
+    )
+    print(
+        f"Blend candidate: {config.candidate_id} | "
+        f"components={config.base_candidate_ids} | "
+        f"weights={normalized_weights} | "
+        f"CV {config.primary_metric}: mean={metric_mean:.6f}, std={metric_std:.6f}"
+    )
+    return candidate_dir

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -1,5 +1,6 @@
+import math
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -57,11 +58,16 @@ class CandidateOptimizationConfig(BaseModel):
     random_state: int = 42
 
 
-class ModelCandidateConfig(BaseModel):
+class BaseCandidateConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_id: str = Field(min_length=1)
+
+
+class ModelCandidateConfig(BaseCandidateConfig):
     model_config = ConfigDict(extra="forbid")
 
     candidate_type: Literal["model"] = "model"
-    candidate_id: str = Field(min_length=1)
     feature_recipe_id: str = Field(default="identity", min_length=1)
     preprocessor: Literal["onehot", "ordinal", "native", "frequency"]
     model_family: Literal[
@@ -84,8 +90,55 @@ class ModelCandidateConfig(BaseModel):
             raise ValueError(
                 "The current runtime does not support combining experiment.candidate.model_params "
                 "with enabled experiment.candidate.optimization."
-            )
+        )
         return self
+
+
+class BlendCandidateConfig(BaseCandidateConfig):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_type: Literal["blend"] = "blend"
+    base_candidate_ids: list[str] = Field(min_length=2)
+    weights: list[float] | None = None
+
+    @model_validator(mode="after")
+    def validate_blend_candidate(self) -> "BlendCandidateConfig":
+        duplicate_candidate_ids = sorted(
+            candidate_id
+            for candidate_id in set(self.base_candidate_ids)
+            if self.base_candidate_ids.count(candidate_id) > 1
+        )
+        if duplicate_candidate_ids:
+            raise ValueError(
+                "Blend candidates require distinct base_candidate_ids. "
+                f"Duplicates: {duplicate_candidate_ids}"
+            )
+
+        if self.weights is None:
+            return self
+
+        if len(self.weights) != len(self.base_candidate_ids):
+            raise ValueError(
+                "Blend candidate weights must match the number of base_candidate_ids. "
+                f"Got {len(self.weights)} weights for {len(self.base_candidate_ids)} base candidates."
+            )
+
+        invalid_weights = [
+            weight for weight in self.weights if not math.isfinite(weight) or weight <= 0
+        ]
+        if invalid_weights:
+            raise ValueError(
+                "Blend candidate weights must all be positive. "
+                f"Invalid weights: {invalid_weights}"
+            )
+
+        return self
+
+
+ExperimentCandidateConfig = Annotated[
+    ModelCandidateConfig | BlendCandidateConfig,
+    Field(discriminator="candidate_type"),
+]
 
 
 class ExperimentSubmitConfig(BaseModel):
@@ -100,7 +153,7 @@ class ExperimentConfig(BaseModel):
 
     name: str = Field(min_length=1)
     notes: str | None = None
-    candidate: ModelCandidateConfig
+    candidate: ExperimentCandidateConfig
     submit: ExperimentSubmitConfig = Field(default_factory=ExperimentSubmitConfig)
 
 
@@ -128,28 +181,29 @@ class AppConfig(BaseModel):
         if self.competition.task_type != "binary" and self.competition.positive_label is not None:
             raise ValueError("competition.positive_label is only supported for binary task_type.")
 
-        self.experiment.candidate.feature_recipe_id = resolve_feature_recipe_id(
-            self.experiment.candidate.feature_recipe_id
-        )
+        if self.is_model_candidate:
+            self.experiment.candidate.feature_recipe_id = resolve_feature_recipe_id(
+                self.experiment.candidate.feature_recipe_id
+            )
 
-        resolved_model_id = self.resolved_model_id
-        optimization = self.experiment.candidate.optimization
-        if optimization.enabled:
-            if optimization.n_trials is None and optimization.timeout_seconds is None:
-                raise ValueError(
-                    "At least one experiment.candidate.optimization stopping condition is required. "
-                    "Set experiment.candidate.optimization.n_trials or "
-                    "experiment.candidate.optimization.timeout_seconds."
-                )
-            if not is_model_tunable(self.task_type, resolved_model_id):
-                supported_tunable_combinations = [
-                    f"{model_family}+{preprocessor}"
-                    for model_family, preprocessor, _ in get_tunable_candidate_model_specs(self.task_type)
-                ]
-                raise ValueError(
-                    "Configured experiment.candidate does not support optimization for task_type "
-                    f"'{self.task_type}'. Supported tunable combinations: {supported_tunable_combinations}"
-                )
+            resolved_model_id = self.resolved_model_id
+            optimization = self.experiment.candidate.optimization
+            if optimization.enabled:
+                if optimization.n_trials is None and optimization.timeout_seconds is None:
+                    raise ValueError(
+                        "At least one experiment.candidate.optimization stopping condition is required. "
+                        "Set experiment.candidate.optimization.n_trials or "
+                        "experiment.candidate.optimization.timeout_seconds."
+                    )
+                if not is_model_tunable(self.task_type, resolved_model_id):
+                    supported_tunable_combinations = [
+                        f"{model_family}+{preprocessor}"
+                        for model_family, preprocessor, _ in get_tunable_candidate_model_specs(self.task_type)
+                    ]
+                    raise ValueError(
+                        "Configured experiment.candidate does not support optimization for task_type "
+                        f"'{self.task_type}'. Supported tunable combinations: {supported_tunable_combinations}"
+                    )
 
         return self
 
@@ -214,19 +268,35 @@ class AppConfig(BaseModel):
         return self.experiment.candidate.candidate_type
 
     @property
+    def is_model_candidate(self) -> bool:
+        return isinstance(self.experiment.candidate, ModelCandidateConfig)
+
+    @property
+    def is_blend_candidate(self) -> bool:
+        return isinstance(self.experiment.candidate, BlendCandidateConfig)
+
+    @property
     def model_family(self) -> str:
+        if not self.is_model_candidate:
+            raise ValueError("model_family is only available for model candidates.")
         return self.experiment.candidate.model_family
 
     @property
     def feature_recipe_id(self) -> str:
+        if not self.is_model_candidate:
+            raise ValueError("feature_recipe_id is only available for model candidates.")
         return self.experiment.candidate.feature_recipe_id
 
     @property
     def preprocessor(self) -> str:
+        if not self.is_model_candidate:
+            raise ValueError("preprocessor is only available for model candidates.")
         return self.experiment.candidate.preprocessor
 
     @property
     def resolved_model_id(self) -> str:
+        if not self.is_model_candidate:
+            raise ValueError("resolved_model_id is only available for model candidates.")
         return resolve_candidate_model_id(
             task_type=self.task_type,
             model_family=self.model_family,
@@ -235,9 +305,25 @@ class AppConfig(BaseModel):
 
     @property
     def model_parameter_overrides(self) -> dict[str, object] | None:
+        if not self.is_model_candidate:
+            raise ValueError("model_parameter_overrides is only available for model candidates.")
         if not self.experiment.candidate.model_params:
             return None
         return dict(self.experiment.candidate.model_params)
+
+    @property
+    def base_candidate_ids(self) -> list[str]:
+        if not self.is_blend_candidate:
+            raise ValueError("base_candidate_ids is only available for blend candidates.")
+        return list(self.experiment.candidate.base_candidate_ids)
+
+    @property
+    def blend_weights(self) -> list[float] | None:
+        if not self.is_blend_candidate:
+            raise ValueError("blend_weights is only available for blend candidates.")
+        if self.experiment.candidate.weights is None:
+            return None
+        return list(self.experiment.candidate.weights)
 
     @property
     def submit_enabled(self) -> bool:

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -419,6 +419,9 @@ def run_training(
     model_spec: TrainingModelSpec | None = None,
     tuning_provenance: dict[str, object] | None = None,
 ) -> Path:
+    if not config.is_model_candidate:
+        raise ValueError("run_training only supports experiment.candidate.candidate_type=model.")
+
     resolved_model_spec = _resolve_training_model_spec(config=config, model_spec=model_spec)
     candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
     if candidate_dir.exists():
@@ -559,6 +562,11 @@ def run_training_workflow(
             "Candidate artifacts already exist for this candidate_id. "
             f"Choose a new experiment.candidate.candidate_id or remove {candidate_dir}"
         )
+
+    if config.is_blend_candidate:
+        from tabular_shenanigans.blend import run_blend_training
+
+        return run_blend_training(config=config, dataset_context=dataset_context)
 
     optimization = config.experiment.candidate.optimization
     if not optimization.enabled:

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -115,6 +115,9 @@ def run_optimization(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
 ) -> OptimizationResult:
+    if not config.is_model_candidate:
+        raise ValueError("Optimization only supports experiment.candidate.candidate_type=model.")
+
     optimization = config.experiment.candidate.optimization
     if not optimization.enabled:
         raise ValueError("Optimization requires experiment.candidate.optimization.enabled=true in config.yaml.")


### PR DESCRIPTION
## Summary
- add `blend` as a first-class `experiment.candidate.candidate_type`
- build blend candidate artifacts from existing compatible candidate directories
- document blend candidate config, artifacts, and verification workflow

Closes #89

## Verification
- `uv run python -m compileall src main.py`
- manual `s6e3` equal-weight blend verification via `AppConfig.model_validate(...)` + `run_training_workflow(...)` + `run_submission(...)`
  - base candidates: `s6e3_frequency_xgboost_v1`, `s6e3_s6e3v1_ordinal_xgboost_v1`
  - result: `s6e3_issue89_blend_pair_v1` with CV `roc_auc=0.9166755054456566`
- manual `s6e3` explicit-weight blend verification via `AppConfig.model_validate(...)` + `run_training_workflow(...)` + `run_submission(...)`
  - weights: `[0.7, 0.3]`
  - result: `s6e3_issue89_blend_weighted_v1` with CV `roc_auc=0.9166444831909091`
