### PR TITLE
Make binary accuracy blends use one rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Materialize one explicit experiment candidate at a time:
   - train one cross-validated model candidate using an optional config-selected feature recipe plus config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs
   - or build one blend candidate from existing compatible candidate artifacts under the same prepared competition context
-- Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`, plus optional candidate-type-specific metadata such as `blend_summary.csv` or optimization files.
+- Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`, plus optional candidate-type-specific metadata such as `blend_summary.csv`, binary-accuracy blend probabilities, or optimization files.
 - When `experiment.candidate.optimization.enabled=true` for a model candidate, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact selected by `candidate_id`.
 - Optionally publish `prepare`, `train`, and `submit` runs plus generated artifacts to a remote MLflow tracking server while preserving the current local file-based workflow.
@@ -170,6 +170,7 @@ Current `experiment.submit` keys:
 Binary prediction artifact contract:
 - `roc_auc` and `log_loss`: `test_predictions.csv` and `submission.csv` contain positive-class probabilities in `[0, 1]`
 - `accuracy`: `test_predictions.csv` and `submission.csv` contain predicted class labels from the observed binary label set
+- `accuracy`: candidates also write `test_prediction_probabilities.csv` with positive-class probabilities for blend reuse, and blends average those probabilities before applying a `0.5` label threshold
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `candidate.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected artifact manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
@@ -196,6 +197,7 @@ Manual verification for each target:
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written
 - for model candidates, confirm `candidate.json` records the selected `feature_recipe_id`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written for the selected candidate artifact
+- for binary `accuracy` candidates, confirm `candidate.json` records the probability-average blend rule and sidecar path, and `artifacts/<competition_slug>/candidates/<candidate_id>/test_prediction_probabilities.csv` is also written
 - run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
@@ -216,6 +218,8 @@ Manual verification for blend candidates:
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` is written with `candidate_type: blend` and component provenance
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/blend_summary.csv` records component candidate IDs, weights, component CV scores, and OOF correlation hints
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv` is written without retraining the base candidates
+- for binary `accuracy` blends, confirm `artifacts/<competition_slug>/candidates/<candidate_id>/test_prediction_probabilities.csv` is written and `test_predictions.csv` matches a `0.5` threshold on those blended probabilities
+- for binary `accuracy` blends, confirm a legacy base candidate without `test_prediction_probabilities.csv` fails fast and must be retrained
 - for binary `roc_auc` and `log_loss` blends, confirm mismatched base-candidate label contracts fail before predictions are averaged
 - run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`
@@ -228,6 +232,7 @@ Manual verification for blend candidates:
 - EDA reports: `reports/<competition_slug>/`
 - Candidate artifacts: `artifacts/<competition_slug>/candidates/<candidate_id>/`
   - includes `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and `submission.csv` when prepared or submitted
