### PR TITLE
Implement split preprocessing and capability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The repository is developed and manually verified primarily against these Playgr
 - Freeze CV assignments once per prepared competition context and reuse them across `train`.
 - Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `train`, and submit-only flows.
 - Materialize one explicit experiment candidate at a time:
-  - train one cross-validated model candidate using an optional config-selected feature recipe plus config-selected preprocessing and model-family choices that resolve internally to the current canonical recipe IDs
+  - train one cross-validated model candidate using an optional config-selected feature recipe plus split numeric and categorical preprocessing choices on top of one config-selected model family
   - or build one blend candidate from existing compatible candidate artifacts under the same prepared competition context
 - Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`, plus optional candidate-type-specific metadata such as `blend_summary.csv`, binary-accuracy blend probabilities, or optimization files.
 - When `experiment.candidate.optimization.enabled=true` for a model candidate, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
@@ -134,10 +134,12 @@ Current `experiment.candidate` contract:
   - `candidate_id`
 - model candidate keys:
   - optional `feature_recipe_id`: tracked deterministic feature recipe applied after raw feature extraction and before preprocessing/model fitting; defaults to `identity`
-  - `preprocessor`: `onehot`, `ordinal`, `native`, or `frequency`
   - `model_family`
     - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
     - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+  - `numeric_preprocessor`: `median`, `standardize`, or `kbins`
+  - `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
+  - temporary legacy shim: `preprocessor` maps to one baseline-equivalent split pair when the split fields are omitted
   - optional `model_params`
   - optional `optimization`:
     - `enabled`
@@ -151,9 +153,22 @@ Current `experiment.candidate` contract:
 
 Blend candidates validate that all base candidates share the same competition slug, task type, primary metric, resolved schema, frozen fold assignments, OOF row order, and test ID order. For binary `roc_auc` and `log_loss` blends, base candidates must also share the same saved `positive_label`, `negative_label`, and `observed_label_pair` contract.
 
-Supported `model_family + preprocessor` combinations for model candidates:
-- regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-- binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
+Model candidates now configure preprocessing with split selectors:
+- `numeric_preprocessor`: `median`, `standardize`, or `kbins`
+- `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
+
+Current model-family support by task:
+- regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+- binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+
+Current hard-invalid preprocessing combinations:
+- `categorical_preprocessor: native` with any `model_family` other than `catboost`
+
+Recommended baseline mappings from the older single-field configs:
+- `onehot` -> `numeric_preprocessor: standardize`, `categorical_preprocessor: onehot`
+- `ordinal` -> `numeric_preprocessor: median`, `categorical_preprocessor: ordinal`
+- `frequency` -> `numeric_preprocessor: median`, `categorical_preprocessor: frequency`
+- `native` -> `numeric_preprocessor: median`, `categorical_preprocessor: native`
 
 Built-in `feature_recipe_id` values for model candidates:
 - `identity`: default pass-through recipe for new competitions
@@ -174,7 +189,7 @@ Binary prediction artifact contract:
 
 If `id_column` or `label_column` are omitted, the training pipeline infers them from `train.csv`, `test.csv`, and `sample_submission.csv`. The resolved `id_column` is preserved for prediction outputs and in `candidate.json`, but it is not part of the model feature matrix. Submission preparation consumes the selected artifact manifest as the schema/task source of truth and uses `sample_submission.csv` only for validation. Invalid overrides, ambiguous inference, a `sample_submission.csv` shape that does not exactly match `[id_column, label_column]`, or a submission ID column that differs from `sample_submission.csv` in values or ordering are hard errors.
 
-The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` into one internal canonical `model_id` for model candidates. Blend candidates materialize a synthetic `blend_weighted_average` artifact model ID and use their component candidate metadata as provenance.
+The current runtime resolves `experiment.candidate.model_family` to one internal canonical `model_id` for model candidates, then records `numeric_preprocessor`, `categorical_preprocessor`, and `preprocessing_scheme_id` separately in candidate artifacts. Blend candidates materialize a synthetic `blend_weighted_average` artifact model ID and use their component candidate metadata as provenance.
 
 `task_type` and `primary_metric` are always config-driven. The pipeline does not infer them from Kaggle metadata.
 
@@ -204,9 +219,9 @@ Manual verification for each target:
 
 Manual verification for optimization:
 - run `uv run python main.py train` with `experiment.candidate.optimization.enabled: true` and at least one stopping condition
-- supported tunable combinations are:
-  - binary: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-  - regression: `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
+- supported tunable model families are:
+  - binary: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+  - regression: `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/optimization_summary.json` is written
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/optimization_trials.csv` records trial state, score, and params
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/candidate.json` records `tuning_provenance`
@@ -249,7 +264,7 @@ Manual verification for blend candidates:
 - The resolved `id_column` is identifier metadata and is excluded from preprocessing and model fitting by default.
 - `config.yaml` must use top-level `competition` and `experiment` sections; the old flat layout is unsupported.
 - The current runtime supports `experiment.candidate.candidate_type: model` and `experiment.candidate.candidate_type: blend`.
-- Model candidates resolve `experiment.candidate.model_family + experiment.candidate.preprocessor` to one canonical internal `model_id`; candidate artifacts record that resolved `model_id` and `preprocessing_scheme_id`.
+- Model candidates resolve `experiment.candidate.model_family` to one canonical internal `model_id`; candidate artifacts also record `numeric_preprocessor`, `categorical_preprocessor`, and `preprocessing_scheme_id`.
 - Model candidates default `experiment.candidate.feature_recipe_id` to `identity`; feature recipes are tracked Python modules rather than runtime scripts or YAML transform blocks.
 - Blend candidates consume existing compatible candidate artifacts and write one new blend candidate artifact without retraining the base candidates.
 - `prepare` is the competition-level source of truth for `competition.json` and `folds.csv`; `train` consumes that frozen context and auto-runs `prepare` only when it is missing.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -42,17 +42,23 @@ experiment:
     candidate_type: model
     candidate_id: baseline_logreg_v1
     feature_recipe_id: identity
-    preprocessor: onehot
     model_family: logistic_regression
+    numeric_preprocessor: standardize
+    categorical_preprocessor: onehot
     model_params: {}
 
     # Keep identity for new competitions, then switch to a tracked code recipe
     # such as s6e3_v1 only when you need competition-specific features.
 
     # Alternative binary model candidates:
-    # preprocessor: ordinal
+    # numeric_preprocessor: kbins
+    # categorical_preprocessor: onehot
+    # model_family: logistic_regression
+    # numeric_preprocessor: median
+    # categorical_preprocessor: ordinal
     # model_family: lightgbm
-    # preprocessor: native
+    # numeric_preprocessor: median
+    # categorical_preprocessor: native
     # model_family: catboost
 
     # Alternative blend candidate shape:

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -38,17 +38,23 @@ experiment:
     candidate_type: model
     candidate_id: baseline_elasticnet_v1
     feature_recipe_id: identity
-    preprocessor: onehot
     model_family: elasticnet
+    numeric_preprocessor: standardize
+    categorical_preprocessor: onehot
     model_params: {}
 
     # Keep identity for new competitions, then switch to a tracked code recipe
     # only when you need competition-specific features.
 
     # Alternative regression model candidates:
-    # preprocessor: ordinal
+    # numeric_preprocessor: kbins
+    # categorical_preprocessor: onehot
+    # model_family: elasticnet
+    # numeric_preprocessor: median
+    # categorical_preprocessor: ordinal
     # model_family: lightgbm
-    # preprocessor: native
+    # numeric_preprocessor: median
+    # categorical_preprocessor: native
     # model_family: catboost
 
     # Alternative blend candidate shape:

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -12,14 +12,17 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 5. Run `prepare` to write report CSVs under `reports/<competition_slug>/`, persist `artifacts/<competition_slug>/competition.json`, and freeze `artifacts/<competition_slug>/folds.csv`.
 6. Resolve `id_column` and `label_column` from `train.csv`, `test.csv`, and `sample_submission.csv`, then prepare raw feature frames from the train/test data with the resolved `id_column` excluded from modeled features.
 7. For model candidates during training and tuning, apply the selected deterministic feature recipe to the raw feature frames. The default `identity` recipe leaves the features unchanged.
-8. For model candidates during training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected model recipe:
-   - `onehot`: numeric median imputation + `StandardScaler`; categorical most-frequent imputation + `OneHotEncoder`
-   - `ordinal`: numeric median imputation; categorical most-frequent imputation + `OrdinalEncoder`
-   - `native`: numeric median imputation inside a pandas frame; categorical missing-value fill with native categorical columns preserved for CatBoost
-   - `frequency`: numeric median imputation; categorical values replaced by fold-local relative frequencies, with unseen categories mapped to `0.0`
-9. For model candidates, resolve the current `experiment.candidate.model_family + preprocessor` combination to one internal canonical model recipe, then train that one configured candidate:
-  - regression: `ridge + onehot`, `elasticnet + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
-  - binary classification: `logistic_regression + onehot`, `random_forest + ordinal`, `extra_trees + ordinal`, `hist_gradient_boosting + ordinal`, `hist_gradient_boosting + frequency`, `lightgbm + ordinal`, `lightgbm + frequency`, `catboost + native`, `xgboost + ordinal`, `xgboost + frequency`
+8. For model candidates during training, load the frozen fold assignments from `folds.csv` and build fold-local preprocessing from the selected split preprocessing components:
+   - numeric:
+     - `median`: numeric median imputation
+     - `standardize`: numeric median imputation + `StandardScaler`
+     - `kbins`: numeric median imputation + dense `KBinsDiscretizer`
+   - categorical:
+     - `onehot`: categorical most-frequent imputation + `OneHotEncoder`
+     - `ordinal`: categorical most-frequent imputation + `OrdinalEncoder`
+     - `frequency`: categorical values replaced by fold-local relative frequencies, with unseen categories mapped to `0.0`
+     - `native`: categorical missing-value fill with native categorical columns preserved inside a pandas frame for CatBoost
+9. For model candidates, resolve `experiment.candidate.model_family` to one internal canonical model recipe, combine it with the selected numeric and categorical preprocessing components, enforce the small hard-invalid compatibility blacklist, then train that one configured candidate.
 10. For blend candidates, load compatible base candidate artifacts from `artifacts/<competition_slug>/candidates/<base_candidate_id>/`, validate shared schema plus frozen-fold alignment, validate the binary probability label contract when `primary_metric` is `roc_auc` or `log_loss`, and materialize blended OOF plus test predictions without retraining the base candidates.
 11. When `experiment.candidate.optimization.enabled=true` for a model candidate, `train` builds one prepared training context, runs an Optuna study on the frozen fold assignments through the shared evaluation core, reuses that prepared context for the final best-trial retrain, and writes optimization metadata inside the candidate directory.
 12. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional candidate-type-specific files such as `blend_summary.csv` or optimization metadata.
