### PR TITLE
Remove legacy preprocessor shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Current `experiment.candidate` contract:
     - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
   - `numeric_preprocessor`: `median`, `standardize`, or `kbins`
   - `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
-  - temporary legacy shim: `preprocessor` maps to one baseline-equivalent split pair when the split fields are omitted
   - optional `model_params`
   - optional `optimization`:
     - `enabled`
@@ -163,12 +162,6 @@ Current model-family support by task:
 
 Current hard-invalid preprocessing combinations:
 - `categorical_preprocessor: native` with any `model_family` other than `catboost`
-
-Recommended baseline mappings from the older single-field configs:
-- `onehot` -> `numeric_preprocessor: standardize`, `categorical_preprocessor: onehot`
-- `ordinal` -> `numeric_preprocessor: median`, `categorical_preprocessor: ordinal`
-- `frequency` -> `numeric_preprocessor: median`, `categorical_preprocessor: frequency`
-- `native` -> `numeric_preprocessor: median`, `categorical_preprocessor: native`
 
 Built-in `feature_recipe_id` values for model candidates:
 - `identity`: default pass-through recipe for new competitions

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -50,7 +50,7 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/feature_recipes/*`: deterministic experiment-scoped feature transforms, including the `identity` default and tracked competition-specific recipe modules.
 - `src/tabular_shenanigans/model_evaluation.py`: shared prepared training-context construction, reusable CV scoring and prediction generation, resolved feature-schema reuse, and model evaluation contracts consumed by both `train` and `tune`.
 - `src/tabular_shenanigans/models.py`: task-scoped model-family registry, capability-based compatibility checks, tunable-model search spaces, optional booster loading, and estimator construction for supported model families.
-- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, resolved feature-schema inference, split numeric/categorical preprocessing components, legacy preprocessor mapping, and native-frame support for CatBoost.
+- `src/tabular_shenanigans/preprocess.py`: feature frame preparation, resolved feature-schema inference, split numeric/categorical preprocessing components, and native-frame support for CatBoost.
 - `src/tabular_shenanigans/cv.py`: task-aware CV splitters and metric scoring helpers.
 - `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact compatibility checks, weighted prediction combination, blend-specific manifest fields, and `blend_summary.csv` writing on top of the shared candidate-artifact layer.
 - `src/tabular_shenanigans/train.py`: config-selected model training orchestration, candidate artifact writing, model-specific manifest fields, and optimization-aware workflow control on top of the shared candidate-artifact and model-evaluation layers.
@@ -100,7 +100,6 @@ Input:
       - binary classification: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
     - `numeric_preprocessor` (`median`, `standardize`, or `kbins`)
     - `categorical_preprocessor` (`onehot`, `ordinal`, `frequency`, or `native`)
-    - temporary legacy shim: `preprocessor` resolves to one baseline-equivalent split pair when the split fields are omitted
     - optional `model_params`
     - optional `optimization`:
       - `enabled` (boolean, default false)
@@ -132,7 +131,6 @@ The current runtime resolves `experiment.candidate.feature_recipe_id` to one tra
 Model candidates configure preprocessing with split selectors:
 - `numeric_preprocessor`: `median`, `standardize`, or `kbins`
 - `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