+  - binary `accuracy` candidates and blends also include `test_prediction_probabilities.csv` for probability-average-then-threshold blending, and `candidate.json` records that rule plus the sidecar path
   - model candidates record the selected `feature_recipe_id`, engineered `feature_columns`, and optional `tuning_provenance`
   - blend candidates also include `blend_summary.csv` and record their component candidates plus normalized weights in `candidate.json`
   - optimized model candidates also include `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -115,6 +115,8 @@ Input:
 Binary prediction artifact contract:
 - `roc_auc` and `log_loss` write positive-class probabilities to `test_predictions.csv` and `submission.csv`
 - `accuracy` writes predicted class labels to `test_predictions.csv` and `submission.csv`
+- `accuracy` also writes `test_prediction_probabilities.csv` with positive-class probabilities for consistent blend reuse
+- binary `accuracy` blends use one aggregation rule for both CV scoring and test export: weighted average of positive-class probabilities, then `0.5` thresholding for `test_predictions.csv`
 
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
@@ -142,6 +144,7 @@ Manual verification steps for each target:
 - confirm inferred `id_column` and `label_column`
 - confirm `candidate.json` is generated in the candidate directory
 - confirm `test_predictions.csv` is generated in the candidate directory
+- for binary `accuracy` candidates, confirm `candidate.json` records `binary_accuracy_blend_rule` plus `binary_accuracy_test_probability_path`, and `test_prediction_probabilities.csv` is also generated in the candidate directory
 - run `uv run python main.py submit`
 - confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected candidate directory
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
@@ -169,6 +172,7 @@ Manual verification steps for each target:
   - `oof_predictions.csv`
   - `test_predictions.csv`
   - `submission.csv` when prepared or submitted
+- binary `accuracy` candidates and blends also include `test_prediction_probabilities.csv`, and `candidate.json` records `binary_accuracy_blend_rule` plus `binary_accuracy_test_probability_path`
 - model candidates also record `feature_recipe_id` plus the engineered `feature_columns`
 - blend candidates also include `blend_summary.csv` and record component candidate provenance plus normalized weights in `candidate.json`
 - optimized model candidates record `tuning_provenance` in `candidate.json`
@@ -197,6 +201,7 @@ Manual verification steps for each target:
 - model candidates: `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
 - blend candidates: `experiment.candidate.base_candidate_ids` must resolve to existing compatible candidate artifacts for the same competition context
 - binary probability blend candidates: all base candidates must share the same saved `positive_label`, `negative_label`, and `observed_label_pair` contract
+- binary accuracy blend candidates: all base candidates must share the same saved label contract and must include the probability-sidecar artifact plus the current probability-average blend rule metadata
 - feature recipes are experiment-scoped, deterministic, leakage-safe transforms applied after raw feature extraction and before preprocessing
 - feature recipes must preserve row counts and row order and must produce identical train/test feature columns
 - training must write exactly one candidate artifact directory keyed by `candidate_id`
@@ -211,6 +216,7 @@ Manual verification steps for each target:
 - The positive class is resolved from the training target and used consistently for diagnostics and scoring
 - Binary `roc_auc` and `log_loss` artifacts use positive-class probabilities
 - Binary `accuracy` artifacts use class labels from the observed binary label pair
+- Binary `accuracy` candidates also persist positive-class test probabilities for consistent blend reuse
 - Binary classification must have an explicit positive-class contract; when `positive_label` is omitted, the workflow only auto-resolves the positive class for `[0, 1]`, `[False, True]`, or `["No", "Yes"]`
 - `id_column` inference must resolve to exactly one column present in `train.csv`, `test.csv`, and `sample_submission.csv`
 - The resolved `id_column` is identifier metadata and must be excluded from preprocessing and model fitting by default
@@ -255,7 +261,8 @@ Hard-error cases include:
 - Unsupported metric for chosen task -> hard error
 - Any CV/training fit or scoring failure -> hard error
 - Blend base candidate artifact missing `candidate.json`, `oof_predictions.csv`, or `test_predictions.csv` -> hard error
-- Blend base candidate mismatch in competition slug, task type, primary metric, schema, binary probability label contract, OOF row order, fold assignments, or test ID order -> hard error
+- Binary accuracy blend base candidate missing `test_prediction_probabilities.csv` or current probability-average blend metadata -> hard error
+- Blend base candidate mismatch in competition slug, task type, primary metric, schema, binary label contract, OOF row order, fold assignments, or test ID order -> hard error
 - Fold assignment gaps in OOF generation -> hard error
 - Candidate artifact directory already exists for the configured `candidate_id` -> hard error
 - Missing configured candidate artifacts at submit time -> hard error

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -16,6 +16,8 @@ from tabular_shenanigans.preprocess import prepare_feature_frames
 BLEND_MODEL_ID = "blend_weighted_average"
 BLEND_MODEL_NAME = "WeightedAverageBlend"
 BLEND_PREPROCESSING_SCHEME_ID = "blend"
+BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME = "test_prediction_probabilities.csv"
+BINARY_ACCURACY_BLEND_RULE = "average_positive_class_probability_then_threshold_0.5"
 
 
 @dataclass(frozen=True)
@@ -111,6 +113,44 @@ def _load_test_predictions(candidate_dir: Path, id_column: str, label_column: st
     return prediction_df
 
 
+def _load_binary_accuracy_test_probabilities(
+    manifest: dict[str, object],
+    candidate_dir: Path,
+    candidate_id: str,
+    id_column: str,
+    label_column: str,
+) -> pd.DataFrame:
+    blend_rule = manifest.get("binary_accuracy_blend_rule")
+    if blend_rule != BINARY_ACCURACY_BLEND_RULE:
+        raise ValueError(
+            "Binary accuracy blends require base candidates written with the current probability-based "
+            f"aggregation contract. Candidate {candidate_id} had binary_accuracy_blend_rule={blend_rule!r}."
+        )
+
+    probability_path_name = manifest.get("binary_accuracy_test_probability_path")
+    if not isinstance(probability_path_name, str) or not probability_path_name:
+        raise ValueError(
+            "Binary accuracy blends require base candidates with test probability artifacts from the current "
+            f"runtime. Candidate {candidate_id} is missing binary_accuracy_test_probability_path; retrain it."
+        )
+
+    probability_path = candidate_dir / probability_path_name
+    if not probability_path.exists():
+        raise ValueError(
+            "Binary accuracy blends require the configured test probability artifact to exist. "
+            f"Candidate {candidate_id} is missing {probability_path}."
+        )
+
+    probability_df = pd.read_csv(probability_path)
+    expected_columns = [id_column, label_column]
+    if probability_df.columns.tolist() != expected_columns:
+        raise ValueError(
+            "Binary accuracy blend probability artifacts must match the resolved schema. "
+            f"Expected columns {expected_columns}, got {probability_df.columns.tolist()} in {probability_path}"
+        )
+    return probability_df
+
+
 def _resolve_blend_weights(
     base_candidate_ids: list[str],
     configured_weights: list[float] | None,
@@ -162,12 +202,12 @@ def _build_target_summary(
     raise ValueError(f"Unsupported task_type for target summary: {task_type}")
 
 
-def _encode_binary_test_labels(
+def _validate_binary_test_labels(
     prediction_values: pd.Series,
     positive_label: object,
     negative_label: object,
     candidate_id: str,
-) -> np.ndarray:
+) -> None:
     normalized_positive_label = _normalize_binary_label(positive_label)
     normalized_negative_label = _normalize_binary_label(negative_label)
     normalized_predictions = prediction_values.map(_normalize_binary_label)
@@ -179,12 +219,33 @@ def _encode_binary_test_labels(
             "Binary accuracy blends require base candidate test predictions to contain only the observed "
             f"class labels. Candidate {candidate_id} had invalid labels: {invalid_labels[:10]}"
         )
-    return normalized_predictions.map(
-        {
-            normalized_negative_label: 0.0,
-            normalized_positive_label: 1.0,
-        }
-    ).to_numpy(dtype=float)
+
+
+def _validate_binary_probability_values(
+    prediction_values: pd.Series,
+    candidate_id: str,
+    artifact_name: str,
+) -> np.ndarray:
+    if not pd.api.types.is_numeric_dtype(prediction_values):
+        raise ValueError(
+            f"Binary probability artifacts must be numeric. Candidate {candidate_id}: {artifact_name}"
+        )
+    if not prediction_values.map(pd.notna).all():
+        raise ValueError(
+            f"Binary probability artifacts cannot contain missing values. Candidate {candidate_id}: {artifact_name}"
+        )
+
+    prediction_array = prediction_values.to_numpy(dtype=float)
+    if not np.isfinite(prediction_array).all():
+        raise ValueError(
+            f"Binary probability artifacts must be finite. Candidate {candidate_id}: {artifact_name}"
+        )
+    if ((prediction_array < 0.0) | (prediction_array > 1.0)).any():
+        raise ValueError(
+            "Binary probability artifacts must stay within [0, 1]. "
+            f"Candidate {candidate_id}: {artifact_name}"
+        )
+    return prediction_array
 
 
 def _validate_binary_probability_label_contract(
@@ -304,7 +365,11 @@ def _load_blend_component(
             f"Candidate {candidate_id} is not compatible."
         )
 
-    if task_type == "binary" and get_binary_prediction_kind(primary_metric) == "probability":
+    binary_prediction_kind = None
+    if task_type == "binary":
+        binary_prediction_kind = get_binary_prediction_kind(primary_metric)
+
+    if binary_prediction_kind == "probability":
         _validate_binary_probability_label_contract(
             manifest=manifest,
             candidate_id=candidate_id,
@@ -313,14 +378,38 @@ def _load_blend_component(
             expected_observed_label_pair=observed_label_pair,
         )
 
-    if task_type == "binary" and get_binary_prediction_kind(primary_metric) == "label":
+    if binary_prediction_kind == "label":
         if positive_label is None or negative_label is None:
             raise ValueError("Binary accuracy blending requires resolved class metadata.")
-        test_predictions = _encode_binary_test_labels(
+        _validate_binary_test_labels(
             prediction_values=prediction_df[label_column],
             positive_label=positive_label,
             negative_label=negative_label,
             candidate_id=candidate_id,
+        )
+        _validate_binary_probability_label_contract(
+            manifest=manifest,
+            candidate_id=candidate_id,
+            positive_label=positive_label,
+            negative_label=negative_label,
+            expected_observed_label_pair=observed_label_pair,
+        )
+        probability_df = _load_binary_accuracy_test_probabilities(
+            manifest=manifest,
+            candidate_dir=candidate_dir,
+            candidate_id=candidate_id,
+            id_column=id_column,
+            label_column=label_column,
+        )
+        if not _series_matches_expected(probability_df[id_column], expected_test_ids):
+            raise ValueError(
+                "Binary accuracy blend probability artifact IDs do not match the configured competition test set. "
+                f"Candidate {candidate_id} is not compatible."
+            )
+        test_predictions = _validate_binary_probability_values(
+            prediction_values=probability_df[label_column],
+            candidate_id=candidate_id,
+            artifact_name="test_prediction_probabilities.csv",
         )
     else:
         if not pd.api.types.is_numeric_dtype(prediction_df[label_column]):
@@ -330,9 +419,7 @@ def _load_blend_component(
             )
         test_predictions = prediction_df[label_column].to_numpy(dtype=float)
 
-    if task_type == "regression" or (
-        task_type == "binary" and get_binary_prediction_kind(primary_metric) == "probability"
-    ):
+    if task_type == "regression" or binary_prediction_kind == "probability":
         if not np.isfinite(test_predictions).all():
             raise ValueError(
                 "Blend base candidate test predictions must be finite. "
@@ -506,7 +593,7 @@ def _build_candidate_manifest(
     components: list[BlendComponent],
     normalized_weights: list[float],
 ) -> dict[str, object]:
-    return {
+    manifest = {
         "artifact_type": "candidate",
         "candidate_id": config.candidate_id,
         "candidate_type": config.candidate_type,
@@ -554,6 +641,10 @@ def _build_candidate_manifest(
         "test_rows": test_rows,
         "test_cols": None,
     }
+    if config.task_type == "binary" and config.primary_metric == "accuracy":
+        manifest["binary_accuracy_blend_rule"] = BINARY_ACCURACY_BLEND_RULE
+        manifest["binary_accuracy_test_probability_path"] = BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME
+    return manifest
 
 
 def _write_candidate_artifacts(
@@ -565,6 +656,7 @@ def _write_candidate_artifacts(
     fold_assignments: np.ndarray,
     test_ids: pd.Series,
     test_predictions: np.ndarray,
+    test_prediction_probabilities: np.ndarray | None,
     id_column: str,
     label_column: str,
     blend_summary_df: pd.DataFrame,
@@ -592,6 +684,17 @@ def _write_candidate_artifacts(
         }
     )
     test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
+    if test_prediction_probabilities is not None:
+        test_probability_df = pd.DataFrame(
+            {
+                id_column: test_ids.to_numpy(),
+                label_column: test_prediction_probabilities,
+            }
+        )
+        test_probability_df.to_csv(
+            candidate_dir / BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
+            index=False,
+        )
     blend_summary_df.to_csv(candidate_dir / "blend_summary.csv", index=False)
 
 
@@ -667,6 +770,7 @@ def run_blend_training(
     weight_array = np.asarray(normalized_weights, dtype=float)
     blended_oof_predictions = np.average(component_oof_predictions, axis=0, weights=weight_array)
     blended_test_predictions = np.average(component_test_predictions, axis=0, weights=weight_array)
+    test_prediction_probabilities = None
 
     if config.task_type == "regression":
         final_test_predictions: np.ndarray | list[object] = blended_test_predictions
@@ -675,6 +779,7 @@ def run_blend_training(
     elif get_binary_prediction_kind(config.primary_metric) == "label":
         if positive_label is None or negative_label is None:
             raise ValueError("Binary label blends require resolved class metadata.")
+        test_prediction_probabilities = np.asarray(blended_test_predictions, dtype=float)
         final_test_predictions = np.where(
             blended_test_predictions >= 0.5,
             positive_label,
@@ -752,6 +857,7 @@ def run_blend_training(
         fold_assignments=fold_assignments,
         test_ids=test_df[id_column],
         test_predictions=np.asarray(final_test_predictions),
+        test_prediction_probabilities=test_prediction_probabilities,
         id_column=id_column,
         label_column=label_column,
         blend_summary_df=blend_summary_df,

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -15,6 +15,9 @@ from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
 
+BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME = "test_prediction_probabilities.csv"
+BINARY_ACCURACY_BLEND_RULE = "average_positive_class_probability_then_threshold_0.5"
+
 
 @dataclass(frozen=True)
 class CvSummary:
@@ -68,6 +71,7 @@ class ModelEvaluationArtifacts:
     fold_metrics_df: pd.DataFrame
     oof_predictions: np.ndarray
     final_test_predictions: np.ndarray
+    test_prediction_probabilities: np.ndarray | None = None
 
 
 @dataclass(frozen=True)
@@ -155,7 +159,7 @@ def _run_cv_evaluation(
     positive_label: object | None,
     negative_label: object | None,
     collect_prediction_artifacts: bool,
-) -> tuple[ModelCvEvaluation, np.ndarray | None, np.ndarray | None]:
+) -> tuple[ModelCvEvaluation, np.ndarray | None, np.ndarray | None, np.ndarray | None]:
     model_definition, _, model_params = build_model(
         task_type,
         model_spec.model_id,
@@ -271,22 +275,29 @@ def _run_cv_evaluation(
     )
 
     if not collect_prediction_artifacts:
-        return cv_evaluation, None, None
+        return cv_evaluation, None, None, None
 
     if oof_predictions is None or test_predictions_per_fold is None:
         raise RuntimeError("Prediction artifacts were requested but not collected.")
 
     mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
+    test_prediction_probabilities = None
     if task_type == "regression" and primary_metric == "rmsle":
         mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
     if task_type == "binary" and binary_prediction_kind == "label":
         if positive_label is None or negative_label is None:
             raise ValueError("Binary label exports require resolved class metadata.")
+        test_prediction_probabilities = np.asarray(mean_test_predictions, dtype=float)
         final_test_predictions = np.where(mean_test_predictions >= 0.5, positive_label, negative_label)
     else:
         final_test_predictions = mean_test_predictions
 
-    return cv_evaluation, oof_predictions, np.asarray(final_test_predictions)
+    return (
+        cv_evaluation,
+        oof_predictions,
+        np.asarray(final_test_predictions),
+        test_prediction_probabilities,
+    )
 
 
 def _score_model_spec(
@@ -303,7 +314,7 @@ def _score_model_spec(
     positive_label: object | None,
     negative_label: object | None,
 ) -> ModelCvEvaluation:
-    cv_evaluation, _, _ = _run_cv_evaluation(
+    cv_evaluation, _, _, _ = _run_cv_evaluation(
         task_type=task_type,
         primary_metric=primary_metric,
         model_spec=model_spec,
@@ -337,7 +348,7 @@ def _evaluate_model_spec(
     positive_label: object | None,
     negative_label: object | None,
 ) -> ModelEvaluationArtifacts:
-    cv_evaluation, oof_predictions, final_test_predictions = _run_cv_evaluation(
+    cv_evaluation, oof_predictions, final_test_predictions, test_prediction_probabilities = _run_cv_evaluation(
         task_type=task_type,
         primary_metric=primary_metric,
         model_spec=model_spec,
@@ -361,6 +372,7 @@ def _evaluate_model_spec(
         fold_metrics_df=cv_evaluation.fold_metrics_df,
         oof_predictions=oof_predictions,
         final_test_predictions=final_test_predictions,
+        test_prediction_probabilities=test_prediction_probabilities,
     )
 
 
@@ -426,7 +438,7 @@ def _build_candidate_manifest(
     test_cols: int,
     tuning_provenance: dict[str, object] | None,
 ) -> dict[str, object]:
-    return {
+    manifest = {
         "artifact_type": "candidate",
         "candidate_id": config.candidate_id,
         "candidate_type": config.candidate_type,
@@ -457,6 +469,10 @@ def _build_candidate_manifest(
         "test_cols": test_cols,
         "tuning_provenance": tuning_provenance,
     }
+    if config.task_type == "binary" and config.primary_metric == "accuracy":
+        manifest["binary_accuracy_blend_rule"] = BINARY_ACCURACY_BLEND_RULE
+        manifest["binary_accuracy_test_probability_path"] = BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME
+    return manifest
 
 
 def _write_candidate_artifacts(
@@ -492,6 +508,17 @@ def _write_candidate_artifacts(
         }
     )
     test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
+    if evaluation_artifacts.test_prediction_probabilities is not None:
+        test_probability_df = pd.DataFrame(
+            {
+                id_column: test_ids.to_numpy(),
+                label_column: evaluation_artifacts.test_prediction_probabilities,
+            }
+        )
+        test_probability_df.to_csv(
+            candidate_dir / BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
+            index=False,
+        )
 
 
 def _write_optimization_artifacts(


### PR DESCRIPTION
Closes #105

## Summary
- persist positive-class test probabilities for binary accuracy candidates alongside the label export
- make binary accuracy blends average those probabilities for both CV scoring and test aggregation, then threshold at `0.5` for `test_predictions.csv`
- fail fast on legacy accuracy candidates that do not carry the new probability-sidecar contract
- document the new accuracy artifact contract in the README and technical guide

## Verification
- `PYTHONDONTWRITEBYTECODE=1 uv run python -m py_compile src/tabular_shenanigans/train.py src/tabular_shenanigans/blend.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python - <<'PY' ... PY`
  - verified a real binary `accuracy` model candidate writes `test_prediction_probabilities.csv` and that `test_predictions.csv` matches a `0.5` threshold on it
  - verified a synthetic binary `accuracy` blend writes blended probabilities, exports labels from the same threshold rule, and differs from the old hard-vote export behavior on the repro case
  - verified a legacy accuracy base candidate without the new probability-sidecar contract fails fast during blend loading
