### PR TITLE
Expand logistic regression tuning space

### DIFF
--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -359,10 +359,26 @@ def _build_hist_gradient_boosting_tuning_space(trial: object) -> dict[str, objec
 
 
 def _build_logreg_tuning_space(trial: object) -> dict[str, object]:
-    return {
-        "C": trial.suggest_float("C", 1e-3, 1e2, log=True),
+    solver = trial.suggest_categorical("solver", ["lbfgs", "liblinear", "saga"])
+    params: dict[str, object] = {
+        "C": trial.suggest_float("C", 1e-4, 1e3, log=True),
         "class_weight": trial.suggest_categorical("class_weight", [None, "balanced"]),
+        "max_iter": trial.suggest_categorical("max_iter", [1000, 2000, 4000]),
+        "solver": solver,
     }
+
+    if solver == "lbfgs":
+        params["penalty"] = "l2"
+        return params
+
+    if solver == "liblinear":
+        params["penalty"] = trial.suggest_categorical("liblinear_penalty", ["l1", "l2"])
+        return params
+
+    params["penalty"] = trial.suggest_categorical("saga_penalty", ["l1", "l2", "elasticnet"])
+    if params["penalty"] == "elasticnet":
+        params["l1_ratio"] = trial.suggest_float("l1_ratio", 0.0, 1.0)
+    return params
 
 
 def _build_lightgbm_tuning_space(trial: object) -> dict[str, object]:


### PR DESCRIPTION
## Summary
Expand the logistic regression Optuna space so onehot logreg can search more than just `C` and `class_weight`.

## What Changed
- expand `_build_logreg_tuning_space` in `src/tabular_shenanigans/models.py`
- add solver-aware conditional branches for valid combinations only
- broaden `C`
- add solver selection across `lbfgs`, `liblinear`, and `saga`
- add solver-compatible penalty search
- add `l1_ratio` only for `saga + elasticnet`
- add `max_iter` as a tunable convergence knob

## Verification
- `uv run python -m compileall src/tabular_shenanigans/models.py`
- `uv run python main.py train` with a 4-trial smoke config on `smoke-binary-canonical`
  - completed successfully
  - wrote `artifacts/smoke-binary-canonical/candidates/smoke_logreg_expanded_space_v1`
  - best smoke result: `0.890573` ROC AUC with `solver=lbfgs`, `C=0.03668874895499183`, `class_weight=balanced`, `max_iter=4000`

## Notes
- sklearn emitted `penalty` deprecation warnings during smoke verification; I am leaving that as a follow-up rather than widening this issue
- this PR intentionally does not change docs because the user-facing config surface did not change

Closes #96