-- legacy `experiment.candidate.preprocessor` remains as a temporary migration shim and resolves to one of the supported split pairs
 The current runtime resolves `experiment.candidate.model_family` to one internal canonical `model_id` for model candidates, and records `preprocessing_scheme_id` separately from the model ID.
 Blend candidates consume compatible existing candidate artifacts and materialize a synthetic `blend_weighted_average` artifact model ID.
 optimization requires at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`.

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -15,10 +15,8 @@ from tabular_shenanigans.models import (
 )
 from tabular_shenanigans.preprocess import (
     CATEGORICAL_PREPROCESSOR_IDS,
-    LEGACY_PREPROCESSOR_MAPPING,
     NUMERIC_PREPROCESSOR_IDS,
     build_preprocessing_scheme_id,
-    resolve_legacy_preprocessor_selection,
 )
 
 
@@ -77,7 +75,6 @@ class ModelCandidateConfig(BaseCandidateConfig):
 
     candidate_type: Literal["model"] = "model"
     feature_recipe_id: str = Field(default="identity", min_length=1)
-    preprocessor: str | None = None
     numeric_preprocessor: str | None = None
     categorical_preprocessor: str | None = None
     model_family: Literal[
@@ -94,6 +91,17 @@ class ModelCandidateConfig(BaseCandidateConfig):
     model_params: dict[str, object] = Field(default_factory=dict)
     optimization: CandidateOptimizationConfig = Field(default_factory=CandidateOptimizationConfig)
 
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_preprocessor(cls, values: object) -> object:
+        if isinstance(values, dict) and "preprocessor" in values:
+            raise ValueError(
+                "experiment.candidate.preprocessor is no longer supported. "
+                "Use experiment.candidate.numeric_preprocessor and "
+                "experiment.candidate.categorical_preprocessor."
+            )
+        return values
+
     @model_validator(mode="after")
     def validate_model_candidate(self) -> "ModelCandidateConfig":
         if self.model_params and self.optimization.enabled:
@@ -102,25 +110,10 @@ class ModelCandidateConfig(BaseCandidateConfig):
                 "with enabled experiment.candidate.optimization."
             )
 
-        if self.preprocessor is not None:
-            if self.numeric_preprocessor is not None or self.categorical_preprocessor is not None:
-                raise ValueError(
-                    "Configure either experiment.candidate.preprocessor or the split "
-                    "experiment.candidate.numeric_preprocessor + experiment.candidate.categorical_preprocessor, "
-                    "not both."
-                )
-            resolved_numeric_preprocessor, resolved_categorical_preprocessor = resolve_legacy_preprocessor_selection(
-                self.preprocessor
-            )
-            self.numeric_preprocessor = resolved_numeric_preprocessor
-            self.categorical_preprocessor = resolved_categorical_preprocessor
-
         if self.numeric_preprocessor is None or self.categorical_preprocessor is None:
-            legacy_preprocessor_ids = sorted(LEGACY_PREPROCESSOR_MAPPING)
             raise ValueError(
                 "Model candidates require experiment.candidate.numeric_preprocessor and "
-                "experiment.candidate.categorical_preprocessor. "
-                f"Legacy experiment.candidate.preprocessor values remain temporarily supported: {legacy_preprocessor_ids}"
+                "experiment.candidate.categorical_preprocessor."
             )
 
         if self.numeric_preprocessor not in NUMERIC_PREPROCESSOR_IDS:

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -17,12 +17,6 @@ from sklearn.preprocessing import (
 NumericPreprocessorBuilder = Callable[[], object]
 CategoricalPreprocessorBuilder = Callable[[], object]
 
-LEGACY_PREPROCESSOR_MAPPING = {
-    "onehot": ("standardize", "onehot"),
-    "ordinal": ("median", "ordinal"),
-    "frequency": ("median", "frequency"),
-    "native": ("median", "native"),
-}
 NUMERIC_PREPROCESSOR_IDS = tuple(["median", "standardize", "kbins"])
 CATEGORICAL_PREPROCESSOR_IDS = tuple(["onehot", "ordinal", "frequency", "native"])
 
@@ -121,16 +115,6 @@ def resolve_feature_schema(
         numeric_columns=numeric_columns,
         categorical_columns=categorical_columns,
     )
-
-
-def resolve_legacy_preprocessor_selection(preprocessor_id: str) -> tuple[str, str]:
-    try:
-        return LEGACY_PREPROCESSOR_MAPPING[preprocessor_id]
-    except KeyError as exc:
-        supported_preprocessor_ids = sorted(LEGACY_PREPROCESSOR_MAPPING)
-        raise ValueError(
-            f"Unsupported preprocessing scheme '{preprocessor_id}'. Supported values: {supported_preprocessor_ids}"
-        ) from exc
 
 
 def build_preprocessing_scheme_id(


### PR DESCRIPTION
Closes #120

## Summary
- remove the temporary `experiment.candidate.preprocessor` compatibility shim
- reject the old `preprocessor` key with a direct migration error
- remove legacy shim references from docs

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/config.py src/tabular_shenanigans/preprocess.py`
- `PYTHONPATH=src .venv/bin/python` inline validation:
  - current local `config.yaml` loads with `numeric_preprocessor=standardize` and `categorical_preprocessor=onehot`
  - an old config payload using `experiment.candidate.preprocessor: onehot` now fails with the explicit migration error