### PR TITLE
Reject mismatched binary probability blend contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Current `experiment.candidate` contract:
   - `base_candidate_ids`: list of at least two existing compatible candidate IDs under the same competition
   - optional `weights`: positive numeric weights with equal-weight default
 
-Blend candidates validate that all base candidates share the same competition slug, task type, primary metric, resolved schema, frozen fold assignments, OOF row order, and test ID order.
+Blend candidates validate that all base candidates share the same competition slug, task type, primary metric, resolved schema, frozen fold assignments, OOF row order, and test ID order. For binary `roc_auc` and `log_loss` blends, base candidates must also share the same saved `positive_label`, `negative_label`, and `observed_label_pair` contract.
 
 Supported `model_family + preprocessor` combinations for model candidates:
 - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
@@ -216,6 +216,7 @@ Manual verification for blend candidates:
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written with `candidate_type: blend` and component provenance
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/blend_summary.csv` records component candidate IDs, weights, component CV scores, and OOF correlation hints
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written without retraining the base candidates
+- for binary `roc_auc` and `log_loss` blends, confirm mismatched base-candidate label contracts fail before predictions are averaged
 - run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -20,7 +20,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 9. For model candidates, resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
   - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
   - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-10. For blend candidates, load compatible base candidate artifacts from `artifacts/<competition_slug>/candidates/<base_candidate_id>/`, validate shared schema plus frozen-fold alignment, and materialize blended OOF plus test predictions without retraining the base candidates.
+10. For blend candidates, load compatible base candidate artifacts from `artifacts/<competition_slug>/candidates/<base_candidate_id>/`, validate shared schema plus frozen-fold alignment, validate the binary probability label contract when `primary_metric` is `roc_auc` or `log_loss`, and materialize blended OOF plus test predictions without retraining the base candidates.
 11. When `experiment.candidate.optimization.enabled=true` for a model candidate, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
 12. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional candidate-type-specific files such as `blend_summary.csv` or optimization metadata.
 13. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
@@ -196,6 +196,7 @@ Manual verification steps for each target:
 - model candidates: `experiment.candidate.feature_recipe_id` must resolve to one supported tracked recipe; `identity` is the default path for new competitions
 - model candidates: `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
 - blend candidates: `experiment.candidate.base_candidate_ids` must resolve to existing compatible candidate artifacts for the same competition context
+- binary probability blend candidates: all base candidates must share the same saved `positive_label`, `negative_label`, and `observed_label_pair` contract
 - feature recipes are experiment-scoped, deterministic, leakage-safe transforms applied after raw feature extraction and before preprocessing
 - feature recipes must preserve row counts and row order and must produce identical train/test feature columns
 - training must write exactly one candidate artifact directory keyed by `candidate_id`
@@ -254,7 +255,7 @@ Hard-error cases include:
 - Unsupported metric for chosen task -> hard error
 - Any CV/training fit or scoring failure -> hard error
 - Blend base candidate artifact missing `candidate.json`, `oof_predictions.csv`, or `test_predictions.csv` -> hard error
-- Blend base candidate mismatch in competition slug, task type, primary metric, schema, OOF row order, fold assignments, or test ID order -> hard error
+- Blend base candidate mismatch in competition slug, task type, primary metric, schema, binary probability label contract, OOF row order, fold assignments, or test ID order -> hard error
 - Fold assignment gaps in OOF generation -> hard error
 - Candidate artifact directory already exists for the configured `candidate_id` -> hard error
 - Missing configured candidate artifacts at submit time -> hard error

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -187,6 +187,49 @@ def _encode_binary_test_labels(
     ).to_numpy(dtype=float)
 
 
+def _validate_binary_probability_label_contract(
+    manifest: dict[str, object],
+    candidate_id: str,
+    positive_label: object | None,
+    negative_label: object | None,
+    expected_observed_label_pair: tuple[object, object] | None,
+) -> None:
+    if positive_label is None or negative_label is None or expected_observed_label_pair is None:
+        raise ValueError("Binary probability blending requires resolved class metadata.")
+
+    manifest_positive_label = manifest.get("positive_label")
+    manifest_negative_label = manifest.get("negative_label")
+    observed_label_pair = manifest.get("observed_label_pair")
+    if (
+        manifest_positive_label is None
+        or manifest_negative_label is None
+        or not isinstance(observed_label_pair, list)
+        or len(observed_label_pair) != 2
+    ):
+        raise ValueError(
+            "Binary probability blend candidates must include positive_label, negative_label, "
+            f"and observed_label_pair metadata. Candidate {candidate_id} is missing that contract."
+        )
+
+    expected_contract = {
+        "positive_label": _normalize_binary_label(positive_label),
+        "negative_label": _normalize_binary_label(negative_label),
+        "observed_label_pair": [
+            _normalize_binary_label(label) for label in expected_observed_label_pair
+        ],
+    }
+    observed_contract = {
+        "positive_label": _normalize_binary_label(manifest_positive_label),
+        "negative_label": _normalize_binary_label(manifest_negative_label),
+        "observed_label_pair": [_normalize_binary_label(label) for label in observed_label_pair],
+    }
+    if observed_contract != expected_contract:
+        raise ValueError(
+            "Binary probability blend candidate label contract does not match the configured blend context. "
+            f"Candidate {candidate_id}: expected {expected_contract}, observed {observed_contract}"
+        )
+
+
 def _load_blend_component(
     competition_slug: str,
     candidate_id: str,
@@ -199,6 +242,7 @@ def _load_blend_component(
     expected_test_ids: pd.Series,
     positive_label: object | None,
     negative_label: object | None,
+    observed_label_pair: tuple[object, object] | None,
 ) -> BlendComponent:
     candidate_dir = _candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
     manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
@@ -258,6 +302,15 @@ def _load_blend_component(
         raise ValueError(
             "Blend base candidate test IDs do not match the configured competition test set. "
             f"Candidate {candidate_id} is not compatible."
+        )
+
+    if task_type == "binary" and get_binary_prediction_kind(primary_metric) == "probability":
+        _validate_binary_probability_label_contract(
+            manifest=manifest,
+            candidate_id=candidate_id,
+            positive_label=positive_label,
+            negative_label=negative_label,
+            expected_observed_label_pair=observed_label_pair,
         )
 
     if task_type == "binary" and get_binary_prediction_kind(primary_metric) == "label":
@@ -604,6 +657,7 @@ def run_blend_training(
             expected_test_ids=test_df[id_column],
             positive_label=positive_label,
             negative_label=negative_label,
+            observed_label_pair=observed_label_pair,
         )
         for base_candidate_id in config.base_candidate_ids
     ]


### PR DESCRIPTION
Closes #102

## Summary
- reject binary probability blend components whose saved positive-class contract does not match the current blend context
- require `positive_label`, `negative_label`, and `observed_label_pair` metadata before accepting `roc_auc` or `log_loss` base candidates
- document the stricter compatibility rule in the README and technical guide

## Verification
- `PYTHONDONTWRITEBYTECODE=1 uv run python -m py_compile src/tabular_shenanigans/blend.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python - <<'PY' ... PY`
  - verified a compatible binary `roc_auc` blend still writes candidate artifacts
  - verified a base candidate with a flipped saved positive-label contract now fails before blending