@@ -46,8 +49,8 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
 - `src/tabular_shenanigans/feature_recipes/*`: deterministic experiment-scoped feature transforms, including the `identity` default and tracked competition-specific recipe modules.
 - `src/tabular_shenanigans/model_evaluation.py`: shared prepared training-context construction, reusable CV scoring and prediction generation, resolved feature-schema reuse, and model evaluation contracts consumed by both `train` and `tune`.
-- `src/tabular_shenanigans/models.py`: model-recipe registry, candidate `model_family + preprocessor` resolution, tunable-model search spaces, optional booster loading, and estimator construction for supported presets.
-- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, resolved feature-schema inference, scheme-specific preprocessing pipelines, and native-frame support for CatBoost.
+- `src/tabular_shenanigans/models.py`: task-scoped model-family registry, capability-based compatibility checks, tunable-model search spaces, optional booster loading, and estimator construction for supported model families.
+- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, resolved feature-schema inference, split numeric/categorical preprocessing components, legacy preprocessor mapping, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact compatibility checks, weighted prediction combination, blend-specific manifest fields, and `blend_summary.csv` writing on top of the shared candidate-artifact layer.
 - `src/tabular_shenanigans/train.py`: config-selected model training orchestration, candidate artifact writing, model-specific manifest fields, and optimization-aware workflow control on top of the shared candidate-artifact and model-evaluation layers.
@@ -92,10 +95,12 @@ Input:
     - `candidate_id`
   - model candidate:
     - `feature_recipe_id` (string, default `identity`; resolves to a tracked deterministic feature recipe applied before preprocessing)
-    - `preprocessor` (`onehot`, `ordinal`, `native`, or `frequency`)
     - `model_family`
       - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
       - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
+    - `numeric_preprocessor` (`median`, `standardize`, or `kbins`)
+    - `categorical_preprocessor` (`onehot`, `ordinal`, `frequency`, or `native`)
+    - temporary legacy shim: `preprocessor` resolves to one baseline-equivalent split pair when the split fields are omitted
     - optional `model_params`
     - optional `optimization`:
       - `enabled` (boolean, default false)
@@ -124,7 +129,11 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 Configured metrics are normalized to the internal metric names during config validation.
 The old flat config layout is unsupported and fails fast.
 The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe for model candidates; built-in recipe IDs are `identity` and `s6e3_v1`.
