### PR TITLE
Unify tuning and training evaluation core

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -21,7 +21,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
   - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
   - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
 10. For blend candidates, load compatible base candidate artifacts from `artifacts/<competition_slug>/candidates/<base_candidate_id>/`, validate shared schema plus frozen-fold alignment, validate the binary probability label contract when `primary_metric` is `roc_auc` or `log_loss`, and materialize blended OOF plus test predictions without retraining the base candidates.
-11. When `experiment.candidate.optimization.enabled=true` for a model candidate, `train` runs an Optuna study on the frozen fold assignments, retrains the best trial into the standard candidate artifact layout, and writes optimization metadata inside the candidate directory.
+11. When `experiment.candidate.optimization.enabled=true` for a model candidate, `train` builds one prepared training context, runs an Optuna study on the frozen fold assignments through the shared evaluation core, reuses that prepared context for the final best-trial retrain, and writes optimization metadata inside the candidate directory.
 12. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional candidate-type-specific files such as `blend_summary.csv` or optimization metadata.
 13. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
 14. When `experiment.tracking.enabled=true`, publish stage-local artifacts and metadata for `prepare`, `train`, and `submit` to the configured MLflow server after the stage succeeds.
@@ -45,12 +45,13 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/feature_recipes/*`: deterministic experiment-scoped feature transforms, including the `identity` default and tracked competition-specific recipe modules.
+- `src/tabular_shenanigans/model_evaluation.py`: shared prepared training-context construction, reusable CV scoring and prediction generation, resolved feature-schema reuse, and model evaluation contracts consumed by both `train` and `tune`.
 - `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
-- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, column typing, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
+- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, resolved feature-schema inference, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact compatibility checks, weighted prediction combination, blend-specific manifest fields, and `blend_summary.csv` writing on top of the shared candidate-artifact layer.
-- `src/tabular_shenanigans/train.py`: config-selected training from the shared dataset context, frozen-fold loading, model-specific manifest fields, and optimization-aware training orchestration on top of the shared candidate-artifact layer.
-- `src/tabular_shenanigans/tune.py`: internal Optuna helper used by `train` when candidate optimization is enabled.
+- `src/tabular_shenanigans/train.py`: config-selected model training orchestration, candidate artifact writing, model-specific manifest fields, and optimization-aware workflow control on top of the shared candidate-artifact and model-evaluation layers.
+- `src/tabular_shenanigans/tune.py`: internal Optuna orchestration used by `train` when candidate optimization is enabled, consuming the shared prepared training context and shared evaluation functions.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates using the shared candidate manifest loader.
 - `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, tag/metric logging, config snapshot logging, and post-stage artifact publishing using the shared candidate manifest loader.
 
@@ -126,7 +127,7 @@ The current runtime resolves `experiment.candidate.feature_recipe_id` to one tra
 The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id` for model candidates.
 Blend candidates consume compatible existing candidate artifacts and materialize a synthetic `blend_weighted_average` artifact model ID.
 optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.
-enabled optimization is consumed by `train` and applies to model candidates only.
+enabled optimization is consumed by `train`, applies to model candidates only, and reuses one prepared training context for Optuna scoring plus the final best-trial retrain within the same invocation.
 Frequency encoding is fold-local and maps unseen categorical values to `0.0`.
 LightGBM, CatBoost, and XGBoost require the optional booster dependencies installed via `uv sync --extra boosters`.
 MLflow tracking requires the optional tracking dependencies installed via `uv sync --extra tracking`.
@@ -207,7 +208,7 @@ Manual verification steps for each target:
 - feature recipes must preserve row counts and row order and must produce identical train/test feature columns
 - training must write exactly one candidate artifact directory keyed by `candidate_id`
 - rerunning an existing `candidate_id` must fail instead of mutating an existing artifact directory
-- enabled optimization is part of `train`, applies to model candidates only, and retrains exactly one tuned candidate into the normal candidate artifact layout
+- enabled optimization is part of `train`, applies to model candidates only, reuses one prepared training context for scoring and retraining, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
 - `submit` must resolve one candidate by `candidate_id`, defaulting to `config.candidate_id`
 - `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -1,0 +1,352 @@
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from tabular_shenanigans.candidate_artifacts import build_target_summary
+from tabular_shenanigans.competition import ensure_prepared_competition_context
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
+from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
+from tabular_shenanigans.feature_recipes import apply_feature_recipe
+from tabular_shenanigans.models import build_model, build_model_fit_kwargs
+from tabular_shenanigans.preprocess import (
+    ResolvedFeatureSchema,
+    build_preprocessor_from_schema,
+    prepare_feature_frames,
+    resolve_feature_schema,
+)
+
+
+@dataclass(frozen=True)
+class CvSummary:
+    metric_name: str
+    metric_mean: float
+    metric_std: float
+    higher_is_better: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "metric_name": self.metric_name,
+            "metric_mean": self.metric_mean,
+            "metric_std": self.metric_std,
+            "higher_is_better": self.higher_is_better,
+        }
+
+
+@dataclass(frozen=True)
+class ModelRunResult:
+    model_id: str
+    model_name: str
+    preprocessing_scheme_id: str
+    model_params: dict[str, object]
+    cv_summary: CvSummary
+
+    def to_fingerprint_entry(self) -> dict[str, object]:
+        return {
+            "model_id": self.model_id,
+            "model_params": self.model_params,
+        }
+
+
+@dataclass(frozen=True)
+class TrainingModelSpec:
+    model_id: str
+    parameter_overrides: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class ModelEvaluationArtifacts:
+    model_result: ModelRunResult
+    fold_metrics_df: pd.DataFrame
+    oof_predictions: np.ndarray
+    final_test_predictions: np.ndarray
+    test_prediction_probabilities: np.ndarray | None = None
+
+
+@dataclass(frozen=True)
+class ModelCvEvaluation:
+    model_result: ModelRunResult
+    fold_metrics_df: pd.DataFrame
+
+
+@dataclass(frozen=True)
+class PreparedTrainingContext:
+    id_column: str
+    label_column: str
+    y_train: pd.Series
+    x_train_features: pd.DataFrame
+    x_test_features: pd.DataFrame
+    split_indices: list[tuple[int, np.ndarray, np.ndarray]]
+    fold_assignments: np.ndarray
+    positive_label: object | None
+    negative_label: object | None
+    observed_label_pair: tuple[object, object] | None
+    target_summary: dict[str, object]
+    feature_schema: ResolvedFeatureSchema
+
+
+def build_prepared_training_context(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+) -> PreparedTrainingContext:
+    if not config.is_model_candidate:
+        raise ValueError("Prepared training context is only supported for model candidates.")
+
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+
+    x_train_raw, x_test_raw, y_train = prepare_feature_frames(
+        train_df=train_df,
+        test_df=test_df,
+        id_column=id_column,
+        label_column=label_column,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        drop_columns=config.drop_columns,
+    )
+
+    positive_label = config.positive_label
+    observed_label_pair = None
+    negative_label = None
+    if config.task_type == "binary":
+        negative_label, positive_label, observed_label_pair = resolve_positive_label(
+            y_values=y_train,
+            configured_positive_label=positive_label,
+        )
+
+    prepared_context = ensure_prepared_competition_context(
+        config=config,
+        dataset_context=dataset_context,
+        expected_feature_columns=x_train_raw.columns.tolist(),
+    )
+    x_train_features, x_test_features = apply_feature_recipe(
+        recipe_id=config.feature_recipe_id,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+    )
+    target_summary = build_target_summary(
+        task_type=config.task_type,
+        y_train=y_train,
+        positive_label=positive_label,
+        negative_label=negative_label,
+        observed_label_pair=observed_label_pair,
+    )
+    feature_schema = resolve_feature_schema(
+        x_train_raw=x_train_features,
+        force_categorical=config.force_categorical,
+        force_numeric=config.force_numeric,
+        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+    )
+    return PreparedTrainingContext(
+        id_column=id_column,
+        label_column=label_column,
+        y_train=y_train,
+        x_train_features=x_train_features,
+        x_test_features=x_test_features,
+        split_indices=prepared_context.split_indices,
+        fold_assignments=prepared_context.fold_assignments,
+        positive_label=positive_label,
+        negative_label=negative_label,
+        observed_label_pair=observed_label_pair,
+        target_summary=target_summary,
+        feature_schema=feature_schema,
+    )
+
+
+def _run_cv_evaluation(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    training_context: PreparedTrainingContext,
+    cv_random_state: int,
+    collect_prediction_artifacts: bool,
+) -> tuple[ModelCvEvaluation, np.ndarray | None, np.ndarray | None, np.ndarray | None]:
+    model_definition, _, model_params = build_model(
+        task_type,
+        model_spec.model_id,
+        cv_random_state,
+        parameter_overrides=model_spec.parameter_overrides,
+    )
+    resolved_model_id = model_definition.model_id
+    model_name = model_definition.model_name
+    preprocessing_scheme_id = model_definition.preprocessing_scheme_id
+
+    oof_predictions = (
+        np.zeros(training_context.x_train_features.shape[0], dtype=float)
+        if collect_prediction_artifacts
+        else None
+    )
+    test_predictions_per_fold = [] if collect_prediction_artifacts else None
+    fold_metrics: list[dict[str, object]] = []
+    use_named_columns = model_name.startswith("LGBM")
+    binary_prediction_kind = None
+    if task_type == "binary":
+        binary_prediction_kind = get_binary_prediction_kind(primary_metric)
+
+    for fold_index, train_idx, valid_idx in training_context.split_indices:
+        x_fold_train = training_context.x_train_features.iloc[train_idx]
+        x_fold_valid = training_context.x_train_features.iloc[valid_idx]
+        y_fold_train = training_context.y_train.iloc[train_idx]
+        y_fold_valid = training_context.y_train.iloc[valid_idx]
+
+        preprocessor = build_preprocessor_from_schema(
+            scheme_id=preprocessing_scheme_id,
+            feature_schema=training_context.feature_schema,
+        )
+        if use_named_columns and hasattr(preprocessor, "set_output"):
+            preprocessor.set_output(transform="pandas")
+        x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
+        x_fold_valid_processed = preprocessor.transform(x_fold_valid)
+        x_test_processed = None
+        if collect_prediction_artifacts:
+            x_test_processed = preprocessor.transform(training_context.x_test_features)
+
+        if preprocessing_scheme_id != "native" and not use_named_columns:
+            x_fold_train_processed = np.asarray(x_fold_train_processed)
+            x_fold_valid_processed = np.asarray(x_fold_valid_processed)
+            if x_test_processed is not None:
+                x_test_processed = np.asarray(x_test_processed)
+
+        _, model, _ = build_model(
+            task_type,
+            resolved_model_id,
+            cv_random_state,
+            parameter_overrides=model_spec.parameter_overrides,
+        )
+        model_fit_kwargs = build_model_fit_kwargs(
+            model_definition=model_definition,
+            x_train_processed=x_fold_train_processed,
+            numeric_columns=training_context.feature_schema.numeric_columns,
+            categorical_columns=training_context.feature_schema.categorical_columns,
+        )
+        model.fit(x_fold_train_processed, y_fold_train, **model_fit_kwargs)
+
+        if task_type == "binary":
+            if training_context.positive_label is None or training_context.negative_label is None:
+                raise ValueError("Binary training requires resolved class metadata.")
+            positive_class_index = list(model.classes_).index(training_context.positive_label)
+            fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, positive_class_index]
+            fold_test_predictions = None
+            if x_test_processed is not None:
+                fold_test_predictions = model.predict_proba(x_test_processed)[:, positive_class_index]
+        else:
+            fold_valid_predictions = model.predict(x_fold_valid_processed)
+            fold_test_predictions = None
+            if x_test_processed is not None:
+                fold_test_predictions = model.predict(x_test_processed)
+
+        fold_score = score_predictions(
+            task_type=task_type,
+            primary_metric=primary_metric,
+            y_true=y_fold_valid,
+            y_pred=fold_valid_predictions,
+            positive_label=training_context.positive_label,
+        )
+
+        if oof_predictions is not None:
+            oof_predictions[valid_idx] = fold_valid_predictions
+        if test_predictions_per_fold is not None and fold_test_predictions is not None:
+            test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
+        fold_metrics.append(
+            {
+                "fold": fold_index,
+                "metric_name": primary_metric,
+                "metric_value": fold_score,
+                "train_rows": int(len(train_idx)),
+                "valid_rows": int(len(valid_idx)),
+            }
+        )
+
+    fold_metrics_df = pd.DataFrame(fold_metrics)
+    cv_evaluation = ModelCvEvaluation(
+        model_result=ModelRunResult(
+            model_id=resolved_model_id,
+            model_name=model_name,
+            preprocessing_scheme_id=preprocessing_scheme_id,
+            model_params=model_params,
+            cv_summary=CvSummary(
+                metric_name=primary_metric,
+                metric_mean=float(fold_metrics_df["metric_value"].mean()),
+                metric_std=float(fold_metrics_df["metric_value"].std(ddof=0)),
+                higher_is_better=is_higher_better(primary_metric),
+            ),
+        ),
+        fold_metrics_df=fold_metrics_df,
+    )
+
+    if not collect_prediction_artifacts:
+        return cv_evaluation, None, None, None
+
+    if oof_predictions is None or test_predictions_per_fold is None:
+        raise RuntimeError("Prediction artifacts were requested but not collected.")
+
+    mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
+    test_prediction_probabilities = None
+    if task_type == "regression" and primary_metric == "rmsle":
+        mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
+    if task_type == "binary" and binary_prediction_kind == "label":
+        if training_context.positive_label is None or training_context.negative_label is None:
+            raise ValueError("Binary label exports require resolved class metadata.")
+        test_prediction_probabilities = np.asarray(mean_test_predictions, dtype=float)
+        final_test_predictions = np.where(
+            mean_test_predictions >= 0.5,
+            training_context.positive_label,
+            training_context.negative_label,
+        )
+    else:
+        final_test_predictions = mean_test_predictions
+
+    return (
+        cv_evaluation,
+        oof_predictions,
+        np.asarray(final_test_predictions),
+        test_prediction_probabilities,
+    )
+
+
+def score_model_spec(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    training_context: PreparedTrainingContext,
+    cv_random_state: int,
+) -> ModelCvEvaluation:
+    cv_evaluation, _, _, _ = _run_cv_evaluation(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        model_spec=model_spec,
+        training_context=training_context,
+        cv_random_state=cv_random_state,
+        collect_prediction_artifacts=False,
+    )
+    return cv_evaluation
+
+
+def evaluate_model_spec(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    training_context: PreparedTrainingContext,
+    cv_random_state: int,
+) -> ModelEvaluationArtifacts:
+    cv_evaluation, oof_predictions, final_test_predictions, test_prediction_probabilities = _run_cv_evaluation(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        model_spec=model_spec,
+        training_context=training_context,
+        cv_random_state=cv_random_state,
+        collect_prediction_artifacts=True,
+    )
+    if oof_predictions is None or final_test_predictions is None:
+        raise RuntimeError("Training evaluation must return OOF and test predictions.")
+
+    return ModelEvaluationArtifacts(
+        model_result=cv_evaluation.model_result,
+        fold_metrics_df=cv_evaluation.fold_metrics_df,
+        oof_predictions=oof_predictions,
+        final_test_predictions=final_test_predictions,
+        test_prediction_probabilities=test_prediction_probabilities,
+    )

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -18,6 +18,13 @@ class PreprocessingDefinition:
     builder: PreprocessorBuilder
 
 
+@dataclass(frozen=True)
+class ResolvedFeatureSchema:
+    feature_columns: list[str]
+    numeric_columns: list[str]
+    categorical_columns: list[str]
+
+
 def _validate_column_names(config_name: str, columns: list[str], available_columns: list[str]) -> None:
     missing_columns = [column for column in columns if column not in available_columns]
     if missing_columns:
@@ -70,6 +77,25 @@ def resolve_feature_types(
         force_categorical=force_categorical or [],
         force_numeric=force_numeric or [],
         low_cardinality_int_threshold=low_cardinality_int_threshold,
+    )
+
+
+def resolve_feature_schema(
+    x_train_raw: pd.DataFrame,
+    force_categorical: list[str] | None = None,
+    force_numeric: list[str] | None = None,
+    low_cardinality_int_threshold: int | None = None,
+) -> ResolvedFeatureSchema:
+    numeric_columns, categorical_columns = resolve_feature_types(
+        x_train_raw=x_train_raw,
+        force_categorical=force_categorical,
+        force_numeric=force_numeric,
+        low_cardinality_int_threshold=low_cardinality_int_threshold,
+    )
+    return ResolvedFeatureSchema(
+        feature_columns=x_train_raw.columns.tolist(),
+        numeric_columns=numeric_columns,
+        categorical_columns=categorical_columns,
     )
 
 
@@ -350,26 +376,36 @@ def build_preprocessor(
     force_numeric: list[str] | None = None,
     low_cardinality_int_threshold: int | None = None,
 ) -> tuple[object, list[str], list[str]]:
-    force_categorical = force_categorical or []
-    force_numeric = force_numeric or []
-
-    numeric_columns, categorical_columns = _resolve_feature_types(
+    feature_schema = resolve_feature_schema(
         x_train_raw=x_train_raw,
         force_categorical=force_categorical,
         force_numeric=force_numeric,
         low_cardinality_int_threshold=low_cardinality_int_threshold,
     )
+    preprocessor = build_preprocessor_from_schema(
+        scheme_id=scheme_id,
+        feature_schema=feature_schema,
+    )
+    return (
+        preprocessor,
+        feature_schema.numeric_columns,
+        feature_schema.categorical_columns,
+    )
 
-    if not numeric_columns and not categorical_columns:
+def build_preprocessor_from_schema(
+    scheme_id: str,
+    feature_schema: ResolvedFeatureSchema,
+) -> object:
+    if not feature_schema.numeric_columns and not feature_schema.categorical_columns:
         raise ValueError("No modeled features remain after excluding id_column and applying drop_columns.")
 
     preprocessing_definition = get_preprocessing_definition(scheme_id)
     preprocessor = preprocessing_definition.builder(
-        x_train_raw.columns.tolist(),
-        numeric_columns,
-        categorical_columns,
+        feature_schema.feature_columns,
+        feature_schema.numeric_columns,
+        feature_schema.categorical_columns,
     )
-    return preprocessor, numeric_columns, categorical_columns
+    return preprocessor
 
 
 def summarize_feature_types(

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -3,86 +3,25 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 from tabular_shenanigans.candidate_artifacts import (
     build_base_config_snapshot,
     build_binary_accuracy_artifact_metadata,
     build_config_fingerprint,
-    build_target_summary,
     candidate_dir as resolve_candidate_dir,
     json_ready,
     write_candidate_artifacts,
 )
-from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
-from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
-from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
-from tabular_shenanigans.feature_recipes import apply_feature_recipe
-from tabular_shenanigans.models import build_model, build_model_fit_kwargs
-from tabular_shenanigans.preprocess import build_preprocessor, prepare_feature_frames
-
-
-@dataclass(frozen=True)
-class CvSummary:
-    metric_name: str
-    metric_mean: float
-    metric_std: float
-    higher_is_better: bool
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "metric_name": self.metric_name,
-            "metric_mean": self.metric_mean,
-            "metric_std": self.metric_std,
-            "higher_is_better": self.higher_is_better,
-        }
-
-
-@dataclass(frozen=True)
-class ModelRunResult:
-    model_id: str
-    model_name: str
-    preprocessing_scheme_id: str
-    model_params: dict[str, object]
-    cv_summary: CvSummary
-
-    def to_manifest_entry(self) -> dict[str, object]:
-        return {
-            "model_id": self.model_id,
-            "model_name": self.model_name,
-            "preprocessing_scheme_id": self.preprocessing_scheme_id,
-            "model_params": self.model_params,
-            "cv_summary": self.cv_summary.to_dict(),
-        }
-
-    def to_fingerprint_entry(self) -> dict[str, object]:
-        return {
-            "model_id": self.model_id,
-            "model_params": self.model_params,
-        }
-
-
-@dataclass(frozen=True)
-class TrainingModelSpec:
-    model_id: str
-    parameter_overrides: dict[str, object] | None = None
-
-
-@dataclass(frozen=True)
-class ModelEvaluationArtifacts:
-    model_result: ModelRunResult
-    fold_metrics_df: pd.DataFrame
-    oof_predictions: np.ndarray
-    final_test_predictions: np.ndarray
-    test_prediction_probabilities: np.ndarray | None = None
-
-
-@dataclass(frozen=True)
-class ModelCvEvaluation:
-    model_result: ModelRunResult
-    fold_metrics_df: pd.DataFrame
+from tabular_shenanigans.data import CompetitionDatasetContext
+from tabular_shenanigans.model_evaluation import (
+    ModelRunResult,
+    PreparedTrainingContext,
+    TrainingModelSpec,
+    build_prepared_training_context,
+    evaluate_model_spec,
+)
 
 
 @dataclass(frozen=True)
@@ -100,238 +39,6 @@ def _resolve_training_model_spec(
     return TrainingModelSpec(
         model_id=config.resolved_model_id,
         parameter_overrides=config.model_parameter_overrides,
-    )
-
-
-def _run_cv_evaluation(
-    task_type: str,
-    primary_metric: str,
-    model_spec: TrainingModelSpec,
-    x_train_raw: pd.DataFrame,
-    x_test_raw: pd.DataFrame | None,
-    y_train: pd.Series,
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-    force_categorical: list[str] | None,
-    force_numeric: list[str] | None,
-    low_cardinality_int_threshold: int | None,
-    cv_random_state: int,
-    positive_label: object | None,
-    negative_label: object | None,
-    collect_prediction_artifacts: bool,
-) -> tuple[ModelCvEvaluation, np.ndarray | None, np.ndarray | None, np.ndarray | None]:
-    model_definition, _, model_params = build_model(
-        task_type,
-        model_spec.model_id,
-        cv_random_state,
-        parameter_overrides=model_spec.parameter_overrides,
-    )
-    resolved_model_id = model_definition.model_id
-    model_name = model_definition.model_name
-    preprocessing_scheme_id = model_definition.preprocessing_scheme_id
-
-    oof_predictions = np.zeros(x_train_raw.shape[0], dtype=float) if collect_prediction_artifacts else None
-    test_predictions_per_fold = [] if collect_prediction_artifacts else None
-    fold_metrics: list[dict[str, object]] = []
-    use_named_columns = model_name.startswith("LGBM")
-    binary_prediction_kind = None
-    if task_type == "binary":
-        binary_prediction_kind = get_binary_prediction_kind(primary_metric)
-
-    for fold_index, train_idx, valid_idx in split_indices:
-        x_fold_train = x_train_raw.iloc[train_idx]
-        x_fold_valid = x_train_raw.iloc[valid_idx]
-        y_fold_train = y_train.iloc[train_idx]
-        y_fold_valid = y_train.iloc[valid_idx]
-
-        preprocessor, numeric_columns, categorical_columns = build_preprocessor(
-            scheme_id=preprocessing_scheme_id,
-            x_train_raw=x_fold_train,
-            force_categorical=force_categorical,
-            force_numeric=force_numeric,
-            low_cardinality_int_threshold=low_cardinality_int_threshold,
-        )
-        if use_named_columns and hasattr(preprocessor, "set_output"):
-            preprocessor.set_output(transform="pandas")
-        x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
-        x_fold_valid_processed = preprocessor.transform(x_fold_valid)
-        x_test_processed = None
-        if collect_prediction_artifacts:
-            if x_test_raw is None:
-                raise ValueError("x_test_raw is required when collect_prediction_artifacts=True.")
-            x_test_processed = preprocessor.transform(x_test_raw)
-
-        if preprocessing_scheme_id != "native" and not use_named_columns:
-            x_fold_train_processed = np.asarray(x_fold_train_processed)
-            x_fold_valid_processed = np.asarray(x_fold_valid_processed)
-            if x_test_processed is not None:
-                x_test_processed = np.asarray(x_test_processed)
-
-        _, model, _ = build_model(
-            task_type,
-            resolved_model_id,
-            cv_random_state,
-            parameter_overrides=model_spec.parameter_overrides,
-        )
-        model_fit_kwargs = build_model_fit_kwargs(
-            model_definition=model_definition,
-            x_train_processed=x_fold_train_processed,
-            numeric_columns=numeric_columns,
-            categorical_columns=categorical_columns,
-        )
-        model.fit(x_fold_train_processed, y_fold_train, **model_fit_kwargs)
-
-        if task_type == "binary":
-            if positive_label is None or negative_label is None:
-                raise ValueError("Binary training requires resolved class metadata.")
-            positive_class_index = list(model.classes_).index(positive_label)
-            fold_valid_predictions = model.predict_proba(x_fold_valid_processed)[:, positive_class_index]
-            fold_test_predictions = None
-            if x_test_processed is not None:
-                fold_test_predictions = model.predict_proba(x_test_processed)[:, positive_class_index]
-        else:
-            fold_valid_predictions = model.predict(x_fold_valid_processed)
-            fold_test_predictions = None
-            if x_test_processed is not None:
-                fold_test_predictions = model.predict(x_test_processed)
-
-        fold_score = score_predictions(
-            task_type=task_type,
-            primary_metric=primary_metric,
-            y_true=y_fold_valid,
-            y_pred=fold_valid_predictions,
-            positive_label=positive_label,
-        )
-
-        if oof_predictions is not None:
-            oof_predictions[valid_idx] = fold_valid_predictions
-        if test_predictions_per_fold is not None and fold_test_predictions is not None:
-            test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
-        fold_metrics.append(
-            {
-                "fold": fold_index,
-                "metric_name": primary_metric,
-                "metric_value": fold_score,
-                "train_rows": int(len(train_idx)),
-                "valid_rows": int(len(valid_idx)),
-            }
-        )
-
-    fold_metrics_df = pd.DataFrame(fold_metrics)
-    cv_evaluation = ModelCvEvaluation(
-        model_result=ModelRunResult(
-            model_id=resolved_model_id,
-            model_name=model_name,
-            preprocessing_scheme_id=preprocessing_scheme_id,
-            model_params=model_params,
-            cv_summary=CvSummary(
-                metric_name=primary_metric,
-                metric_mean=float(fold_metrics_df["metric_value"].mean()),
-                metric_std=float(fold_metrics_df["metric_value"].std(ddof=0)),
-                higher_is_better=is_higher_better(primary_metric),
-            ),
-        ),
-        fold_metrics_df=fold_metrics_df,
-    )
-
-    if not collect_prediction_artifacts:
-        return cv_evaluation, None, None, None
-
-    if oof_predictions is None or test_predictions_per_fold is None:
-        raise RuntimeError("Prediction artifacts were requested but not collected.")
-
-    mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
-    test_prediction_probabilities = None
-    if task_type == "regression" and primary_metric == "rmsle":
-        mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
-    if task_type == "binary" and binary_prediction_kind == "label":
-        if positive_label is None or negative_label is None:
-            raise ValueError("Binary label exports require resolved class metadata.")
-        test_prediction_probabilities = np.asarray(mean_test_predictions, dtype=float)
-        final_test_predictions = np.where(mean_test_predictions >= 0.5, positive_label, negative_label)
-    else:
-        final_test_predictions = mean_test_predictions
-
-    return (
-        cv_evaluation,
-        oof_predictions,
-        np.asarray(final_test_predictions),
-        test_prediction_probabilities,
-    )
-
-
-def _score_model_spec(
-    task_type: str,
-    primary_metric: str,
-    model_spec: TrainingModelSpec,
-    x_train_raw: pd.DataFrame,
-    y_train: pd.Series,
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-    force_categorical: list[str] | None,
-    force_numeric: list[str] | None,
-    low_cardinality_int_threshold: int | None,
-    cv_random_state: int,
-    positive_label: object | None,
-    negative_label: object | None,
-) -> ModelCvEvaluation:
-    cv_evaluation, _, _, _ = _run_cv_evaluation(
-        task_type=task_type,
-        primary_metric=primary_metric,
-        model_spec=model_spec,
-        x_train_raw=x_train_raw,
-        x_test_raw=None,
-        y_train=y_train,
-        split_indices=split_indices,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        low_cardinality_int_threshold=low_cardinality_int_threshold,
-        cv_random_state=cv_random_state,
-        positive_label=positive_label,
-        negative_label=negative_label,
-        collect_prediction_artifacts=False,
-    )
-    return cv_evaluation
-
-
-def _evaluate_model_spec(
-    task_type: str,
-    primary_metric: str,
-    model_spec: TrainingModelSpec,
-    x_train_raw: pd.DataFrame,
-    x_test_raw: pd.DataFrame,
-    y_train: pd.Series,
-    split_indices: list[tuple[int, np.ndarray, np.ndarray]],
-    force_categorical: list[str] | None,
-    force_numeric: list[str] | None,
-    low_cardinality_int_threshold: int | None,
-    cv_random_state: int,
-    positive_label: object | None,
-    negative_label: object | None,
-) -> ModelEvaluationArtifacts:
-    cv_evaluation, oof_predictions, final_test_predictions, test_prediction_probabilities = _run_cv_evaluation(
-        task_type=task_type,
-        primary_metric=primary_metric,
-        model_spec=model_spec,
-        x_train_raw=x_train_raw,
-        x_test_raw=x_test_raw,
-        y_train=y_train,
-        split_indices=split_indices,
-        force_categorical=force_categorical,
-        force_numeric=force_numeric,
-        low_cardinality_int_threshold=low_cardinality_int_threshold,
-        cv_random_state=cv_random_state,
-        positive_label=positive_label,
-        negative_label=negative_label,
-        collect_prediction_artifacts=True,
-    )
-    if oof_predictions is None or final_test_predictions is None:
-        raise RuntimeError("Training evaluation must return OOF and test predictions.")
-
-    return ModelEvaluationArtifacts(
-        model_result=cv_evaluation.model_result,
-        fold_metrics_df=cv_evaluation.fold_metrics_df,
-        oof_predictions=oof_predictions,
-        final_test_predictions=final_test_predictions,
-        test_prediction_probabilities=test_prediction_probabilities,
     )
 
 
@@ -375,18 +82,7 @@ def _build_candidate_manifest(
     model_result: ModelRunResult,
     config_snapshot: dict[str, object],
     config_fingerprint: str,
-    observed_label_pair: tuple[object, object] | None,
-    negative_label: object | None,
-    positive_label: object | None,
-    id_column: str,
-    label_column: str,
-    feature_recipe_id: str,
-    feature_columns: list[str],
-    target_summary: dict[str, object],
-    train_rows: int,
-    train_cols: int,
-    test_rows: int,
-    test_cols: int,
+    training_context: PreparedTrainingContext,
     tuning_provenance: dict[str, object] | None,
 ) -> dict[str, object]:
     manifest = {
@@ -400,24 +96,28 @@ def _build_candidate_manifest(
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
         "model_family": config.model_family,
-        "feature_recipe_id": feature_recipe_id,
-        "feature_columns": feature_columns,
+        "feature_recipe_id": config.feature_recipe_id,
+        "feature_columns": training_context.x_train_features.columns.tolist(),
         "preprocessor": config.preprocessor,
         "model_id": model_result.model_id,
         "model_name": model_result.model_name,
         "preprocessing_scheme_id": model_result.preprocessing_scheme_id,
         "model_params": model_result.model_params,
         "cv_summary": model_result.cv_summary.to_dict(),
-        "observed_label_pair": list(observed_label_pair) if observed_label_pair is not None else None,
-        "negative_label": negative_label,
-        "positive_label": positive_label,
-        "id_column": id_column,
-        "label_column": label_column,
-        "target_summary": target_summary,
-        "train_rows": train_rows,
-        "train_cols": train_cols,
-        "test_rows": test_rows,
-        "test_cols": test_cols,
+        "observed_label_pair": (
+            list(training_context.observed_label_pair)
+            if training_context.observed_label_pair is not None
+            else None
+        ),
+        "negative_label": training_context.negative_label,
+        "positive_label": training_context.positive_label,
+        "id_column": training_context.id_column,
+        "label_column": training_context.label_column,
+        "target_summary": training_context.target_summary,
+        "train_rows": int(training_context.x_train_features.shape[0]),
+        "train_cols": int(training_context.x_train_features.shape[1]),
+        "test_rows": int(training_context.x_test_features.shape[0]),
+        "test_cols": int(training_context.x_test_features.shape[1]),
         "tuning_provenance": tuning_provenance,
     }
     manifest.update(
@@ -452,6 +152,7 @@ def run_training(
     dataset_context: CompetitionDatasetContext,
     model_spec: TrainingModelSpec | None = None,
     tuning_provenance: dict[str, object] | None = None,
+    prepared_training_context: PreparedTrainingContext | None = None,
 ) -> Path:
     if not config.is_model_candidate:
         raise ValueError("run_training only supports experiment.candidate.candidate_type=model.")
@@ -464,67 +165,19 @@ def run_training(
             f"Choose a new experiment.candidate.candidate_id or remove {candidate_dir}"
         )
 
-    task_type = config.task_type
-    primary_metric = config.primary_metric
-    positive_label = config.positive_label
-
-    train_df = dataset_context.train_df
-    test_df = dataset_context.test_df
-    id_column = dataset_context.id_column
-    label_column = dataset_context.label_column
-
-    x_train_raw, x_test_raw, y_train = prepare_feature_frames(
-        train_df=train_df,
-        test_df=test_df,
-        id_column=id_column,
-        label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
-    )
-
-    observed_label_pair = None
-    negative_label = None
-    if task_type == "binary":
-        negative_label, positive_label, observed_label_pair = resolve_positive_label(
-            y_values=y_train,
-            configured_positive_label=positive_label,
+    training_context = prepared_training_context
+    if training_context is None:
+        training_context = build_prepared_training_context(
+            config=config,
+            dataset_context=dataset_context,
         )
 
-    prepared_context = ensure_prepared_competition_context(
-        config=config,
-        dataset_context=dataset_context,
-        expected_feature_columns=x_train_raw.columns.tolist(),
-    )
-    split_indices = prepared_context.split_indices
-    fold_assignments = prepared_context.fold_assignments
-    x_train_features, x_test_features = apply_feature_recipe(
-        recipe_id=config.feature_recipe_id,
-        x_train_raw=x_train_raw,
-        x_test_raw=x_test_raw,
-    )
-    target_summary = build_target_summary(
-        task_type=task_type,
-        y_train=y_train,
-        positive_label=positive_label,
-        negative_label=negative_label,
-        observed_label_pair=observed_label_pair,
-    )
-
-    evaluation_artifacts = _evaluate_model_spec(
-        task_type=task_type,
-        primary_metric=primary_metric,
+    evaluation_artifacts = evaluate_model_spec(
+        task_type=config.task_type,
+        primary_metric=config.primary_metric,
         model_spec=resolved_model_spec,
-        x_train_raw=x_train_features,
-        x_test_raw=x_test_features,
-        y_train=y_train,
-        split_indices=split_indices,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+        training_context=training_context,
         cv_random_state=config.cv_random_state,
-        positive_label=positive_label,
-        negative_label=negative_label,
     )
     model_result = evaluation_artifacts.model_result
     print(
@@ -532,17 +185,17 @@ def run_training(
         f"feature_recipe={config.feature_recipe_id} | "
         f"model={model_result.model_id} ({model_result.model_name}) | "
         f"preprocessing={model_result.preprocessing_scheme_id} | "
-        f"features={x_train_features.shape[1]} | "
-        f"CV {primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
+        f"features={training_context.x_train_features.shape[1]} | "
+        f"CV {config.primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
         f"std={model_result.cv_summary.metric_std:.6f}"
     )
 
     config_snapshot = _build_config_snapshot(
         config=config,
         model_spec=resolved_model_spec,
-        positive_label=positive_label,
-        id_column=id_column,
-        label_column=label_column,
+        positive_label=training_context.positive_label,
+        id_column=training_context.id_column,
+        label_column=training_context.label_column,
         tuning_provenance=tuning_provenance,
     )
     config_fingerprint = _build_config_fingerprint(
@@ -556,18 +209,7 @@ def run_training(
         model_result=model_result,
         config_snapshot=config_snapshot,
         config_fingerprint=config_fingerprint,
-        observed_label_pair=observed_label_pair,
-        negative_label=negative_label,
-        positive_label=positive_label,
-        id_column=id_column,
-        label_column=label_column,
-        feature_recipe_id=config.feature_recipe_id,
-        feature_columns=x_train_features.columns.tolist(),
-        target_summary=target_summary,
-        train_rows=int(x_train_features.shape[0]),
-        train_cols=int(x_train_features.shape[1]),
-        test_rows=int(x_test_features.shape[0]),
-        test_cols=int(x_test_features.shape[1]),
+        training_context=training_context,
         tuning_provenance=tuning_provenance,
     )
 
@@ -577,13 +219,13 @@ def run_training(
         candidate_dir_path=candidate_dir,
         manifest=candidate_manifest,
         fold_metrics_df=evaluation_artifacts.fold_metrics_df,
-        y_train=y_train,
+        y_train=training_context.y_train,
         oof_predictions=evaluation_artifacts.oof_predictions,
-        fold_assignments=fold_assignments,
-        test_ids=test_df[id_column],
+        fold_assignments=training_context.fold_assignments,
+        test_ids=dataset_context.test_df[training_context.id_column],
         test_predictions=evaluation_artifacts.final_test_predictions,
-        id_column=id_column,
-        label_column=label_column,
+        id_column=training_context.id_column,
+        label_column=training_context.label_column,
         test_prediction_probabilities=evaluation_artifacts.test_prediction_probabilities,
     )
     return candidate_dir
@@ -611,12 +253,21 @@ def run_training_workflow(
 
     from tabular_shenanigans.tune import run_optimization
 
-    optimization_result = run_optimization(config=config, dataset_context=dataset_context)
+    prepared_training_context = build_prepared_training_context(
+        config=config,
+        dataset_context=dataset_context,
+    )
+    optimization_result = run_optimization(
+        config=config,
+        dataset_context=dataset_context,
+        prepared_training_context=prepared_training_context,
+    )
     candidate_dir = run_training(
         config=config,
         dataset_context=dataset_context,
         model_spec=optimization_result.best_model_spec,
         tuning_provenance=optimization_result.tuning_provenance,
+        prepared_training_context=prepared_training_context,
     )
     _write_optimization_artifacts(
         candidate_dir=candidate_dir,

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -5,19 +5,17 @@ from datetime import datetime, timezone
 import optuna
 import pandas as pd
 
-from tabular_shenanigans.competition import ensure_prepared_competition_context
+from tabular_shenanigans.candidate_artifacts import build_base_config_snapshot, json_ready
 from tabular_shenanigans.config import AppConfig
-from tabular_shenanigans.cv import is_higher_better, resolve_positive_label
+from tabular_shenanigans.cv import is_higher_better
 from tabular_shenanigans.data import CompetitionDatasetContext
-from tabular_shenanigans.feature_recipes import apply_feature_recipe
-from tabular_shenanigans.models import build_tuning_space, get_model_definition
-from tabular_shenanigans.preprocess import prepare_feature_frames
-from tabular_shenanigans.train import (
+from tabular_shenanigans.model_evaluation import (
+    PreparedTrainingContext,
     TrainingModelSpec,
-    _build_target_summary,
-    _json_ready,
-    _score_model_spec,
+    build_prepared_training_context,
+    score_model_spec,
 )
+from tabular_shenanigans.models import build_tuning_space, get_model_definition
 
 
 @dataclass(frozen=True)
@@ -37,21 +35,16 @@ def _make_study_id() -> str:
 def _build_optimization_config_snapshot(
     config: AppConfig,
     tuning_model_spec: TrainingModelSpec,
-    positive_label: object | None,
-    id_column: str,
-    label_column: str,
+    training_context: PreparedTrainingContext,
 ) -> dict[str, object]:
-    return {
-        "competition": {
-            **config.competition.model_dump(mode="python"),
-            "primary_metric": config.primary_metric,
-            "positive_label": positive_label,
-            "id_column": id_column,
-            "label_column": label_column,
-        },
-        "experiment": config.experiment.model_dump(mode="python"),
-        "resolved_model_id": tuning_model_spec.model_id,
-    }
+    config_snapshot = build_base_config_snapshot(
+        config=config,
+        positive_label=training_context.positive_label,
+        id_column=training_context.id_column,
+        label_column=training_context.label_column,
+    )
+    config_snapshot["resolved_model_id"] = tuning_model_spec.model_id
+    return config_snapshot
 
 
 def _build_trials_df(study: optuna.Study, metric_name: str) -> pd.DataFrame:
@@ -67,8 +60,8 @@ def _build_trials_df(study: optuna.Study, metric_name: str) -> pd.DataFrame:
             "started_at_utc": trial.datetime_start.isoformat() if trial.datetime_start is not None else "",
             "completed_at_utc": trial.datetime_complete.isoformat() if trial.datetime_complete is not None else "",
             "duration_seconds": trial.duration.total_seconds() if trial.duration is not None else None,
-            "params_json": json.dumps(_json_ready(trial.params), sort_keys=True),
-            "model_params_json": json.dumps(_json_ready(trial.user_attrs.get("model_params")), sort_keys=True),
+            "params_json": json.dumps(json_ready(trial.params), sort_keys=True),
+            "model_params_json": json.dumps(json_ready(trial.user_attrs.get("model_params")), sort_keys=True),
         }
         for param_name in param_names:
             row[f"param_{param_name}"] = trial.params.get(param_name)
@@ -103,7 +96,9 @@ def _build_optimization_summary(
         "model_name": model_name,
         "preprocessing_scheme_id": preprocessing_scheme_id,
         "trial_count": len(study.trials),
-        "completed_trial_count": len([trial for trial in study.trials if trial.state == optuna.trial.TrialState.COMPLETE]),
+        "completed_trial_count": len(
+            [trial for trial in study.trials if trial.state == optuna.trial.TrialState.COMPLETE]
+        ),
         "best_trial_number": best_trial.number,
         "best_value": best_trial.value,
         "best_params": best_parameter_overrides,
@@ -115,6 +110,7 @@ def _build_optimization_summary(
 def run_optimization(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
+    prepared_training_context: PreparedTrainingContext | None = None,
 ) -> OptimizationResult:
     if not config.is_model_candidate:
         raise ValueError("Optimization only supports experiment.candidate.candidate_type=model.")
@@ -128,56 +124,18 @@ def run_optimization(
     tuning_model_spec = TrainingModelSpec(model_id=config.resolved_model_id)
     model_definition = get_model_definition(task_type, tuning_model_spec.model_id)
 
-    train_df = dataset_context.train_df
-    test_df = dataset_context.test_df
-    id_column = dataset_context.id_column
-    label_column = dataset_context.label_column
-
-    x_train_raw, x_test_raw, y_train = prepare_feature_frames(
-        train_df=train_df,
-        test_df=test_df,
-        id_column=id_column,
-        label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
-    )
-
-    positive_label = config.positive_label
-    observed_label_pair = None
-    negative_label = None
-    if task_type == "binary":
-        negative_label, positive_label, observed_label_pair = resolve_positive_label(
-            y_values=y_train,
-            configured_positive_label=positive_label,
+    training_context = prepared_training_context
+    if training_context is None:
+        training_context = build_prepared_training_context(
+            config=config,
+            dataset_context=dataset_context,
         )
-
-    prepared_context = ensure_prepared_competition_context(
-        config=config,
-        dataset_context=dataset_context,
-        expected_feature_columns=x_train_raw.columns.tolist(),
-    )
-    split_indices = prepared_context.split_indices
-    x_train_features, _ = apply_feature_recipe(
-        recipe_id=config.feature_recipe_id,
-        x_train_raw=x_train_raw,
-        x_test_raw=x_test_raw,
-    )
-    target_summary = _build_target_summary(
-        task_type=task_type,
-        y_train=y_train,
-        positive_label=positive_label,
-        negative_label=negative_label,
-        observed_label_pair=observed_label_pair,
-    )
 
     study_id = _make_study_id()
     optimization_config_snapshot = _build_optimization_config_snapshot(
         config=config,
         tuning_model_spec=tuning_model_spec,
-        positive_label=positive_label,
-        id_column=id_column,
-        label_column=label_column,
+        training_context=training_context,
     )
 
     direction = "maximize" if is_higher_better(primary_metric) else "minimize"
@@ -187,28 +145,21 @@ def run_optimization(
 
     def objective(trial: optuna.Trial) -> float:
         parameter_overrides = build_tuning_space(task_type, tuning_model_spec.model_id, trial)
-        cv_evaluation = _score_model_spec(
+        cv_evaluation = score_model_spec(
             task_type=task_type,
             primary_metric=primary_metric,
             model_spec=TrainingModelSpec(
                 model_id=tuning_model_spec.model_id,
                 parameter_overrides=parameter_overrides,
             ),
-            x_train_raw=x_train_features,
-            y_train=y_train,
-            split_indices=split_indices,
-            force_categorical=config.force_categorical,
-            force_numeric=config.force_numeric,
-            low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+            training_context=training_context,
             cv_random_state=config.cv_random_state,
-            positive_label=positive_label,
-            negative_label=negative_label,
         )
         metric_mean = cv_evaluation.model_result.cv_summary.metric_mean
         metric_std = cv_evaluation.model_result.cv_summary.metric_std
         trial.set_user_attr("metric_std", metric_std)
-        trial.set_user_attr("parameter_overrides", _json_ready(parameter_overrides))
-        trial.set_user_attr("model_params", _json_ready(cv_evaluation.model_result.model_params))
+        trial.set_user_attr("parameter_overrides", json_ready(parameter_overrides))
+        trial.set_user_attr("model_params", json_ready(cv_evaluation.model_result.model_params))
         print(
             f"Trial {trial.number}: {primary_metric}={metric_mean:.6f} "
             f"(std={metric_std:.6f}) params={parameter_overrides}"
@@ -242,7 +193,7 @@ def run_optimization(
         tuning_model_spec=tuning_model_spec,
         model_name=model_definition.model_name,
         preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
-        target_summary=target_summary,
+        target_summary=training_context.target_summary,
         best_parameter_overrides=best_parameter_overrides,
     )
     return OptimizationResult(


### PR DESCRIPTION
Closes #106

## Summary
- add a shared `model_evaluation.py` module for prepared training context construction and shared CV evaluation
- cache resolved feature schema once per prepared training context and reuse it across folds and Optuna trials
- rewire `train.py` and `tune.py` so optimization-enabled runs reuse the same prepared training context for tuning and final retraining

## Verification
- compiled `preprocess.py`, `model_evaluation.py`, `train.py`, and `tune.py` with a no-bytecode `compile(...)` pass
- ran a focused local smoke script that trained one plain binary model candidate and one optimization-enabled binary model candidate on a synthetic competition zip
- confirmed the optimized path still wrote `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`
- instrumented the shared evaluation module during the optimization smoke run and confirmed `prepare_feature_frames`, `apply_feature_recipe`, and `resolve_feature_schema` were each called exactly once across Optuna scoring plus final retraining