### PR TITLE
Deduplicate candidate artifact handling

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -41,17 +41,18 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, training, and submission.
 - `src/tabular_shenanigans/competition.py`: competition-level preparation, `competition.json` persistence, `folds.csv` persistence, prepared-context validation, and split reconstruction from frozen folds.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, and runtime contract validation.
+- `src/tabular_shenanigans/candidate_artifacts.py`: shared candidate artifact path resolution, manifest loading, config fingerprint helpers, target-summary generation, and common candidate file writing.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/feature_recipes/*`: deterministic experiment-scoped feature transforms, including the `identity` default and tracked competition-specific recipe modules.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
 - `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
-- `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact loading, weighted prediction combination, and `blend_summary.csv` writing.
-- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, candidate artifact writing, candidate manifest generation, and optimization-aware training orchestration.
+- `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact compatibility checks, weighted prediction combination, blend-specific manifest fields, and `blend_summary.csv` writing on top of the shared candidate-artifact layer.
+- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, model-specific manifest fields, and optimization-aware training orchestration on top of the shared candidate-artifact layer.
 - `src/tabular_shenanigans/tune.py`: internal Optuna helper used by `train` when candidate optimization is enabled.
-- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates.
-- `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, tag/metric logging, config snapshot logging, and post-stage artifact publishing.
+- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates using the shared candidate manifest loader.
+- `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, tag/metric logging, config snapshot logging, and post-stage artifact publishing using the shared candidate manifest loader.
 
 ## Configuration Contract
 Input:

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -7,6 +5,17 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from tabular_shenanigans.candidate_artifacts import (
+    BINARY_ACCURACY_BLEND_RULE,
+    BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
+    build_base_config_snapshot,
+    build_binary_accuracy_artifact_metadata,
+    build_config_fingerprint as make_candidate_config_fingerprint,
+    build_target_summary,
+    candidate_dir as resolve_candidate_dir,
+    load_candidate_manifest,
+    write_candidate_artifacts as write_common_candidate_artifacts,
+)
 from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
@@ -16,8 +25,6 @@ from tabular_shenanigans.preprocess import prepare_feature_frames
 BLEND_MODEL_ID = "blend_weighted_average"
 BLEND_MODEL_NAME = "WeightedAverageBlend"
 BLEND_PREPROCESSING_SCHEME_ID = "blend"
-BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME = "test_prediction_probabilities.csv"
-BINARY_ACCURACY_BLEND_RULE = "average_positive_class_probability_then_threshold_0.5"
 
 
 @dataclass(frozen=True)
@@ -32,22 +39,6 @@ class BlendComponent:
     cv_metric_std: float
     oof_predictions: np.ndarray
     test_predictions: np.ndarray
-
-
-def _json_ready(value: object) -> object:
-    if isinstance(value, dict):
-        return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
-    if isinstance(value, list):
-        return [_json_ready(item) for item in value]
-    if isinstance(value, tuple):
-        return [_json_ready(item) for item in value]
-    if isinstance(value, np.generic):
-        return value.item()
-    return value
-
-
-def _candidate_dir(competition_slug: str, candidate_id: str) -> Path:
-    return Path("artifacts") / competition_slug / "candidates" / candidate_id
 
 
 def _normalize_binary_label(value: object) -> str:
@@ -74,16 +65,6 @@ def _series_matches_expected(observed: pd.Series, expected: pd.Series) -> bool:
     observed_values = observed_reset.map(_normalize_binary_label)
     expected_values = expected_reset.map(_normalize_binary_label)
     return observed_values.equals(expected_values)
-
-
-def _load_candidate_manifest(candidate_dir: Path) -> dict[str, object]:
-    manifest_path = candidate_dir / "candidate.json"
-    if not manifest_path.exists():
-        raise ValueError(f"Missing candidate manifest required for blending: {manifest_path}")
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if not isinstance(manifest, dict):
-        raise ValueError(f"Candidate manifest must be a JSON object: {manifest_path}")
-    return manifest
 
 
 def _load_oof_predictions(candidate_dir: Path) -> pd.DataFrame:
@@ -166,40 +147,6 @@ def _resolve_blend_weights(
     if not np.isfinite(weight_sum) or weight_sum <= 0:
         raise ValueError("Blend candidate weights must sum to a positive value.")
     return [float(weight / weight_sum) for weight in configured_weights]
-
-
-def _build_target_summary(
-    task_type: str,
-    y_train: pd.Series,
-    positive_label: object | None = None,
-    negative_label: object | None = None,
-    observed_label_pair: tuple[object, object] | None = None,
-) -> dict[str, object]:
-    if task_type == "regression":
-        return {
-            "target_mean": float(y_train.mean()),
-            "target_std": float(y_train.std(ddof=0)),
-            "target_min": float(y_train.min()),
-            "target_max": float(y_train.max()),
-        }
-
-    if task_type == "binary":
-        if positive_label is None or negative_label is None or observed_label_pair is None:
-            raise ValueError("Binary target summary requires resolved label metadata.")
-        positive_count = int((y_train == positive_label).sum())
-        row_count = int(y_train.shape[0])
-        negative_count = row_count - positive_count
-        return {
-            "observed_label_1": str(observed_label_pair[0]),
-            "observed_label_2": str(observed_label_pair[1]),
-            "negative_label": str(negative_label),
-            "positive_label": str(positive_label),
-            "positive_count": positive_count,
-            "negative_count": negative_count,
-            "target_prevalence": float(positive_count / row_count),
-        }
-
-    raise ValueError(f"Unsupported task_type for target summary: {task_type}")
 
 
 def _validate_binary_test_labels(
@@ -305,8 +252,11 @@ def _load_blend_component(
     negative_label: object | None,
     observed_label_pair: tuple[object, object] | None,
 ) -> BlendComponent:
-    candidate_dir = _candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
-    manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
+    candidate_dir = resolve_candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
+    manifest = load_candidate_manifest(
+        candidate_dir_path=candidate_dir,
+        missing_message=f"Missing candidate manifest required for blending: {candidate_dir / 'candidate.json'}",
+    )
 
     manifest_competition_slug = manifest.get("competition_slug")
     manifest_task_type = manifest.get("task_type")
@@ -535,23 +485,20 @@ def _build_config_snapshot(
     label_column: str,
     normalized_weights: list[float],
 ) -> dict[str, object]:
-    return {
-        "competition": {
-            **config.competition.model_dump(mode="python"),
-            "primary_metric": config.primary_metric,
-            "positive_label": positive_label,
-            "id_column": id_column,
-            "label_column": label_column,
-        },
-        "experiment": config.experiment.model_dump(mode="python"),
-        "resolved_blend_components": [
-            {
-                "candidate_id": candidate_id,
-                "weight": weight,
-            }
-            for candidate_id, weight in zip(config.base_candidate_ids, normalized_weights, strict=True)
-        ],
-    }
+    config_snapshot = build_base_config_snapshot(
+        config=config,
+        positive_label=positive_label,
+        id_column=id_column,
+        label_column=label_column,
+    )
+    config_snapshot["resolved_blend_components"] = [
+        {
+            "candidate_id": candidate_id,
+            "weight": weight,
+        }
+        for candidate_id, weight in zip(config.base_candidate_ids, normalized_weights, strict=True)
+    ]
+    return config_snapshot
 
 
 def _build_config_fingerprint(
@@ -559,20 +506,20 @@ def _build_config_fingerprint(
     components: list[BlendComponent],
     normalized_weights: list[float],
 ) -> str:
-    fingerprint_payload = {
-        "config_snapshot": config_snapshot,
-        "blend_components": [
-            {
-                "candidate_id": component.candidate_id,
-                "config_fingerprint": component.config_fingerprint,
-                "weight": weight,
-            }
-            for component, weight in zip(components, normalized_weights, strict=True)
-        ],
-        "model_id": BLEND_MODEL_ID,
-    }
-    fingerprint_payload_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
-    return hashlib.sha256(fingerprint_payload_json.encode("utf-8")).hexdigest()[:12]
+    return make_candidate_config_fingerprint(
+        {
+            "config_snapshot": config_snapshot,
+            "blend_components": [
+                {
+                    "candidate_id": component.candidate_id,
+                    "config_fingerprint": component.config_fingerprint,
+                    "weight": weight,
+                }
+                for component, weight in zip(components, normalized_weights, strict=True)
+            ],
+            "model_id": BLEND_MODEL_ID,
+        }
+    )
 
 
 def _build_candidate_manifest(
@@ -641,9 +588,12 @@ def _build_candidate_manifest(
         "test_rows": test_rows,
         "test_cols": None,
     }
-    if config.task_type == "binary" and config.primary_metric == "accuracy":
-        manifest["binary_accuracy_blend_rule"] = BINARY_ACCURACY_BLEND_RULE
-        manifest["binary_accuracy_test_probability_path"] = BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME
+    manifest.update(
+        build_binary_accuracy_artifact_metadata(
+            task_type=config.task_type,
+            primary_metric=config.primary_metric,
+        )
+    )
     return manifest
 
 
@@ -661,40 +611,19 @@ def _write_candidate_artifacts(
     label_column: str,
     blend_summary_df: pd.DataFrame,
 ) -> None:
-    (candidate_dir / "candidate.json").write_text(
-        json.dumps(_json_ready(manifest), indent=2, sort_keys=True),
-        encoding="utf-8",
+    write_common_candidate_artifacts(
+        candidate_dir_path=candidate_dir,
+        manifest=manifest,
+        fold_metrics_df=fold_metrics_df,
+        y_train=y_train,
+        oof_predictions=oof_predictions,
+        fold_assignments=fold_assignments,
+        test_ids=test_ids,
+        test_predictions=test_predictions,
+        id_column=id_column,
+        label_column=label_column,
+        test_prediction_probabilities=test_prediction_probabilities,
     )
-    fold_metrics_df.to_csv(candidate_dir / "fold_metrics.csv", index=False)
-
-    oof_df = pd.DataFrame(
-        {
-            "row_idx": np.arange(y_train.shape[0], dtype=int),
-            "y_true": y_train.to_numpy(),
-            "y_pred": oof_predictions,
-            "fold": fold_assignments,
-        }
-    )
-    oof_df.to_csv(candidate_dir / "oof_predictions.csv", index=False)
-
-    test_predictions_df = pd.DataFrame(
-        {
-            id_column: test_ids.to_numpy(),
-            label_column: test_predictions,
-        }
-    )
-    test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
-    if test_prediction_probabilities is not None:
-        test_probability_df = pd.DataFrame(
-            {
-                id_column: test_ids.to_numpy(),
-                label_column: test_prediction_probabilities,
-            }
-        )
-        test_probability_df.to_csv(
-            candidate_dir / BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
-            index=False,
-        )
     blend_summary_df.to_csv(candidate_dir / "blend_summary.csv", index=False)
 
 
@@ -705,7 +634,7 @@ def run_blend_training(
     if not config.is_blend_candidate:
         raise ValueError("Blend training requires experiment.candidate.candidate_type=blend.")
 
-    candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
+    candidate_dir = resolve_candidate_dir(config.competition_slug, config.candidate_id)
     if candidate_dir.exists():
         raise ValueError(
             "Candidate artifacts already exist for this candidate_id. "
@@ -807,7 +736,7 @@ def run_blend_training(
         normalized_weights=normalized_weights,
     )
 
-    target_summary = _build_target_summary(
+    target_summary = build_target_summary(
         task_type=config.task_type,
         y_train=y_train,
         positive_label=positive_label,

--- a/src/tabular_shenanigans/candidate_artifacts.py
+++ b/src/tabular_shenanigans/candidate_artifacts.py
@@ -1,0 +1,162 @@
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from tabular_shenanigans.config import AppConfig
+
+BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME = "test_prediction_probabilities.csv"
+BINARY_ACCURACY_BLEND_RULE = "average_positive_class_probability_then_threshold_0.5"
+
+
+def json_ready(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): json_ready(nested_value) for key, nested_value in value.items()}
+    if isinstance(value, list):
+        return [json_ready(item) for item in value]
+    if isinstance(value, tuple):
+        return [json_ready(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def candidate_dir(competition_slug: str, candidate_id: str) -> Path:
+    return Path("artifacts") / competition_slug / "candidates" / candidate_id
+
+
+def load_candidate_manifest(
+    candidate_dir_path: Path,
+    missing_message: str | None = None,
+) -> dict[str, object]:
+    manifest_path = candidate_dir_path / "candidate.json"
+    if not manifest_path.exists():
+        if missing_message is not None:
+            raise ValueError(missing_message)
+        raise ValueError(f"Missing candidate manifest: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError(f"Candidate manifest must be a JSON object: {manifest_path}")
+    return manifest
+
+
+def build_target_summary(
+    task_type: str,
+    y_train: pd.Series,
+    positive_label: object | None = None,
+    negative_label: object | None = None,
+    observed_label_pair: tuple[object, object] | None = None,
+) -> dict[str, object]:
+    if task_type == "regression":
+        return {
+            "target_mean": float(y_train.mean()),
+            "target_std": float(y_train.std(ddof=0)),
+            "target_min": float(y_train.min()),
+            "target_max": float(y_train.max()),
+        }
+
+    if task_type == "binary":
+        if positive_label is None or negative_label is None or observed_label_pair is None:
+            raise ValueError("Binary target summary requires resolved label metadata.")
+        positive_count = int((y_train == positive_label).sum())
+        row_count = int(y_train.shape[0])
+        negative_count = row_count - positive_count
+        return {
+            "observed_label_1": str(observed_label_pair[0]),
+            "observed_label_2": str(observed_label_pair[1]),
+            "negative_label": str(negative_label),
+            "positive_label": str(positive_label),
+            "positive_count": positive_count,
+            "negative_count": negative_count,
+            "target_prevalence": float(positive_count / row_count),
+        }
+
+    raise ValueError(f"Unsupported task_type for target summary: {task_type}")
+
+
+def build_base_config_snapshot(
+    config: AppConfig,
+    positive_label: object | None,
+    id_column: str,
+    label_column: str,
+) -> dict[str, object]:
+    return {
+        "competition": {
+            **config.competition.model_dump(mode="python"),
+            "primary_metric": config.primary_metric,
+            "positive_label": positive_label,
+            "id_column": id_column,
+            "label_column": label_column,
+        },
+        "experiment": config.experiment.model_dump(mode="python"),
+    }
+
+
+def build_config_fingerprint(fingerprint_payload: dict[str, object]) -> str:
+    fingerprint_payload_json = json.dumps(json_ready(fingerprint_payload), sort_keys=True)
+    return hashlib.sha256(fingerprint_payload_json.encode("utf-8")).hexdigest()[:12]
+
+
+def build_binary_accuracy_artifact_metadata(
+    task_type: str,
+    primary_metric: str,
+) -> dict[str, object]:
+    if task_type != "binary" or primary_metric != "accuracy":
+        return {}
+    return {
+        "binary_accuracy_blend_rule": BINARY_ACCURACY_BLEND_RULE,
+        "binary_accuracy_test_probability_path": BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
+    }
+
+
+def write_candidate_artifacts(
+    candidate_dir_path: Path,
+    manifest: dict[str, object],
+    fold_metrics_df: pd.DataFrame,
+    y_train: pd.Series,
+    oof_predictions: np.ndarray,
+    fold_assignments: np.ndarray,
+    test_ids: pd.Series,
+    test_predictions: np.ndarray,
+    id_column: str,
+    label_column: str,
+    test_prediction_probabilities: np.ndarray | None = None,
+) -> None:
+    (candidate_dir_path / "candidate.json").write_text(
+        json.dumps(json_ready(manifest), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    fold_metrics_df.to_csv(candidate_dir_path / "fold_metrics.csv", index=False)
+
+    oof_df = pd.DataFrame(
+        {
+            "row_idx": np.arange(y_train.shape[0], dtype=int),
+            "y_true": y_train.to_numpy(),
+            "y_pred": oof_predictions,
+            "fold": fold_assignments,
+        }
+    )
+    oof_df.to_csv(candidate_dir_path / "oof_predictions.csv", index=False)
+
+    test_predictions_df = pd.DataFrame(
+        {
+            id_column: test_ids.to_numpy(),
+            label_column: test_predictions,
+        }
+    )
+    test_predictions_df.to_csv(candidate_dir_path / "test_predictions.csv", index=False)
+
+    if test_prediction_probabilities is not None:
+        test_probability_df = pd.DataFrame(
+            {
+                id_column: test_ids.to_numpy(),
+                label_column: test_prediction_probabilities,
+            }
+        )
+        test_probability_df.to_csv(
+            candidate_dir_path / BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
+            index=False,
+        )

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -7,6 +6,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from tabular_shenanigans.candidate_artifacts import (
+    candidate_dir as resolve_candidate_dir,
+    load_candidate_manifest,
+)
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.data import get_binary_prediction_kind, load_sample_submission_template, validate_sample_submission_schema
 
@@ -41,10 +44,6 @@ class SubmissionContext:
     prediction_path: Path
 
 
-def _candidate_dir(competition_slug: str, candidate_id: str) -> Path:
-    return Path("artifacts") / competition_slug / "candidates" / candidate_id
-
-
 def _submission_ledger_path(competition_slug: str) -> Path:
     return Path("artifacts") / competition_slug / "submissions.csv"
 
@@ -69,19 +68,6 @@ def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None
         merged_df.to_csv(ledger_path, index=False)
         return
     ledger_df.to_csv(ledger_path, index=False)
-
-
-def _load_candidate_manifest(candidate_dir: Path) -> dict[str, object]:
-    manifest_path = candidate_dir / "candidate.json"
-    if not manifest_path.exists():
-        raise ValueError(
-            f"Missing candidate manifest: {manifest_path}. Submission requires current candidate artifacts."
-        )
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if not isinstance(manifest, dict):
-        raise ValueError(f"Candidate manifest must be a JSON object: {manifest_path}")
-    return manifest
-
 
 def _require_manifest_value(manifest: dict[str, object], field_name: str) -> object:
     field_value = manifest.get(field_name)
@@ -113,8 +99,14 @@ def _load_submission_context(
     competition_slug: str,
     candidate_id: str,
 ) -> SubmissionContext:
-    candidate_dir = _candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
-    candidate_manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
+    candidate_dir = resolve_candidate_dir(competition_slug=competition_slug, candidate_id=candidate_id)
+    candidate_manifest = load_candidate_manifest(
+        candidate_dir_path=candidate_dir,
+        missing_message=(
+            f"Missing candidate manifest: {candidate_dir / 'candidate.json'}. "
+            "Submission requires current candidate artifacts."
+        ),
+    )
     cv_summary = candidate_manifest.get("cv_summary")
     if not isinstance(cv_summary, dict):
         raise ValueError("Candidate manifest cv_summary must be a mapping.")

--- a/src/tabular_shenanigans/tracking.py
+++ b/src/tabular_shenanigans/tracking.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
+from tabular_shenanigans.candidate_artifacts import load_candidate_manifest
 from tabular_shenanigans.config import AppConfig
 
 
@@ -44,15 +45,6 @@ def _build_stage_run_name(
     if extra_tags is not None and extra_tags.get("candidate_id") is not None:
         run_name_parts.append(str(extra_tags["candidate_id"]))
     return " | ".join(run_name_parts)
-
-
-def _load_candidate_manifest(candidate_dir: Path) -> dict[str, object]:
-    manifest_path = candidate_dir / "candidate.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    if not isinstance(manifest, dict):
-        raise ValueError(f"Candidate manifest must be a JSON object: {manifest_path}")
-    return manifest
-
 
 @contextmanager
 def start_stage_run(
@@ -111,7 +103,7 @@ def log_prepare_outputs(prepared_context) -> None:
 
 def log_train_outputs(candidate_dir: Path) -> None:
     mlflow = _load_mlflow()
-    manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
+    manifest = load_candidate_manifest(candidate_dir_path=candidate_dir)
     cv_summary = manifest.get("cv_summary")
     if not isinstance(cv_summary, dict):
         raise ValueError(f"Candidate manifest cv_summary must be a mapping: {candidate_dir / 'candidate.json'}")
@@ -169,7 +161,7 @@ def log_submit_outputs(
 ) -> None:
     mlflow = _load_mlflow()
     candidate_dir = submission_path.parent
-    manifest = _load_candidate_manifest(candidate_dir=candidate_dir)
+    manifest = load_candidate_manifest(candidate_dir_path=candidate_dir)
     cv_summary = manifest.get("cv_summary")
     if not isinstance(cv_summary, dict):
         raise ValueError(f"Candidate manifest cv_summary must be a mapping: {candidate_dir / 'candidate.json'}")

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -7,6 +6,15 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from tabular_shenanigans.candidate_artifacts import (
+    build_base_config_snapshot,
+    build_binary_accuracy_artifact_metadata,
+    build_config_fingerprint,
+    build_target_summary,
+    candidate_dir as resolve_candidate_dir,
+    json_ready,
+    write_candidate_artifacts,
+)
 from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
@@ -14,9 +22,6 @@ from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_predi
 from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
-
-BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME = "test_prediction_probabilities.csv"
-BINARY_ACCURACY_BLEND_RULE = "average_positive_class_probability_then_threshold_0.5"
 
 
 @dataclass(frozen=True)
@@ -86,18 +91,6 @@ class OptimizationArtifacts:
     trials_df: pd.DataFrame
 
 
-def _json_ready(value: object) -> object:
-    if isinstance(value, dict):
-        return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
-    if isinstance(value, list):
-        return [_json_ready(item) for item in value]
-    if isinstance(value, tuple):
-        return [_json_ready(item) for item in value]
-    if isinstance(value, np.generic):
-        return value.item()
-    return value
-
-
 def _resolve_training_model_spec(
     config: AppConfig,
     model_spec: TrainingModelSpec | None = None,
@@ -108,40 +101,6 @@ def _resolve_training_model_spec(
         model_id=config.resolved_model_id,
         parameter_overrides=config.model_parameter_overrides,
     )
-
-
-def _build_target_summary(
-    task_type: str,
-    y_train: pd.Series,
-    positive_label: object | None = None,
-    negative_label: object | None = None,
-    observed_label_pair: tuple[object, object] | None = None,
-) -> dict[str, object]:
-    if task_type == "regression":
-        return {
-            "target_mean": float(y_train.mean()),
-            "target_std": float(y_train.std(ddof=0)),
-            "target_min": float(y_train.min()),
-            "target_max": float(y_train.max()),
-        }
-
-    if task_type == "binary":
-        if positive_label is None or negative_label is None or observed_label_pair is None:
-            raise ValueError("Binary target summary requires resolved label metadata.")
-        positive_count = int((y_train == positive_label).sum())
-        row_count = int(y_train.shape[0])
-        negative_count = row_count - positive_count
-        return {
-            "observed_label_1": str(observed_label_pair[0]),
-            "observed_label_2": str(observed_label_pair[1]),
-            "negative_label": str(negative_label),
-            "positive_label": str(positive_label),
-            "positive_count": positive_count,
-            "negative_count": negative_count,
-            "target_prevalence": float(positive_count / row_count),
-        }
-
-    raise ValueError(f"Unsupported task_type for target summary: {task_type}")
 
 
 def _run_cv_evaluation(
@@ -376,10 +335,6 @@ def _evaluate_model_spec(
     )
 
 
-def _candidate_dir(competition_slug: str, candidate_id: str) -> Path:
-    return Path("artifacts") / competition_slug / "candidates" / candidate_id
-
-
 def _build_config_snapshot(
     config: AppConfig,
     model_spec: TrainingModelSpec,
@@ -388,17 +343,13 @@ def _build_config_snapshot(
     label_column: str,
     tuning_provenance: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    config_snapshot = {
-        "competition": {
-            **config.competition.model_dump(mode="python"),
-            "primary_metric": config.primary_metric,
-            "positive_label": positive_label,
-            "id_column": id_column,
-            "label_column": label_column,
-        },
-        "experiment": config.experiment.model_dump(mode="python"),
-        "resolved_model_id": model_spec.model_id,
-    }
+    config_snapshot = build_base_config_snapshot(
+        config=config,
+        positive_label=positive_label,
+        id_column=id_column,
+        label_column=label_column,
+    )
+    config_snapshot["resolved_model_id"] = model_spec.model_id
     if model_spec.parameter_overrides:
         config_snapshot["resolved_model_parameter_overrides"] = model_spec.parameter_overrides
     if tuning_provenance is not None:
@@ -410,12 +361,12 @@ def _build_config_fingerprint(
     config_snapshot: dict[str, object],
     model_result: ModelRunResult,
 ) -> str:
-    fingerprint_payload = {
-        "config_snapshot": config_snapshot,
-        "model": model_result.to_fingerprint_entry(),
-    }
-    fingerprint_payload_json = json.dumps(_json_ready(fingerprint_payload), sort_keys=True)
-    return hashlib.sha256(fingerprint_payload_json.encode("utf-8")).hexdigest()[:12]
+    return build_config_fingerprint(
+        {
+            "config_snapshot": config_snapshot,
+            "model": model_result.to_fingerprint_entry(),
+        }
+    )
 
 
 def _build_candidate_manifest(
@@ -469,56 +420,13 @@ def _build_candidate_manifest(
         "test_cols": test_cols,
         "tuning_provenance": tuning_provenance,
     }
-    if config.task_type == "binary" and config.primary_metric == "accuracy":
-        manifest["binary_accuracy_blend_rule"] = BINARY_ACCURACY_BLEND_RULE
-        manifest["binary_accuracy_test_probability_path"] = BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME
+    manifest.update(
+        build_binary_accuracy_artifact_metadata(
+            task_type=config.task_type,
+            primary_metric=config.primary_metric,
+        )
+    )
     return manifest
-
-
-def _write_candidate_artifacts(
-    candidate_dir: Path,
-    manifest: dict[str, object],
-    evaluation_artifacts: ModelEvaluationArtifacts,
-    y_train: pd.Series,
-    fold_assignments: np.ndarray,
-    test_ids: pd.Series,
-    id_column: str,
-    label_column: str,
-) -> None:
-    (candidate_dir / "candidate.json").write_text(
-        json.dumps(_json_ready(manifest), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    evaluation_artifacts.fold_metrics_df.to_csv(candidate_dir / "fold_metrics.csv", index=False)
-
-    oof_df = pd.DataFrame(
-        {
-            "row_idx": np.arange(y_train.shape[0], dtype=int),
-            "y_true": y_train.to_numpy(),
-            "y_pred": evaluation_artifacts.oof_predictions,
-            "fold": fold_assignments,
-        }
-    )
-    oof_df.to_csv(candidate_dir / "oof_predictions.csv", index=False)
-
-    test_predictions_df = pd.DataFrame(
-        {
-            id_column: test_ids.to_numpy(),
-            label_column: evaluation_artifacts.final_test_predictions,
-        }
-    )
-    test_predictions_df.to_csv(candidate_dir / "test_predictions.csv", index=False)
-    if evaluation_artifacts.test_prediction_probabilities is not None:
-        test_probability_df = pd.DataFrame(
-            {
-                id_column: test_ids.to_numpy(),
-                label_column: evaluation_artifacts.test_prediction_probabilities,
-            }
-        )
-        test_probability_df.to_csv(
-            candidate_dir / BINARY_ACCURACY_TEST_PROBABILITIES_FILENAME,
-            index=False,
-        )
 
 
 def _write_optimization_artifacts(
@@ -526,7 +434,7 @@ def _write_optimization_artifacts(
     optimization_artifacts: OptimizationArtifacts,
 ) -> None:
     (candidate_dir / "optimization_summary.json").write_text(
-        json.dumps(_json_ready(optimization_artifacts.summary), indent=2, sort_keys=True),
+        json.dumps(json_ready(optimization_artifacts.summary), indent=2, sort_keys=True),
         encoding="utf-8",
     )
     optimization_artifacts.trials_df.to_csv(candidate_dir / "optimization_trials.csv", index=False)
@@ -534,7 +442,7 @@ def _write_optimization_artifacts(
     best_params = optimization_artifacts.summary.get("best_params")
     if isinstance(best_params, dict):
         (candidate_dir / "optimization_best_params.json").write_text(
-            json.dumps(_json_ready(best_params), indent=2, sort_keys=True),
+            json.dumps(json_ready(best_params), indent=2, sort_keys=True),
             encoding="utf-8",
         )
 
@@ -549,7 +457,7 @@ def run_training(
         raise ValueError("run_training only supports experiment.candidate.candidate_type=model.")
 
     resolved_model_spec = _resolve_training_model_spec(config=config, model_spec=model_spec)
-    candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
+    candidate_dir = resolve_candidate_dir(config.competition_slug, config.candidate_id)
     if candidate_dir.exists():
         raise ValueError(
             "Candidate artifacts already exist for this candidate_id. "
@@ -595,7 +503,7 @@ def run_training(
         x_train_raw=x_train_raw,
         x_test_raw=x_test_raw,
     )
-    target_summary = _build_target_summary(
+    target_summary = build_target_summary(
         task_type=task_type,
         y_train=y_train,
         positive_label=positive_label,
@@ -665,15 +573,18 @@ def run_training(
 
     candidate_dir.parent.mkdir(parents=True, exist_ok=True)
     candidate_dir.mkdir(parents=False, exist_ok=False)
-    _write_candidate_artifacts(
-        candidate_dir=candidate_dir,
+    write_candidate_artifacts(
+        candidate_dir_path=candidate_dir,
         manifest=candidate_manifest,
-        evaluation_artifacts=evaluation_artifacts,
+        fold_metrics_df=evaluation_artifacts.fold_metrics_df,
         y_train=y_train,
+        oof_predictions=evaluation_artifacts.oof_predictions,
         fold_assignments=fold_assignments,
         test_ids=test_df[id_column],
+        test_predictions=evaluation_artifacts.final_test_predictions,
         id_column=id_column,
         label_column=label_column,
+        test_prediction_probabilities=evaluation_artifacts.test_prediction_probabilities,
     )
     return candidate_dir
 
@@ -682,7 +593,7 @@ def run_training_workflow(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
 ) -> Path:
-    candidate_dir = _candidate_dir(config.competition_slug, config.candidate_id)
+    candidate_dir = resolve_candidate_dir(config.competition_slug, config.candidate_id)
     if candidate_dir.exists():
         raise ValueError(
             "Candidate artifacts already exist for this candidate_id. "


### PR DESCRIPTION
Closes #103

## Summary
- add a shared candidate artifact utility module for manifest/path/fingerprint/target-summary helpers
- rewire train and blend to use the shared artifact writer while keeping candidate-specific manifest assembly local
- move submit and tracking onto the shared candidate manifest loader and document the new module responsibility

## Verification
- compiled `src/tabular_shenanigans/candidate_artifacts.py`, `train.py`, `blend.py`, `submit.py`, and `tracking.py` with a no-bytecode `compile(...)` pass
- ran a focused local smoke script that created a synthetic binary competition zip, trained two model candidates, trained one blend candidate, prepared a submission from the blend, and exercised tracking artifact logging with a dummy MLflow client
- confirmed the shared artifact layout still produced `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, `test_prediction_probabilities.csv`, `blend_summary.csv`, and `submission.csv` where expected