-The current runtime resolves `experiment.candidate.model_family + experiment.candidate.preprocessor` to one internal canonical `model_id` for model candidates.
+Model candidates configure preprocessing with split selectors:
+- `numeric_preprocessor`: `median`, `standardize`, or `kbins`
+- `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
+- legacy `experiment.candidate.preprocessor` remains as a temporary migration shim and resolves to one of the supported split pairs
+The current runtime resolves `experiment.candidate.model_family` to one internal canonical `model_id` for model candidates, and records `preprocessing_scheme_id` separately from the model ID.
 Blend candidates consume compatible existing candidate artifacts and materialize a synthetic `blend_weighted_average` artifact model ID.
 optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.
 enabled optimization is consumed by `train`, applies to model candidates only, and reuses one prepared training context for Optuna scoring plus the final best-trial retrain within the same invocation.
@@ -175,7 +184,7 @@ Manual verification steps for each target:
   - `test_predictions.csv`
   - `submission.csv` when prepared or submitted
 - binary `accuracy` candidates and blends also include `test_prediction_probabilities.csv`, and `candidate.json` records `binary_accuracy_blend_rule` plus `binary_accuracy_test_probability_path`
-- model candidates also record `feature_recipe_id` plus the engineered `feature_columns`
+- model candidates also record `feature_recipe_id`, `numeric_preprocessor`, `categorical_preprocessor`, `preprocessing_scheme_id`, and the engineered `feature_columns`
 - blend candidates also include `blend_summary.csv` and record component candidate provenance plus normalized weights in `candidate.json`
 - optimized model candidates record `tuning_provenance` in `candidate.json`
 - optimized candidates also include:
@@ -200,7 +209,9 @@ Manual verification steps for each target:
 - `train` must consume the prepared fold assignments and fail if the prepared context no longer matches the current config or resolved dataset schema
 - the current runtime supports one `experiment.candidate` of type `model` or `blend`
 - model candidates: `experiment.candidate.feature_recipe_id` must resolve to one supported tracked recipe; `identity` is the default path for new competitions
-- model candidates: `experiment.candidate.model_family + experiment.candidate.preprocessor` must resolve to one supported canonical recipe for the configured task
+- model candidates: `experiment.candidate.model_family` must resolve to one supported canonical model for the configured task
+- model candidates: `experiment.candidate.numeric_preprocessor` and `experiment.candidate.categorical_preprocessor` must each resolve to one supported preprocessing component
+- model candidates: `categorical_preprocessor: native` is only valid with `model_family: catboost`
 - blend candidates: `experiment.candidate.base_candidate_ids` must resolve to existing compatible candidate artifacts for the same competition context
 - binary probability blend candidates: all base candidates must share the same saved `positive_label`, `negative_label`, and `observed_label_pair` contract
 - binary accuracy blend candidates: all base candidates must share the same saved label contract and must include the probability-sidecar artifact plus the current probability-average blend rule metadata
@@ -211,7 +222,7 @@ Manual verification steps for each target:
 - enabled optimization is part of `train`, applies to model candidates only, reuses one prepared training context for scoring and retraining, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
 - `submit` must resolve one candidate by `candidate_id`, defaulting to `config.candidate_id`
-- `native_catboost` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
+- `categorical_preprocessor: native` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
 - Binary classification supports any two-class target labels
@@ -245,9 +256,11 @@ Hard-error cases include:
 - Any use of the old flat config layout -> hard error
 - Unsupported `experiment.candidate.candidate_type` -> hard error
 - Unknown `experiment.candidate.feature_recipe_id` for a model candidate -> hard error
-- Invalid configured `experiment.candidate.model_family + preprocessor` combination for a model candidate -> hard error
+- Invalid configured `experiment.candidate.model_family` for the current task -> hard error
+- Invalid configured `experiment.candidate.numeric_preprocessor` or `experiment.candidate.categorical_preprocessor` -> hard error
+- Invalid `categorical_preprocessor: native` with a non-`catboost` model family -> hard error
 - enabled optimization without `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds` -> hard error
-- enabled optimization for an unsupported model candidate combination -> hard error
+- enabled optimization for an unsupported model family -> hard error
 - Missing/invalid competition zip contents -> hard error
 - Missing `competition.json` or `folds.csv` during `train` -> auto-run `prepare`
 - Prepared competition context that no longer matches the current config or resolved dataset schema -> hard error
@@ -288,7 +301,7 @@ Hard-error cases include:
 - New user-facing config keys should be added to the relevant nested config model in `config.py` and documented in both this file and `README.md`.
 - If the user-facing config workflow changes, update `config.binary.example.yaml` and `config.regression.example.yaml` alongside the docs.
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
-- New model families should be introduced in `models.py` with explicit task compatibility, canonical recipe IDs, and matching artifact outputs.
+- New model families should be introduced in `models.py` with explicit task compatibility, capability metadata, and matching artifact outputs.
 - New feature recipes should be added under `src/tabular_shenanigans/feature_recipes/`, registered explicitly, and kept deterministic plus leakage-safe.
 - New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract or the preprocessing-first recipe naming convention.
 - New candidate or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.

--- a/main.py
+++ b/main.py
@@ -61,7 +61,9 @@ def _print_resolved_setup(config: AppConfig) -> None:
         f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
         f"candidate_id={config.candidate_id}, candidate_type=model, "
         f"feature_recipe={config.feature_recipe_id}, model_family={config.model_family}, "
-        f"preprocessor={config.preprocessor}, model_id={config.resolved_model_id}"
+        f"numeric_preprocessor={config.numeric_preprocessor}, "
+        f"categorical_preprocessor={config.categorical_preprocessor}, "
+        f"model_id={config.resolved_model_id}"
     )
 
 
@@ -97,7 +99,9 @@ def _build_train_tracking_tags(config: AppConfig) -> dict[str, object]:
     if config.is_model_candidate:
         tags["model_id"] = config.resolved_model_id
         tags["feature_recipe_id"] = config.feature_recipe_id
-        tags["preprocessor"] = config.preprocessor
+        tags["numeric_preprocessor"] = config.numeric_preprocessor
+        tags["categorical_preprocessor"] = config.categorical_preprocessor
+        tags["preprocessing_scheme_id"] = config.preprocessing_scheme_id
         return tags
 
     tags["base_candidate_count"] = len(config.base_candidate_ids)

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -8,9 +8,17 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from tabular_shenanigans.data import SUPPORTED_PRIMARY_METRICS, is_metric_valid_for_task, normalize_primary_metric
 from tabular_shenanigans.feature_recipes import resolve_feature_recipe_id
 from tabular_shenanigans.models import (
-    get_tunable_candidate_model_specs,
+    get_tunable_model_ids,
     is_model_tunable,
     resolve_candidate_model_id,
+    validate_model_preprocessing_compatibility,
+)
+from tabular_shenanigans.preprocess import (
+    CATEGORICAL_PREPROCESSOR_IDS,
+    LEGACY_PREPROCESSOR_MAPPING,
+    NUMERIC_PREPROCESSOR_IDS,
+    build_preprocessing_scheme_id,
+    resolve_legacy_preprocessor_selection,
 )
 
 
@@ -69,7 +77,9 @@ class ModelCandidateConfig(BaseCandidateConfig):
 
     candidate_type: Literal["model"] = "model"
     feature_recipe_id: str = Field(default="identity", min_length=1)
-    preprocessor: Literal["onehot", "ordinal", "native", "frequency"]
+    preprocessor: str | None = None
+    numeric_preprocessor: str | None = None
+    categorical_preprocessor: str | None = None
     model_family: Literal[
         "ridge",
         "elasticnet",
@@ -90,7 +100,40 @@ class ModelCandidateConfig(BaseCandidateConfig):
             raise ValueError(
                 "The current runtime does not support combining experiment.candidate.model_params "
                 "with enabled experiment.candidate.optimization."
-        )
+            )
+
+        if self.preprocessor is not None:
+            if self.numeric_preprocessor is not None or self.categorical_preprocessor is not None:
+                raise ValueError(
+                    "Configure either experiment.candidate.preprocessor or the split "
+                    "experiment.candidate.numeric_preprocessor + experiment.candidate.categorical_preprocessor, "
+                    "not both."
+                )
+            resolved_numeric_preprocessor, resolved_categorical_preprocessor = resolve_legacy_preprocessor_selection(
+                self.preprocessor
+            )
+            self.numeric_preprocessor = resolved_numeric_preprocessor
+            self.categorical_preprocessor = resolved_categorical_preprocessor
+
+        if self.numeric_preprocessor is None or self.categorical_preprocessor is None:
+            legacy_preprocessor_ids = sorted(LEGACY_PREPROCESSOR_MAPPING)
+            raise ValueError(
+                "Model candidates require experiment.candidate.numeric_preprocessor and "
+                "experiment.candidate.categorical_preprocessor. "
+                f"Legacy experiment.candidate.preprocessor values remain temporarily supported: {legacy_preprocessor_ids}"
+            )
+
+        if self.numeric_preprocessor not in NUMERIC_PREPROCESSOR_IDS:
+            raise ValueError(
+                "Unsupported experiment.candidate.numeric_preprocessor "
+                f"'{self.numeric_preprocessor}'. Supported values: {sorted(NUMERIC_PREPROCESSOR_IDS)}"
+            )
+
+        if self.categorical_preprocessor not in CATEGORICAL_PREPROCESSOR_IDS:
+            raise ValueError(
+                "Unsupported experiment.candidate.categorical_preprocessor "
+                f"'{self.categorical_preprocessor}'. Supported values: {sorted(CATEGORICAL_PREPROCESSOR_IDS)}"
+            )
         return self
 
 
@@ -212,6 +255,11 @@ class AppConfig(BaseModel):
             )
 
             resolved_model_id = self.resolved_model_id
+            validate_model_preprocessing_compatibility(
+                task_type=self.task_type,
+                model_id=resolved_model_id,
+                categorical_preprocessor_id=self.categorical_preprocessor,
+            )
             optimization = self.experiment.candidate.optimization
             if optimization.enabled:
                 if optimization.n_trials is None and optimization.timeout_seconds is None:
@@ -221,13 +269,10 @@ class AppConfig(BaseModel):
                         "experiment.candidate.optimization.timeout_seconds."
                     )
                 if not is_model_tunable(self.task_type, resolved_model_id):
-                    supported_tunable_combinations = [
-                        f"{model_family}+{preprocessor}"
-                        for model_family, preprocessor, _ in get_tunable_candidate_model_specs(self.task_type)
-                    ]
+                    supported_tunable_model_families = get_tunable_model_ids(self.task_type)
                     raise ValueError(
-                        "Configured experiment.candidate does not support optimization for task_type "
-                        f"'{self.task_type}'. Supported tunable combinations: {supported_tunable_combinations}"
+                        f"Configured model_family '{self.model_family}' does not support optimization for task_type "
+                        f"'{self.task_type}'. Supported tunable model families: {supported_tunable_model_families}"
                     )
 
         return self
@@ -313,10 +358,25 @@ class AppConfig(BaseModel):
         return self.experiment.candidate.feature_recipe_id
 
     @property
-    def preprocessor(self) -> str:
+    def numeric_preprocessor(self) -> str:
+        if not self.is_model_candidate or self.experiment.candidate.numeric_preprocessor is None:
+            raise ValueError("numeric_preprocessor is only available for model candidates.")
+        return self.experiment.candidate.numeric_preprocessor
+
+    @property
+    def categorical_preprocessor(self) -> str:
+        if not self.is_model_candidate or self.experiment.candidate.categorical_preprocessor is None:
+            raise ValueError("categorical_preprocessor is only available for model candidates.")
+        return self.experiment.candidate.categorical_preprocessor
+
+    @property
+    def preprocessing_scheme_id(self) -> str:
         if not self.is_model_candidate:
-            raise ValueError("preprocessor is only available for model candidates.")
-        return self.experiment.candidate.preprocessor
+            raise ValueError("preprocessing_scheme_id is only available for model candidates.")
+        return build_preprocessing_scheme_id(
+            numeric_preprocessor_id=self.numeric_preprocessor,
+            categorical_preprocessor_id=self.categorical_preprocessor,
+        )
 
     @property
     def resolved_model_id(self) -> str:
@@ -325,7 +385,6 @@ class AppConfig(BaseModel):
         return resolve_candidate_model_id(
             task_type=self.task_type,
             model_family=self.model_family,
-            preprocessor=self.preprocessor,
         )
 
     @property

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -12,6 +12,7 @@ from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import (
     ResolvedFeatureSchema,
+    build_preprocessing_scheme_id,
     build_preprocessor_from_schema,
     prepare_feature_frames,
     resolve_feature_schema,
@@ -45,6 +46,7 @@ class ModelRunResult:
     def to_fingerprint_entry(self) -> dict[str, object]:
         return {
             "model_id": self.model_id,
+            "preprocessing_scheme_id": self.preprocessing_scheme_id,
             "model_params": self.model_params,
         }
 
@@ -84,6 +86,9 @@ class PreparedTrainingContext:
     observed_label_pair: tuple[object, object] | None
     target_summary: dict[str, object]
     feature_schema: ResolvedFeatureSchema
+    numeric_preprocessor: str
+    categorical_preprocessor: str
+    preprocessing_scheme_id: str
 
 
 def build_prepared_training_context(
@@ -153,6 +158,12 @@ def build_prepared_training_context(
         observed_label_pair=observed_label_pair,
         target_summary=target_summary,
         feature_schema=feature_schema,
+        numeric_preprocessor=config.numeric_preprocessor,
+        categorical_preprocessor=config.categorical_preprocessor,
+        preprocessing_scheme_id=build_preprocessing_scheme_id(
+            numeric_preprocessor_id=config.numeric_preprocessor,
+            categorical_preprocessor_id=config.categorical_preprocessor,
+        ),
     )
 
 
@@ -172,7 +183,7 @@ def _run_cv_evaluation(
     )
     resolved_model_id = model_definition.model_id
     model_name = model_definition.model_name
-    preprocessing_scheme_id = model_definition.preprocessing_scheme_id
+    preprocessing_scheme_id = training_context.preprocessing_scheme_id
 
     oof_predictions = (
         np.zeros(training_context.x_train_features.shape[0], dtype=float)
@@ -193,8 +204,9 @@ def _run_cv_evaluation(
         y_fold_valid = training_context.y_train.iloc[valid_idx]
 
         preprocessor = build_preprocessor_from_schema(
-            scheme_id=preprocessing_scheme_id,
             feature_schema=training_context.feature_schema,
+            numeric_preprocessor_id=training_context.numeric_preprocessor,
+            categorical_preprocessor_id=training_context.categorical_preprocessor,
         )
         if use_named_columns and hasattr(preprocessor, "set_output"):
             preprocessor.set_output(transform="pandas")
@@ -204,7 +216,7 @@ def _run_cv_evaluation(
         if collect_prediction_artifacts:
             x_test_processed = preprocessor.transform(training_context.x_test_features)
 
-        if preprocessing_scheme_id != "native" and not use_named_columns:
+        if training_context.categorical_preprocessor != "native" and not use_named_columns:
             x_fold_train_processed = np.asarray(x_fold_train_processed)
             x_fold_valid_processed = np.asarray(x_fold_valid_processed)
             if x_test_processed is not None:
@@ -221,6 +233,7 @@ def _run_cv_evaluation(
             x_train_processed=x_fold_train_processed,
             numeric_columns=training_context.feature_schema.numeric_columns,
             categorical_columns=training_context.feature_schema.categorical_columns,
+            uses_native_categorical_preprocessing=training_context.categorical_preprocessor == "native",
         )
         model.fit(x_fold_train_processed, y_fold_train, **model_fit_kwargs)
 

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -23,10 +23,10 @@ TuningSpaceBuilder = Callable[[object], dict[str, object]]
 class ModelDefinition:
     model_id: str
     model_name: str
-    preprocessing_scheme_id: str
     builder: ModelBuilder
     fit_kwargs_builder: FitKwargsBuilder | None = None
     tuning_space_builder: TuningSpaceBuilder | None = None
+    supports_native_categorical_preprocessing: bool = False
 
 
 class BinaryLabelEncodingClassifier:
@@ -427,6 +427,8 @@ def _build_catboost_fit_kwargs(
     categorical_columns: list[str],
 ) -> dict[str, object]:
     del numeric_columns
+    if not categorical_columns:
+        return {}
     if not isinstance(x_train_processed, pd.DataFrame):
         raise ValueError("CatBoost native preprocessing must produce a pandas DataFrame.")
     cat_feature_indices = [x_train_processed.columns.get_loc(column) for column in categorical_columns]
@@ -434,234 +436,122 @@ def _build_catboost_fit_kwargs(
 
 
 DEFAULT_MODEL_ID_BY_TASK = {
-    "regression": "onehot_elasticnet",
-    "binary": "onehot_logreg",
+    "regression": "elasticnet",
+    "binary": "logistic_regression",
 }
 
 MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
     "regression": {
-        "onehot_ridge": ModelDefinition(
-            model_id="onehot_ridge",
+        "ridge": ModelDefinition(
+            model_id="ridge",
             model_name="Ridge",
-            preprocessing_scheme_id="onehot",
             builder=_build_ridge,
         ),
-        "onehot_elasticnet": ModelDefinition(
-            model_id="onehot_elasticnet",
+        "elasticnet": ModelDefinition(
+            model_id="elasticnet",
             model_name="ElasticNet",
-            preprocessing_scheme_id="onehot",
             builder=_build_elasticnet,
         ),
-        "ordinal_randomforest": ModelDefinition(
-            model_id="ordinal_randomforest",
+        "random_forest": ModelDefinition(
+            model_id="random_forest",
             model_name="RandomForestRegressor",
-            preprocessing_scheme_id="ordinal",
             builder=_build_random_forest_regressor,
             tuning_space_builder=_build_random_forest_tuning_space,
         ),
-        "ordinal_extratrees": ModelDefinition(
-            model_id="ordinal_extratrees",
+        "extra_trees": ModelDefinition(
+            model_id="extra_trees",
             model_name="ExtraTreesRegressor",
-            preprocessing_scheme_id="ordinal",
             builder=_build_extra_trees_regressor,
             tuning_space_builder=_build_extra_trees_tuning_space,
         ),
-        "ordinal_hgb": ModelDefinition(
-            model_id="ordinal_hgb",
+        "hist_gradient_boosting": ModelDefinition(
+            model_id="hist_gradient_boosting",
             model_name="HistGradientBoostingRegressor",
-            preprocessing_scheme_id="ordinal",
             builder=_build_hist_gradient_boosting_regressor,
             tuning_space_builder=_build_hist_gradient_boosting_tuning_space,
         ),
-        "frequency_hgb": ModelDefinition(
-            model_id="frequency_hgb",
-            model_name="HistGradientBoostingRegressor",
-            preprocessing_scheme_id="frequency",
-            builder=_build_hist_gradient_boosting_regressor,
-            tuning_space_builder=_build_hist_gradient_boosting_tuning_space,
-        ),
-        "ordinal_lightgbm": ModelDefinition(
-            model_id="ordinal_lightgbm",
+        "lightgbm": ModelDefinition(
+            model_id="lightgbm",
             model_name="LGBMRegressor",
-            preprocessing_scheme_id="ordinal",
             builder=_build_lightgbm_regressor,
             tuning_space_builder=_build_lightgbm_tuning_space,
         ),
-        "frequency_lightgbm": ModelDefinition(
-            model_id="frequency_lightgbm",
-            model_name="LGBMRegressor",
-            preprocessing_scheme_id="frequency",
-            builder=_build_lightgbm_regressor,
-            tuning_space_builder=_build_lightgbm_tuning_space,
-        ),
-        "native_catboost": ModelDefinition(
-            model_id="native_catboost",
+        "catboost": ModelDefinition(
+            model_id="catboost",
             model_name="CatBoostRegressor",
-            preprocessing_scheme_id="native",
             builder=_build_catboost_regressor,
             fit_kwargs_builder=_build_catboost_fit_kwargs,
             tuning_space_builder=_build_catboost_tuning_space,
+            supports_native_categorical_preprocessing=True,
         ),
-        "ordinal_xgboost": ModelDefinition(
-            model_id="ordinal_xgboost",
+        "xgboost": ModelDefinition(
+            model_id="xgboost",
             model_name="XGBRegressor",
-            preprocessing_scheme_id="ordinal",
-            builder=_build_xgboost_regressor,
-            tuning_space_builder=_build_xgboost_tuning_space,
-        ),
-        "frequency_xgboost": ModelDefinition(
-            model_id="frequency_xgboost",
-            model_name="XGBRegressor",
-            preprocessing_scheme_id="frequency",
             builder=_build_xgboost_regressor,
             tuning_space_builder=_build_xgboost_tuning_space,
         ),
     },
     "binary": {
-        "onehot_logreg": ModelDefinition(
-            model_id="onehot_logreg",
+        "logistic_regression": ModelDefinition(
+            model_id="logistic_regression",
             model_name="LogisticRegression",
-            preprocessing_scheme_id="onehot",
             builder=_build_logreg,
             tuning_space_builder=_build_logreg_tuning_space,
         ),
-        "ordinal_randomforest": ModelDefinition(
-            model_id="ordinal_randomforest",
+        "random_forest": ModelDefinition(
+            model_id="random_forest",
             model_name="RandomForestClassifier",
-            preprocessing_scheme_id="ordinal",
             builder=_build_random_forest_classifier,
             tuning_space_builder=_build_random_forest_tuning_space,
         ),
-        "ordinal_extratrees": ModelDefinition(
-            model_id="ordinal_extratrees",
+        "extra_trees": ModelDefinition(
+            model_id="extra_trees",
             model_name="ExtraTreesClassifier",
-            preprocessing_scheme_id="ordinal",
             builder=_build_extra_trees_classifier,
             tuning_space_builder=_build_extra_trees_tuning_space,
         ),
-        "ordinal_hgb": ModelDefinition(
-            model_id="ordinal_hgb",
+        "hist_gradient_boosting": ModelDefinition(
+            model_id="hist_gradient_boosting",
             model_name="HistGradientBoostingClassifier",
-            preprocessing_scheme_id="ordinal",
             builder=_build_hist_gradient_boosting_classifier,
             tuning_space_builder=_build_hist_gradient_boosting_tuning_space,
         ),
-        "frequency_hgb": ModelDefinition(
-            model_id="frequency_hgb",
-            model_name="HistGradientBoostingClassifier",
-            preprocessing_scheme_id="frequency",
-            builder=_build_hist_gradient_boosting_classifier,
-            tuning_space_builder=_build_hist_gradient_boosting_tuning_space,
-        ),
-        "ordinal_lightgbm": ModelDefinition(
-            model_id="ordinal_lightgbm",
+        "lightgbm": ModelDefinition(
+            model_id="lightgbm",
             model_name="LGBMClassifier",
-            preprocessing_scheme_id="ordinal",
             builder=_build_lightgbm_classifier,
             tuning_space_builder=_build_lightgbm_tuning_space,
         ),
-        "frequency_lightgbm": ModelDefinition(
-            model_id="frequency_lightgbm",
-            model_name="LGBMClassifier",
-            preprocessing_scheme_id="frequency",
-            builder=_build_lightgbm_classifier,
-            tuning_space_builder=_build_lightgbm_tuning_space,
-        ),
-        "native_catboost": ModelDefinition(
-            model_id="native_catboost",
+        "catboost": ModelDefinition(
+            model_id="catboost",
             model_name="CatBoostClassifier",
-            preprocessing_scheme_id="native",
             builder=_build_catboost_classifier,
             fit_kwargs_builder=_build_catboost_fit_kwargs,
             tuning_space_builder=_build_catboost_tuning_space,
+            supports_native_categorical_preprocessing=True,
         ),
-        "ordinal_xgboost": ModelDefinition(
-            model_id="ordinal_xgboost",
+        "xgboost": ModelDefinition(
+            model_id="xgboost",
             model_name="XGBClassifier",
-            preprocessing_scheme_id="ordinal",
-            builder=_build_xgboost_classifier,
-            tuning_space_builder=_build_xgboost_tuning_space,
-        ),
-        "frequency_xgboost": ModelDefinition(
-            model_id="frequency_xgboost",
-            model_name="XGBClassifier",
-            preprocessing_scheme_id="frequency",
             builder=_build_xgboost_classifier,
             tuning_space_builder=_build_xgboost_tuning_space,
         ),
     },
 }
-
-
-CANDIDATE_MODEL_REGISTRY: dict[str, dict[tuple[str, str], str]] = {
-    "regression": {
-        ("ridge", "onehot"): "onehot_ridge",
-        ("elasticnet", "onehot"): "onehot_elasticnet",
-        ("random_forest", "ordinal"): "ordinal_randomforest",
-        ("extra_trees", "ordinal"): "ordinal_extratrees",
-        ("hist_gradient_boosting", "ordinal"): "ordinal_hgb",
-        ("hist_gradient_boosting", "frequency"): "frequency_hgb",
-        ("lightgbm", "ordinal"): "ordinal_lightgbm",
-        ("lightgbm", "frequency"): "frequency_lightgbm",
-        ("catboost", "native"): "native_catboost",
-        ("xgboost", "ordinal"): "ordinal_xgboost",
-        ("xgboost", "frequency"): "frequency_xgboost",
-    },
-    "binary": {
-        ("logistic_regression", "onehot"): "onehot_logreg",
-        ("random_forest", "ordinal"): "ordinal_randomforest",
-        ("extra_trees", "ordinal"): "ordinal_extratrees",
-        ("hist_gradient_boosting", "ordinal"): "ordinal_hgb",
-        ("hist_gradient_boosting", "frequency"): "frequency_hgb",
-        ("lightgbm", "ordinal"): "ordinal_lightgbm",
-        ("lightgbm", "frequency"): "frequency_lightgbm",
-        ("catboost", "native"): "native_catboost",
-        ("xgboost", "ordinal"): "ordinal_xgboost",
-        ("xgboost", "frequency"): "frequency_xgboost",
-    },
-}
-
-
-def _get_task_candidate_model_registry(task_type: str) -> dict[tuple[str, str], str]:
-    try:
-        return CANDIDATE_MODEL_REGISTRY[task_type]
-    except KeyError as exc:
-        raise ValueError(f"Unsupported task_type for candidate model selection: {task_type}") from exc
-
-
-def get_supported_candidate_model_specs(task_type: str) -> list[tuple[str, str, str]]:
-    task_registry = _get_task_candidate_model_registry(task_type)
-    return sorted(
-        (model_family, preprocessor, model_id)
-        for (model_family, preprocessor), model_id in task_registry.items()
-    )
-
-
-def get_tunable_candidate_model_specs(task_type: str) -> list[tuple[str, str, str]]:
-    return sorted(
-        (model_family, preprocessor, model_id)
-        for model_family, preprocessor, model_id in get_supported_candidate_model_specs(task_type)
-        if is_model_tunable(task_type, model_id)
-    )
 
 
 def resolve_candidate_model_id(
     task_type: str,
     model_family: str,
-    preprocessor: str,
 ) -> str:
-    task_registry = _get_task_candidate_model_registry(task_type)
-    candidate_key = (model_family, preprocessor)
-    if candidate_key in task_registry:
-        return resolve_model_id(task_type, task_registry[candidate_key])
+    task_registry = _get_task_model_registry(task_type)
+    if model_family in task_registry:
+        return model_family
 
-    supported_combinations = [
-        f"{supported_model_family}+{supported_preprocessor}"
-        for supported_model_family, supported_preprocessor, _ in get_supported_candidate_model_specs(task_type)
-    ]
+    supported_model_families = sorted(task_registry)
     raise ValueError(
-        f"Candidate model_family '{model_family}' with preprocessor '{preprocessor}' is not valid for task_type "
-        f"'{task_type}'. Supported combinations: {supported_combinations}"
+        f"Candidate model_family '{model_family}' is not valid for task_type '{task_type}'. "
+        f"Supported model families: {supported_model_families}"
     )
 
 
@@ -689,6 +579,22 @@ def get_tunable_model_ids(task_type: str) -> list[str]:
         model_id
         for model_id, model_definition in task_registry.items()
         if model_definition.tuning_space_builder is not None
+    )
+
+
+def validate_model_preprocessing_compatibility(
+    task_type: str,
+    model_id: str,
+    categorical_preprocessor_id: str,
+) -> None:
+    model_definition = get_model_definition(task_type, model_id)
+    if categorical_preprocessor_id != "native":
+        return
+    if model_definition.supports_native_categorical_preprocessing:
+        return
+    raise ValueError(
+        f"Model family '{model_definition.model_id}' does not support "
+        "categorical_preprocessor='native'. Use model_family='catboost' for native categorical handling."
     )
 
 
@@ -749,7 +655,8 @@ def build_model_fit_kwargs(
     x_train_processed: object,
     numeric_columns: list[str],
     categorical_columns: list[str],
+    uses_native_categorical_preprocessing: bool,
 ) -> dict[str, object]:
-    if model_definition.fit_kwargs_builder is None:
+    if model_definition.fit_kwargs_builder is None or not uses_native_categorical_preprocessing:
         return {}
     return model_definition.fit_kwargs_builder(x_train_processed, numeric_columns, categorical_columns)

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -6,16 +6,40 @@ import pandas as pd
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer, OneHotEncoder, OrdinalEncoder, StandardScaler
+from sklearn.preprocessing import (
+    FunctionTransformer,
+    KBinsDiscretizer,
+    OneHotEncoder,
+    OrdinalEncoder,
+    StandardScaler,
+)
 
-PreprocessorBuilder = Callable[[list[str], list[str], list[str]], object]
+NumericPreprocessorBuilder = Callable[[], object]
+CategoricalPreprocessorBuilder = Callable[[], object]
+
+LEGACY_PREPROCESSOR_MAPPING = {
+    "onehot": ("standardize", "onehot"),
+    "ordinal": ("median", "ordinal"),
+    "frequency": ("median", "frequency"),
+    "native": ("median", "native"),
+}
+NUMERIC_PREPROCESSOR_IDS = tuple(["median", "standardize", "kbins"])
+CATEGORICAL_PREPROCESSOR_IDS = tuple(["onehot", "ordinal", "frequency", "native"])
 
 
 @dataclass(frozen=True)
-class PreprocessingDefinition:
+class NumericPreprocessingDefinition:
     scheme_id: str
     scheme_name: str
-    builder: PreprocessorBuilder
+    builder: NumericPreprocessorBuilder
+
+
+@dataclass(frozen=True)
+class CategoricalPreprocessingDefinition:
+    scheme_id: str
+    scheme_name: str
+    compose_mode: str
+    builder: CategoricalPreprocessorBuilder | None = None
 
 
 @dataclass(frozen=True)
@@ -99,6 +123,45 @@ def resolve_feature_schema(
     )
 
 
+def resolve_legacy_preprocessor_selection(preprocessor_id: str) -> tuple[str, str]:
+    try:
+        return LEGACY_PREPROCESSOR_MAPPING[preprocessor_id]
+    except KeyError as exc:
+        supported_preprocessor_ids = sorted(LEGACY_PREPROCESSOR_MAPPING)
+        raise ValueError(
+            f"Unsupported preprocessing scheme '{preprocessor_id}'. Supported values: {supported_preprocessor_ids}"
+        ) from exc
+
+
+def build_preprocessing_scheme_id(
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+) -> str:
+    return f"num_{numeric_preprocessor_id}__cat_{categorical_preprocessor_id}"
+
+
+def categorical_preprocessor_uses_native_columns(categorical_preprocessor_id: str) -> bool:
+    return categorical_preprocessor_id == "native"
+
+
+def _ensure_dense_array(values: object) -> np.ndarray:
+    if hasattr(values, "toarray"):
+        return values.toarray()
+    return np.asarray(values)
+
+
+def _resolve_transformed_numeric_columns(
+    numeric_preprocessor: object,
+    numeric_columns: list[str],
+) -> list[str]:
+    if not numeric_columns:
+        return []
+    if hasattr(numeric_preprocessor, "get_feature_names_out"):
+        feature_names = numeric_preprocessor.get_feature_names_out(numeric_columns)
+        return [str(feature_name) for feature_name in feature_names]
+    return list(numeric_columns)
+
+
 class NativeFramePreprocessor:
     CATEGORICAL_MISSING_VALUE = "__missing__"
 
@@ -107,42 +170,48 @@ class NativeFramePreprocessor:
         feature_columns: list[str],
         numeric_columns: list[str],
         categorical_columns: list[str],
+        numeric_preprocessor: object,
     ) -> None:
         self.feature_columns = feature_columns
         self.numeric_columns = numeric_columns
         self.categorical_columns = categorical_columns
-        self.numeric_fill_values: pd.Series | None = None
+        self.numeric_preprocessor = numeric_preprocessor
+        self.transformed_numeric_columns: list[str] = list(numeric_columns)
 
     def fit(self, frame: pd.DataFrame) -> "NativeFramePreprocessor":
         if self.numeric_columns:
-            self.numeric_fill_values = frame.loc[:, self.numeric_columns].median()
-        else:
-            self.numeric_fill_values = pd.Series(dtype=float)
+            self.numeric_preprocessor.fit(frame.loc[:, self.numeric_columns])
+            self.transformed_numeric_columns = _resolve_transformed_numeric_columns(
+                self.numeric_preprocessor,
+                self.numeric_columns,
+            )
         return self
 
-    def transform(self, frame: pd.DataFrame) -> pd.DataFrame:
-        transformed_frame = frame.loc[:, self.feature_columns].copy()
+    def _transform_numeric_frame(self, frame: pd.DataFrame) -> pd.DataFrame:
+        if not self.numeric_columns:
+            return pd.DataFrame(index=frame.index)
+        transformed_values = self.numeric_preprocessor.transform(frame.loc[:, self.numeric_columns])
+        return pd.DataFrame(
+            _ensure_dense_array(transformed_values),
+            index=frame.index,
+            columns=self.transformed_numeric_columns,
+        )
 
-        if self.numeric_columns:
-            transformed_frame.loc[:, self.numeric_columns] = transformed_frame.loc[:, self.numeric_columns].fillna(
-                self.numeric_fill_values
-            )
+    def transform(self, frame: pd.DataFrame) -> pd.DataFrame:
+        transformed_frames: list[pd.DataFrame] = [self._transform_numeric_frame(frame)]
 
         if self.categorical_columns:
-            transformed_frame = transformed_frame.astype(
-                {column: object for column in self.categorical_columns},
-                copy=False,
-            )
-            categorical_frame = transformed_frame.loc[:, self.categorical_columns].astype(object)
+            categorical_frame = frame.loc[:, self.categorical_columns].astype(object)
             categorical_frame = categorical_frame.where(
                 categorical_frame.notna(),
                 self.CATEGORICAL_MISSING_VALUE,
             )
-            categorical_frame = categorical_frame.astype(str)
-            for column in self.categorical_columns:
-                transformed_frame.loc[:, column] = categorical_frame.loc[:, column]
+            transformed_frames.append(categorical_frame.astype(str))
 
-        return transformed_frame
+        populated_frames = [transformed_frame for transformed_frame in transformed_frames if not transformed_frame.empty]
+        if not populated_frames:
+            return pd.DataFrame(index=frame.index)
+        return pd.concat(populated_frames, axis=1)
 
     def fit_transform(self, frame: pd.DataFrame) -> pd.DataFrame:
         return self.fit(frame).transform(frame)
@@ -156,24 +225,26 @@ class FrequencyFramePreprocessor:
         feature_columns: list[str],
         numeric_columns: list[str],
         categorical_columns: list[str],
+        numeric_preprocessor: object,
     ) -> None:
         self.feature_columns = feature_columns
         self.numeric_columns = numeric_columns
         self.categorical_columns = categorical_columns
-        self.numeric_fill_values: pd.Series | None = None
+        self.numeric_preprocessor = numeric_preprocessor
+        self.transformed_numeric_columns: list[str] = list(numeric_columns)
         self.category_frequencies: dict[str, dict[str, float]] = {}
 
     def fit(self, frame: pd.DataFrame) -> "FrequencyFramePreprocessor":
-        training_frame = frame.loc[:, self.feature_columns]
-
         if self.numeric_columns:
-            self.numeric_fill_values = training_frame.loc[:, self.numeric_columns].median()
-        else:
-            self.numeric_fill_values = pd.Series(dtype=float)
+            self.numeric_preprocessor.fit(frame.loc[:, self.numeric_columns])
+            self.transformed_numeric_columns = _resolve_transformed_numeric_columns(
+                self.numeric_preprocessor,
+                self.numeric_columns,
+            )
 
         for column in self.categorical_columns:
             normalized_series = _normalize_categorical_series(
-                training_frame[column],
+                frame[column],
                 missing_value=self.CATEGORICAL_MISSING_VALUE,
             )
             value_frequencies = normalized_series.value_counts(normalize=True, dropna=False)
@@ -184,29 +255,35 @@ class FrequencyFramePreprocessor:
 
         return self
 
+    def _transform_numeric_frame(self, frame: pd.DataFrame) -> pd.DataFrame:
+        if not self.numeric_columns:
+            return pd.DataFrame(index=frame.index)
+        transformed_values = self.numeric_preprocessor.transform(frame.loc[:, self.numeric_columns])
+        return pd.DataFrame(
+            _ensure_dense_array(transformed_values),
+            index=frame.index,
+            columns=self.transformed_numeric_columns,
+        )
+
     def transform(self, frame: pd.DataFrame) -> pd.DataFrame:
-        transformed_frame = frame.loc[:, self.feature_columns].copy()
+        transformed_frames: list[pd.DataFrame] = [self._transform_numeric_frame(frame)]
 
-        if self.numeric_columns:
-            transformed_frame.loc[:, self.numeric_columns] = transformed_frame.loc[:, self.numeric_columns].fillna(
-                self.numeric_fill_values
-            )
+        if self.categorical_columns:
+            encoded_categorical_columns: dict[str, pd.Series] = {}
+            for column in self.categorical_columns:
+                normalized_series = _normalize_categorical_series(
+                    frame[column],
+                    missing_value=self.CATEGORICAL_MISSING_VALUE,
+                )
+                encoded_categorical_columns[column] = normalized_series.map(
+                    self.category_frequencies[column]
+                ).fillna(0.0)
+            transformed_frames.append(pd.DataFrame(encoded_categorical_columns, index=frame.index).astype(float))
 
-        encoded_categorical_columns: dict[str, pd.Series] = {}
-        for column in self.categorical_columns:
-            normalized_series = _normalize_categorical_series(
-                transformed_frame[column],
-                missing_value=self.CATEGORICAL_MISSING_VALUE,
-            )
-            encoded_categorical_columns[column] = normalized_series.map(self.category_frequencies[column]).fillna(0.0)
-
-        if encoded_categorical_columns:
-            transformed_frame = transformed_frame.drop(columns=self.categorical_columns)
-            encoded_categorical_frame = pd.DataFrame(encoded_categorical_columns, index=frame.index).astype(float)
-            transformed_frame = transformed_frame.join(encoded_categorical_frame)
-            transformed_frame = transformed_frame.loc[:, self.feature_columns]
-
-        return transformed_frame
+        populated_frames = [transformed_frame for transformed_frame in transformed_frames if not transformed_frame.empty]
+        if not populated_frames:
+            return pd.DataFrame(index=frame.index)
+        return pd.concat(populated_frames, axis=1)
 
     def fit_transform(self, frame: pd.DataFrame) -> pd.DataFrame:
         return self.fit(frame).transform(frame)
@@ -229,9 +306,7 @@ def prepare_feature_frames(
     _validate_column_names("drop_columns", drop_columns, available_feature_columns)
 
     excluded_feature_columns = [id_column]
-    excluded_feature_columns.extend(
-        column for column in drop_columns if column != id_column
-    )
+    excluded_feature_columns.extend(column for column in drop_columns if column != id_column)
 
     x_train_raw = train_df.drop(columns=[label_column, *excluded_feature_columns])
     y_train = train_df[label_column]
@@ -247,20 +322,38 @@ def prepare_feature_frames(
     return x_train_raw, x_test_raw, y_train
 
 
-def _build_linear_onehot_preprocessor(
-    feature_columns: list[str],
-    numeric_columns: list[str],
-    categorical_columns: list[str],
-) -> ColumnTransformer:
-    del feature_columns
-    numeric_pipeline = Pipeline(
+def _build_numeric_median_preprocessor() -> object:
+    return SimpleImputer(strategy="median")
+
+
+def _build_numeric_standardize_preprocessor() -> object:
+    return Pipeline(
         steps=[
             ("imputer", SimpleImputer(strategy="median")),
             ("scaler", StandardScaler()),
         ]
     )
 
-    categorical_pipeline = Pipeline(
+
+def _build_numeric_kbins_preprocessor() -> object:
+    return Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            (
+                "kbins",
+                KBinsDiscretizer(
+                    n_bins=5,
+                    encode="onehot-dense",
+                    strategy="quantile",
+                    quantile_method="averaged_inverted_cdf",
+                ),
+            ),
+        ]
+    )
+
+
+def _build_categorical_onehot_preprocessor() -> object:
+    return Pipeline(
         steps=[
             ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
             ("imputer", SimpleImputer(strategy="most_frequent")),
@@ -268,27 +361,9 @@ def _build_linear_onehot_preprocessor(
         ]
     )
 
-    transformers = []
-    if numeric_columns:
-        transformers.append(("num", numeric_pipeline, numeric_columns))
-    if categorical_columns:
-        transformers.append(("cat", categorical_pipeline, categorical_columns))
-    return ColumnTransformer(transformers=transformers, remainder="drop")
 
-
-def _build_ordinal_preprocessor(
-    feature_columns: list[str],
-    numeric_columns: list[str],
-    categorical_columns: list[str],
-) -> ColumnTransformer:
-    del feature_columns
-    numeric_pipeline = Pipeline(
-        steps=[
-            ("imputer", SimpleImputer(strategy="median")),
-        ]
-    )
-
-    categorical_pipeline = Pipeline(
+def _build_categorical_ordinal_preprocessor() -> object:
+    return Pipeline(
         steps=[
             ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
             ("imputer", SimpleImputer(strategy="most_frequent")),
@@ -303,75 +378,88 @@ def _build_ordinal_preprocessor(
         ]
     )
 
-    transformers = []
-    if numeric_columns:
-        transformers.append(("num", numeric_pipeline, numeric_columns))
-    if categorical_columns:
-        transformers.append(("cat", categorical_pipeline, categorical_columns))
-    return ColumnTransformer(transformers=transformers, remainder="drop")
 
+NUMERIC_PREPROCESSING_REGISTRY = {
+    "median": NumericPreprocessingDefinition(
+        scheme_id="median",
+        scheme_name="MedianImpute",
+        builder=_build_numeric_median_preprocessor,
+    ),
+    "standardize": NumericPreprocessingDefinition(
+        scheme_id="standardize",
+        scheme_name="MedianImputeStandardize",
+        builder=_build_numeric_standardize_preprocessor,
+    ),
+    "kbins": NumericPreprocessingDefinition(
+        scheme_id="kbins",
+        scheme_name="MedianImputeKBins",
+        builder=_build_numeric_kbins_preprocessor,
+    ),
+}
 
-def _build_native_preprocessor(
-    feature_columns: list[str],
-    numeric_columns: list[str],
-    categorical_columns: list[str],
-) -> NativeFramePreprocessor:
-    return NativeFramePreprocessor(
-        feature_columns=feature_columns,
-        numeric_columns=numeric_columns,
-        categorical_columns=categorical_columns,
-    )
-
-
-def _build_frequency_preprocessor(
-    feature_columns: list[str],
-    numeric_columns: list[str],
-    categorical_columns: list[str],
-) -> FrequencyFramePreprocessor:
-    return FrequencyFramePreprocessor(
-        feature_columns=feature_columns,
-        numeric_columns=numeric_columns,
-        categorical_columns=categorical_columns,
-    )
-
-
-PREPROCESSING_REGISTRY = {
-    "onehot": PreprocessingDefinition(
+CATEGORICAL_PREPROCESSING_REGISTRY = {
+    "onehot": CategoricalPreprocessingDefinition(
         scheme_id="onehot",
-        scheme_name="OneHotLinear",
-        builder=_build_linear_onehot_preprocessor,
+        scheme_name="OneHotCategorical",
+        compose_mode="column_transformer",
+        builder=_build_categorical_onehot_preprocessor,
     ),
-    "ordinal": PreprocessingDefinition(
+    "ordinal": CategoricalPreprocessingDefinition(
         scheme_id="ordinal",
-        scheme_name="OrdinalTree",
-        builder=_build_ordinal_preprocessor,
+        scheme_name="OrdinalCategorical",
+        compose_mode="column_transformer",
+        builder=_build_categorical_ordinal_preprocessor,
     ),
-    "native": PreprocessingDefinition(
-        scheme_id="native",
-        scheme_name="NativeFrame",
-        builder=_build_native_preprocessor,
-    ),
-    "frequency": PreprocessingDefinition(
+    "frequency": CategoricalPreprocessingDefinition(
         scheme_id="frequency",
-        scheme_name="FrequencyEncoded",
-        builder=_build_frequency_preprocessor,
+        scheme_name="FrequencyCategorical",
+        compose_mode="frequency_frame",
+    ),
+    "native": CategoricalPreprocessingDefinition(
+        scheme_id="native",
+        scheme_name="NativeCategorical",
+        compose_mode="native_frame",
     ),
 }
 
 
-def get_preprocessing_definition(scheme_id: str) -> PreprocessingDefinition:
+def get_numeric_preprocessing_definition(scheme_id: str) -> NumericPreprocessingDefinition:
     try:
-        return PREPROCESSING_REGISTRY[scheme_id]
+        return NUMERIC_PREPROCESSING_REGISTRY[scheme_id]
     except KeyError as exc:
-        supported_scheme_ids = sorted(PREPROCESSING_REGISTRY)
+        supported_scheme_ids = sorted(NUMERIC_PREPROCESSING_REGISTRY)
         raise ValueError(
-            f"Unsupported preprocessing scheme '{scheme_id}'. Supported values: {supported_scheme_ids}"
+            f"Unsupported numeric_preprocessor '{scheme_id}'. Supported values: {supported_scheme_ids}"
         ) from exc
 
 
+def get_categorical_preprocessing_definition(scheme_id: str) -> CategoricalPreprocessingDefinition:
+    try:
+        return CATEGORICAL_PREPROCESSING_REGISTRY[scheme_id]
+    except KeyError as exc:
+        supported_scheme_ids = sorted(CATEGORICAL_PREPROCESSING_REGISTRY)
+        raise ValueError(
+            f"Unsupported categorical_preprocessor '{scheme_id}'. Supported values: {supported_scheme_ids}"
+        ) from exc
+
+
+def _build_column_transformer_preprocessor(
+    feature_schema: ResolvedFeatureSchema,
+    numeric_preprocessor: object,
+    categorical_preprocessor: object,
+) -> ColumnTransformer:
+    transformers = []
+    if feature_schema.numeric_columns:
+        transformers.append(("num", numeric_preprocessor, feature_schema.numeric_columns))
+    if feature_schema.categorical_columns:
+        transformers.append(("cat", categorical_preprocessor, feature_schema.categorical_columns))
+    return ColumnTransformer(transformers=transformers, remainder="drop")
+
+
 def build_preprocessor(
-    scheme_id: str,
     x_train_raw: pd.DataFrame,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
     force_categorical: list[str] | None = None,
     force_numeric: list[str] | None = None,
     low_cardinality_int_threshold: int | None = None,
@@ -383,29 +471,54 @@ def build_preprocessor(
         low_cardinality_int_threshold=low_cardinality_int_threshold,
     )
     preprocessor = build_preprocessor_from_schema(
-        scheme_id=scheme_id,
         feature_schema=feature_schema,
+        numeric_preprocessor_id=numeric_preprocessor_id,
+        categorical_preprocessor_id=categorical_preprocessor_id,
     )
-    return (
-        preprocessor,
-        feature_schema.numeric_columns,
-        feature_schema.categorical_columns,
-    )
+    return preprocessor, feature_schema.numeric_columns, feature_schema.categorical_columns
+
 
 def build_preprocessor_from_schema(
-    scheme_id: str,
     feature_schema: ResolvedFeatureSchema,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
 ) -> object:
     if not feature_schema.numeric_columns and not feature_schema.categorical_columns:
         raise ValueError("No modeled features remain after excluding id_column and applying drop_columns.")
 
-    preprocessing_definition = get_preprocessing_definition(scheme_id)
-    preprocessor = preprocessing_definition.builder(
-        feature_schema.feature_columns,
-        feature_schema.numeric_columns,
-        feature_schema.categorical_columns,
+    numeric_definition = get_numeric_preprocessing_definition(numeric_preprocessor_id)
+    categorical_definition = get_categorical_preprocessing_definition(categorical_preprocessor_id)
+    numeric_preprocessor = numeric_definition.builder()
+
+    if categorical_definition.compose_mode == "column_transformer":
+        if categorical_definition.builder is None:
+            raise RuntimeError("column_transformer categorical preprocessing requires a builder.")
+        return _build_column_transformer_preprocessor(
+            feature_schema=feature_schema,
+            numeric_preprocessor=numeric_preprocessor,
+            categorical_preprocessor=categorical_definition.builder(),
+        )
+
+    if categorical_definition.compose_mode == "frequency_frame":
+        return FrequencyFramePreprocessor(
+            feature_columns=feature_schema.feature_columns,
+            numeric_columns=feature_schema.numeric_columns,
+            categorical_columns=feature_schema.categorical_columns,
+            numeric_preprocessor=numeric_preprocessor,
+        )
+
+    if categorical_definition.compose_mode == "native_frame":
+        return NativeFramePreprocessor(
+            feature_columns=feature_schema.feature_columns,
+            numeric_columns=feature_schema.numeric_columns,
+            categorical_columns=feature_schema.categorical_columns,
+            numeric_preprocessor=numeric_preprocessor,
+        )
+
+    raise ValueError(
+        "Unsupported categorical preprocessing compose mode: "
+        f"{categorical_definition.compose_mode!r}"
     )
-    return preprocessor
 
 
 def summarize_feature_types(

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -57,6 +57,9 @@ def _build_config_snapshot(
         label_column=label_column,
     )
     config_snapshot["resolved_model_id"] = model_spec.model_id
+    config_snapshot["resolved_numeric_preprocessor"] = config.numeric_preprocessor
+    config_snapshot["resolved_categorical_preprocessor"] = config.categorical_preprocessor
+    config_snapshot["resolved_preprocessing_scheme_id"] = config.preprocessing_scheme_id
     if model_spec.parameter_overrides:
         config_snapshot["resolved_model_parameter_overrides"] = model_spec.parameter_overrides
     if tuning_provenance is not None:
@@ -98,7 +101,8 @@ def _build_candidate_manifest(
         "model_family": config.model_family,
         "feature_recipe_id": config.feature_recipe_id,
         "feature_columns": training_context.x_train_features.columns.tolist(),
-        "preprocessor": config.preprocessor,
+        "numeric_preprocessor": config.numeric_preprocessor,
+        "categorical_preprocessor": config.categorical_preprocessor,
         "model_id": model_result.model_id,
         "model_name": model_result.model_name,
         "preprocessing_scheme_id": model_result.preprocessing_scheme_id,

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -44,6 +44,9 @@ def _build_optimization_config_snapshot(
         label_column=training_context.label_column,
     )
     config_snapshot["resolved_model_id"] = tuning_model_spec.model_id
+    config_snapshot["resolved_numeric_preprocessor"] = training_context.numeric_preprocessor
+    config_snapshot["resolved_categorical_preprocessor"] = training_context.categorical_preprocessor
+    config_snapshot["resolved_preprocessing_scheme_id"] = training_context.preprocessing_scheme_id
     return config_snapshot
 
 
@@ -192,7 +195,7 @@ def run_optimization(
         optimization_config_snapshot=optimization_config_snapshot,
         tuning_model_spec=tuning_model_spec,
         model_name=model_definition.model_name,
-        preprocessing_scheme_id=model_definition.preprocessing_scheme_id,
+        preprocessing_scheme_id=training_context.preprocessing_scheme_id,
         target_summary=training_context.target_summary,
         best_parameter_overrides=best_parameter_overrides,
     )


### PR DESCRIPTION
Closes #98
Closes #114

## Summary
- split model preprocessing into numeric and categorical selections with a temporary legacy `preprocessor` mapping
- add dense KBins numeric preprocessing and compose preprocessing from shared numeric/categorical components
- replace the exact model whitelist with task-scoped model families plus a small hard-invalid native-categorical blacklist
- record resolved preprocessing selections explicitly in candidate and optimization artifacts
- update examples and docs to describe the split preprocessing contract

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/preprocess.py src/tabular_shenanigans/models.py src/tabular_shenanigans/config.py src/tabular_shenanigans/model_evaluation.py src/tabular_shenanigans/train.py src/tabular_shenanigans/tune.py`
- synthetic local verification in a disposable temp directory using the repo `.venv`:
  - binary logistic baseline with `standardize + onehot` trained successfully and wrote candidate artifacts
  - binary logistic with `kbins + onehot` trained successfully and wrote candidate artifacts
  - optimization-enabled binary logistic with `kbins + onehot` completed 2 Optuna trials and wrote optimization artifacts
  - regression elasticnet with `standardize + onehot` trained successfully and wrote candidate artifacts
  - legacy `preprocessor: onehot` resolved to `standardize + onehot`
  - invalid `categorical_preprocessor: native` with `model_family: logistic_regression` failed fast during config validation