### PR TITLE
Reduce AppConfig proxy surface

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -43,7 +43,7 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 ## Module Responsibilities
 - `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, training, and submission.
 - `src/tabular_shenanigans/competition.py`: competition-level preparation, `competition.json` persistence, `folds.csv` persistence, prepared-context validation, and split reconstruction from frozen folds.
-- `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, and runtime contract validation.
+- `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, runtime contract validation, and a small set of derived helpers on `AppConfig`.
 - `src/tabular_shenanigans/candidate_artifacts.py`: shared candidate artifact path resolution, manifest loading, config fingerprint helpers, target-summary generation, and common candidate file writing.
 - `src/tabular_shenanigans/data.py`: competition download, zip access, metric helpers, dataset schema resolution, and sample-submission template loading.
 - `src/tabular_shenanigans/eda.py`: competition-scan EDA summaries written to CSV from the shared dataset context, including missingness, categorical cardinality, target summary, and feature-type counts.
@@ -127,6 +127,7 @@ Binary prediction artifact contract:
 The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema mismatches, and missing required fields are hard errors.
 Configured metrics are normalized to the internal metric names during config validation.
 The old flat config layout is unsupported and fails fast.
+Runtime modules consume `config.competition` and `config.experiment` directly; `AppConfig` keeps only minimal derived helpers such as candidate-type checks and resolved model ID lookup.
 The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe for model candidates; built-in recipe IDs are `identity` and `s6e3_v1`.
 Model candidates configure preprocessing with split selectors:
 - `numeric_preprocessor`: `median`, `standardize`, or `kbins`

--- a/main.py
+++ b/main.py
@@ -36,48 +36,54 @@ def build_parser() -> argparse.ArgumentParser:
     submit_parser = subparsers.add_parser("submit", help="Prepare or submit from a candidate artifact.")
     submit_parser.add_argument(
         "--candidate-id",
-        help="Optional candidate_id resolved under artifacts/<competition_slug>/candidates/<candidate_id>. Defaults to config.candidate_id.",
+        help=(
+            "Optional candidate_id resolved under artifacts/<competition_slug>/candidates/<candidate_id>. "
+            "Defaults to config.experiment.candidate.candidate_id."
+        ),
     )
 
     return parser
 
 
 def _print_resolved_setup(config: AppConfig) -> None:
+    competition = config.competition
+    candidate = config.experiment.candidate
     if config.is_blend_candidate:
-        blend_weights = config.blend_weights
+        blend_weights = candidate.weights
         weight_summary = "equal-weight"
         if blend_weights is not None:
             weight_summary = ",".join(str(weight) for weight in blend_weights)
         print(
             "Resolved competition setup: "
-            f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
-            f"candidate_id={config.candidate_id}, candidate_type=blend, "
-            f"base_candidates={config.base_candidate_ids}, weights={weight_summary}"
+            f"task_type={competition.task_type}, primary_metric={competition.primary_metric}, "
+            f"candidate_id={candidate.candidate_id}, candidate_type=blend, "
+            f"base_candidates={candidate.base_candidate_ids}, weights={weight_summary}"
         )
         return
 
     print(
         "Resolved competition setup: "
-        f"task_type={config.task_type}, primary_metric={config.primary_metric}, "
-        f"candidate_id={config.candidate_id}, candidate_type=model, "
-        f"feature_recipe={config.feature_recipe_id}, model_family={config.model_family}, "
-        f"numeric_preprocessor={config.numeric_preprocessor}, "
-        f"categorical_preprocessor={config.categorical_preprocessor}, "
+        f"task_type={competition.task_type}, primary_metric={competition.primary_metric}, "
+        f"candidate_id={candidate.candidate_id}, candidate_type=model, "
+        f"feature_recipe={candidate.feature_recipe_id}, model_family={candidate.model_family}, "
+        f"numeric_preprocessor={candidate.numeric_preprocessor}, "
+        f"categorical_preprocessor={candidate.categorical_preprocessor}, "
         f"model_id={config.resolved_model_id}"
     )
 
 
 def _ensure_data_ready(config: AppConfig) -> Path:
-    data_dir = fetch_competition_data(config.competition_slug)
+    data_dir = fetch_competition_data(config.competition.slug)
     print(f"Data ready: {data_dir}")
     return data_dir
 
 
 def _load_shared_dataset_context(config: AppConfig):
+    competition = config.competition
     return load_competition_dataset_context(
-        competition_slug=config.competition_slug,
-        configured_id_column=config.id_column,
-        configured_label_column=config.label_column,
+        competition_slug=competition.slug,
+        configured_id_column=competition.id_column,
+        configured_label_column=competition.label_column,
     )
 
 
@@ -92,19 +98,20 @@ def _prepare_competition_stage(config: AppConfig):
 
 
 def _build_train_tracking_tags(config: AppConfig) -> dict[str, object]:
+    candidate = config.experiment.candidate
     tags: dict[str, object] = {
-        "candidate_id": config.candidate_id,
-        "candidate_type": config.candidate_type,
+        "candidate_id": candidate.candidate_id,
+        "candidate_type": candidate.candidate_type,
     }
     if config.is_model_candidate:
         tags["model_id"] = config.resolved_model_id
-        tags["feature_recipe_id"] = config.feature_recipe_id
-        tags["numeric_preprocessor"] = config.numeric_preprocessor
-        tags["categorical_preprocessor"] = config.categorical_preprocessor
-        tags["preprocessing_scheme_id"] = config.preprocessing_scheme_id
+        tags["feature_recipe_id"] = candidate.feature_recipe_id
+        tags["numeric_preprocessor"] = candidate.numeric_preprocessor
+        tags["categorical_preprocessor"] = candidate.categorical_preprocessor
+        tags["preprocessing_scheme_id"] = candidate.preprocessing_scheme_id
         return tags
 
-    tags["base_candidate_count"] = len(config.base_candidate_ids)
+    tags["base_candidate_count"] = len(candidate.base_candidate_ids)
     return tags
 
 
@@ -175,7 +182,7 @@ def _run_submit_stage(
     config: AppConfig,
     candidate_id: str | None = None,
 ) -> tuple[Path, str]:
-    resolved_candidate_id = candidate_id or config.candidate_id
+    resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
     print(f"Using candidate_id: {resolved_candidate_id}")
     submission_path, submission_status = run_submission(
         config=config,
@@ -190,7 +197,7 @@ def _run_submit_stage_with_tracking(
     pipeline_invocation_id: str,
     candidate_id: str | None = None,
 ) -> tuple[Path, str]:
-    resolved_candidate_id = candidate_id or config.candidate_id
+    resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
     tracking_context = nullcontext()
     if is_tracking_enabled(config):
         tracking_context = start_stage_run(
@@ -204,9 +211,9 @@ def _run_submit_stage_with_tracking(
         if is_tracking_enabled(config):
             log_runtime_config(config)
             submission_message = build_submission_message(
-                competition_slug=config.competition_slug,
+                competition_slug=config.competition.slug,
                 candidate_id=resolved_candidate_id,
-                submit_message_prefix=config.submit_message_prefix,
+                submit_message_prefix=config.experiment.submit.message_prefix,
             )
         else:
             submission_message = ""
@@ -216,12 +223,12 @@ def _run_submit_stage_with_tracking(
         )
         if is_tracking_enabled(config):
             log_submit_outputs(
-                competition_slug=config.competition_slug,
+                competition_slug=config.competition.slug,
                 candidate_id=resolved_candidate_id,
                 submission_path=submission_path,
                 submission_status=submission_status,
                 message=submission_message,
-                submit_enabled=config.submit_enabled,
+                submit_enabled=config.experiment.submit.enabled,
             )
         return submission_path, submission_status
 

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -485,6 +485,7 @@ def _build_config_snapshot(
     label_column: str,
     normalized_weights: list[float],
 ) -> dict[str, object]:
+    candidate = config.experiment.candidate
     config_snapshot = build_base_config_snapshot(
         config=config,
         positive_label=positive_label,
@@ -496,7 +497,7 @@ def _build_config_snapshot(
             "candidate_id": candidate_id,
             "weight": weight,
         }
-        for candidate_id, weight in zip(config.base_candidate_ids, normalized_weights, strict=True)
+        for candidate_id, weight in zip(candidate.base_candidate_ids, normalized_weights, strict=True)
     ]
     return config_snapshot
 
@@ -540,24 +541,26 @@ def _build_candidate_manifest(
     components: list[BlendComponent],
     normalized_weights: list[float],
 ) -> dict[str, object]:
+    competition = config.competition
+    candidate = config.experiment.candidate
     manifest = {
         "artifact_type": "candidate",
-        "candidate_id": config.candidate_id,
-        "candidate_type": config.candidate_type,
+        "candidate_id": candidate.candidate_id,
+        "candidate_type": candidate.candidate_type,
         "generated_at_utc": generated_at_utc,
-        "competition_slug": config.competition_slug,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
+        "competition_slug": competition.slug,
+        "task_type": competition.task_type,
+        "primary_metric": competition.primary_metric,
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
         "model_id": BLEND_MODEL_ID,
         "model_name": BLEND_MODEL_NAME,
         "preprocessing_scheme_id": BLEND_PREPROCESSING_SCHEME_ID,
         "cv_summary": {
-            "metric_name": config.primary_metric,
+            "metric_name": competition.primary_metric,
             "metric_mean": metric_mean,
             "metric_std": metric_std,
-            "higher_is_better": is_higher_better(config.primary_metric),
+            "higher_is_better": is_higher_better(competition.primary_metric),
         },
         "component_candidates": [
             {
@@ -569,10 +572,10 @@ def _build_candidate_manifest(
                 "feature_recipe_id": component.feature_recipe_id,
                 "weight": weight,
                 "cv_summary": {
-                    "metric_name": config.primary_metric,
+                    "metric_name": competition.primary_metric,
                     "metric_mean": component.cv_metric_mean,
                     "metric_std": component.cv_metric_std,
-                    "higher_is_better": is_higher_better(config.primary_metric),
+                    "higher_is_better": is_higher_better(competition.primary_metric),
                 },
             }
             for component, weight in zip(components, normalized_weights, strict=True)
@@ -590,8 +593,8 @@ def _build_candidate_manifest(
     }
     manifest.update(
         build_binary_accuracy_artifact_metadata(
-            task_type=config.task_type,
-            primary_metric=config.primary_metric,
+            task_type=competition.task_type,
+            primary_metric=competition.primary_metric,
         )
     )
     return manifest
@@ -634,7 +637,10 @@ def run_blend_training(
     if not config.is_blend_candidate:
         raise ValueError("Blend training requires experiment.candidate.candidate_type=blend.")
 
-    candidate_dir = resolve_candidate_dir(config.competition_slug, config.candidate_id)
+    competition = config.competition
+    features = competition.features
+    candidate = config.experiment.candidate
+    candidate_dir = resolve_candidate_dir(competition.slug, candidate.candidate_id)
     if candidate_dir.exists():
         raise ValueError(
             "Candidate artifacts already exist for this candidate_id. "
@@ -652,9 +658,9 @@ def run_blend_training(
         test_df=test_df,
         id_column=id_column,
         label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
+        force_categorical=features.force_categorical,
+        force_numeric=features.force_numeric,
+        drop_columns=features.drop_columns,
     )
     prepared_context = ensure_prepared_competition_context(
         config=config,
@@ -663,25 +669,25 @@ def run_blend_training(
     )
     fold_assignments = prepared_context.fold_assignments
 
-    positive_label = config.positive_label
+    positive_label = competition.positive_label
     negative_label = None
     observed_label_pair = None
-    if config.task_type == "binary":
+    if competition.task_type == "binary":
         negative_label, positive_label, observed_label_pair = resolve_positive_label(
             y_values=y_train,
             configured_positive_label=positive_label,
         )
 
     normalized_weights = _resolve_blend_weights(
-        base_candidate_ids=config.base_candidate_ids,
-        configured_weights=config.blend_weights,
+        base_candidate_ids=candidate.base_candidate_ids,
+        configured_weights=candidate.weights,
     )
     components = [
         _load_blend_component(
-            competition_slug=config.competition_slug,
+            competition_slug=competition.slug,
             candidate_id=base_candidate_id,
-            task_type=config.task_type,
-            primary_metric=config.primary_metric,
+            task_type=competition.task_type,
+            primary_metric=competition.primary_metric,
             id_column=id_column,
             label_column=label_column,
             expected_y_train=y_train,
@@ -691,7 +697,7 @@ def run_blend_training(
             negative_label=negative_label,
             observed_label_pair=observed_label_pair,
         )
-        for base_candidate_id in config.base_candidate_ids
+        for base_candidate_id in candidate.base_candidate_ids
     ]
 
     component_oof_predictions = np.vstack([component.oof_predictions for component in components])
@@ -701,11 +707,11 @@ def run_blend_training(
     blended_test_predictions = np.average(component_test_predictions, axis=0, weights=weight_array)
     test_prediction_probabilities = None
 
-    if config.task_type == "regression":
+    if competition.task_type == "regression":
         final_test_predictions: np.ndarray | list[object] = blended_test_predictions
-        if config.primary_metric == "rmsle":
+        if competition.primary_metric == "rmsle":
             final_test_predictions = np.clip(blended_test_predictions, a_min=0.0, a_max=None)
-    elif get_binary_prediction_kind(config.primary_metric) == "label":
+    elif get_binary_prediction_kind(competition.primary_metric) == "label":
         if positive_label is None or negative_label is None:
             raise ValueError("Binary label blends require resolved class metadata.")
         test_prediction_probabilities = np.asarray(blended_test_predictions, dtype=float)
@@ -718,8 +724,8 @@ def run_blend_training(
         final_test_predictions = blended_test_predictions
 
     fold_metrics_df = _build_fold_metrics(
-        task_type=config.task_type,
-        primary_metric=config.primary_metric,
+        task_type=competition.task_type,
+        primary_metric=competition.primary_metric,
         y_train=y_train,
         oof_predictions=blended_oof_predictions,
         fold_assignments=fold_assignments,
@@ -728,8 +734,8 @@ def run_blend_training(
     metric_mean = float(fold_metrics_df["metric_value"].mean())
     metric_std = float(fold_metrics_df["metric_value"].std(ddof=0))
     blend_summary_df = _build_blend_summary(
-        candidate_id=config.candidate_id,
-        metric_name=config.primary_metric,
+        candidate_id=candidate.candidate_id,
+        metric_name=competition.primary_metric,
         metric_mean=metric_mean,
         metric_std=metric_std,
         components=components,
@@ -737,7 +743,7 @@ def run_blend_training(
     )
 
     target_summary = build_target_summary(
-        task_type=config.task_type,
+        task_type=competition.task_type,
         y_train=y_train,
         positive_label=positive_label,
         negative_label=negative_label,
@@ -792,9 +798,9 @@ def run_blend_training(
         blend_summary_df=blend_summary_df,
     )
     print(
-        f"Blend candidate: {config.candidate_id} | "
-        f"components={config.base_candidate_ids} | "
+        f"Blend candidate: {candidate.candidate_id} | "
+        f"components={candidate.base_candidate_ids} | "
         f"weights={normalized_weights} | "
-        f"CV {config.primary_metric}: mean={metric_mean:.6f}, std={metric_std:.6f}"
+        f"CV {competition.primary_metric}: mean={metric_mean:.6f}, std={metric_std:.6f}"
     )
     return candidate_dir

--- a/src/tabular_shenanigans/candidate_artifacts.py
+++ b/src/tabular_shenanigans/candidate_artifacts.py
@@ -83,10 +83,11 @@ def build_base_config_snapshot(
     id_column: str,
     label_column: str,
 ) -> dict[str, object]:
+    competition = config.competition
     return {
         "competition": {
-            **config.competition.model_dump(mode="python"),
-            "primary_metric": config.primary_metric,
+            **competition.model_dump(mode="python"),
+            "primary_metric": competition.primary_metric,
             "positive_label": positive_label,
             "id_column": id_column,
             "label_column": label_column,

--- a/src/tabular_shenanigans/competition.py
+++ b/src/tabular_shenanigans/competition.py
@@ -126,11 +126,12 @@ def _build_competition_manifest(
     positive_label: object | None,
     observed_label_pair: tuple[object, object] | None,
 ) -> dict[str, object]:
+    competition = config.competition
     return {
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-        "competition_slug": config.competition_slug,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
+        "competition_slug": competition.slug,
+        "task_type": competition.task_type,
+        "primary_metric": competition.primary_metric,
         "id_column": dataset_context.id_column,
         "label_column": dataset_context.label_column,
         "positive_label": positive_label,
@@ -164,6 +165,9 @@ def prepare_competition(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
 ) -> PreparedCompetitionContext:
+    competition = config.competition
+    features = competition.features
+    cv = competition.cv
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
     id_column = dataset_context.id_column
@@ -174,34 +178,34 @@ def prepare_competition(
         test_df=test_df,
         id_column=id_column,
         label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
+        force_categorical=features.force_categorical,
+        force_numeric=features.force_numeric,
+        drop_columns=features.drop_columns,
     )
 
-    positive_label = config.positive_label
+    positive_label = competition.positive_label
     observed_label_pair = None
-    if config.task_type == "binary":
+    if competition.task_type == "binary":
         _, positive_label, observed_label_pair = resolve_positive_label(
             y_values=y_train,
             configured_positive_label=positive_label,
         )
 
     split_indices = materialize_split_indices(
-        task_type=config.task_type,
+        task_type=competition.task_type,
         x_train_raw=x_train_raw,
         y_train=y_train,
-        n_splits=config.cv_n_splits,
-        shuffle=config.cv_shuffle,
-        random_state=config.cv_random_state,
+        n_splits=cv.n_splits,
+        shuffle=cv.shuffle,
+        random_state=cv.random_state,
     )
     fold_assignments = build_fold_assignments(row_count=x_train_raw.shape[0], split_indices=split_indices)
     report_dir = run_eda(config=config, dataset_context=dataset_context)
 
-    competition_dir = _competition_dir(config.competition_slug)
+    competition_dir = _competition_dir(competition.slug)
     competition_dir.mkdir(parents=True, exist_ok=True)
-    manifest_path = _competition_manifest_path(config.competition_slug)
-    folds_path = _competition_folds_path(config.competition_slug)
+    manifest_path = _competition_manifest_path(competition.slug)
+    folds_path = _competition_folds_path(competition.slug)
     manifest = _build_competition_manifest(
         config=config,
         dataset_context=dataset_context,
@@ -259,16 +263,17 @@ def _validate_prepared_context(
     fold_assignments: np.ndarray,
     expected_feature_columns: list[str] | None,
 ) -> None:
-    expected_cv = config.competition.cv.model_dump(mode="python")
-    expected_features = config.competition.features.model_dump(mode="python")
+    competition = config.competition
+    expected_cv = competition.cv.model_dump(mode="python")
+    expected_features = competition.features.model_dump(mode="python")
     train_rows = int(dataset_context.train_df.shape[0])
     test_rows = int(dataset_context.test_df.shape[0])
 
-    if manifest.get("competition_slug") != config.competition_slug:
+    if manifest.get("competition_slug") != competition.slug:
         raise ValueError("Prepared competition context does not match the configured competition slug.")
-    if manifest.get("task_type") != config.task_type:
+    if manifest.get("task_type") != competition.task_type:
         raise ValueError("Prepared competition context does not match the configured task_type. Re-run prepare.")
-    if manifest.get("primary_metric") != config.primary_metric:
+    if manifest.get("primary_metric") != competition.primary_metric:
         raise ValueError("Prepared competition context does not match the configured primary_metric. Re-run prepare.")
     if manifest.get("id_column") != dataset_context.id_column:
         raise ValueError("Prepared competition context does not match the resolved id_column. Re-run prepare.")
@@ -288,7 +293,7 @@ def _validate_prepared_context(
         raise ValueError("Prepared competition context does not match the resolved feature columns. Re-run prepare.")
 
     split_indices = build_split_indices_from_fold_assignments(fold_assignments)
-    if len(split_indices) != config.cv_n_splits:
+    if len(split_indices) != competition.cv.n_splits:
         raise ValueError("Prepared fold assignments do not match competition.cv.n_splits. Re-run prepare.")
 
 
@@ -297,8 +302,9 @@ def load_prepared_competition_context(
     dataset_context: CompetitionDatasetContext,
     expected_feature_columns: list[str] | None = None,
 ) -> PreparedCompetitionContext:
-    manifest_path = _competition_manifest_path(config.competition_slug)
-    folds_path = _competition_folds_path(config.competition_slug)
+    competition_slug = config.competition.slug
+    manifest_path = _competition_manifest_path(competition_slug)
+    folds_path = _competition_folds_path(competition_slug)
     manifest = _load_competition_manifest(manifest_path=manifest_path)
     fold_assignments = _load_fold_assignments(folds_path=folds_path)
     _validate_prepared_context(
@@ -309,8 +315,8 @@ def load_prepared_competition_context(
         expected_feature_columns=expected_feature_columns,
     )
     return PreparedCompetitionContext(
-        competition_dir=_competition_dir(config.competition_slug),
-        report_dir=Path("reports") / config.competition_slug,
+        competition_dir=_competition_dir(competition_slug),
+        report_dir=Path("reports") / competition_slug,
         manifest_path=manifest_path,
         folds_path=folds_path,
         manifest=manifest,
@@ -324,7 +330,8 @@ def ensure_prepared_competition_context(
     dataset_context: CompetitionDatasetContext,
     expected_feature_columns: list[str] | None = None,
 ) -> PreparedCompetitionContext:
-    if has_prepared_competition_context(config.competition_slug):
+    competition_slug = config.competition.slug
+    if has_prepared_competition_context(competition_slug):
         return load_prepared_competition_context(
             config=config,
             dataset_context=dataset_context,

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -129,6 +129,18 @@ class ModelCandidateConfig(BaseCandidateConfig):
             )
         return self
 
+    @property
+    def preprocessing_scheme_id(self) -> str:
+        if self.numeric_preprocessor is None or self.categorical_preprocessor is None:
+            raise ValueError(
+                "preprocessing_scheme_id requires experiment.candidate.numeric_preprocessor and "
+                "experiment.candidate.categorical_preprocessor."
+            )
+        return build_preprocessing_scheme_id(
+            numeric_preprocessor_id=self.numeric_preprocessor,
+            categorical_preprocessor_id=self.categorical_preprocessor,
+        )
+
 
 class BlendCandidateConfig(BaseCandidateConfig):
     model_config = ConfigDict(extra="forbid")
@@ -226,34 +238,33 @@ class AppConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_config(self) -> "AppConfig":
-        normalized_primary_metric = normalize_primary_metric(self.competition.primary_metric)
+        competition = self.competition
+        normalized_primary_metric = normalize_primary_metric(competition.primary_metric)
         if normalized_primary_metric is None:
             raise ValueError(
                 "Configured competition.primary_metric is not supported. "
                 f"Supported values: {sorted(set(SUPPORTED_PRIMARY_METRICS.values()))}"
             )
-        if not is_metric_valid_for_task(self.competition.task_type, normalized_primary_metric):
+        if not is_metric_valid_for_task(competition.task_type, normalized_primary_metric):
             raise ValueError(
                 "Configured competition.primary_metric "
-                f"'{normalized_primary_metric}' is not valid for task_type '{self.competition.task_type}'."
+                f"'{normalized_primary_metric}' is not valid for task_type '{competition.task_type}'."
             )
-        self.competition.primary_metric = normalized_primary_metric
+        competition.primary_metric = normalized_primary_metric
 
-        if self.competition.task_type != "binary" and self.competition.positive_label is not None:
+        if competition.task_type != "binary" and competition.positive_label is not None:
             raise ValueError("competition.positive_label is only supported for binary task_type.")
 
         if self.is_model_candidate:
-            self.experiment.candidate.feature_recipe_id = resolve_feature_recipe_id(
-                self.experiment.candidate.feature_recipe_id
-            )
-
+            candidate = self.experiment.candidate
+            candidate.feature_recipe_id = resolve_feature_recipe_id(candidate.feature_recipe_id)
             resolved_model_id = self.resolved_model_id
             validate_model_preprocessing_compatibility(
-                task_type=self.task_type,
+                task_type=competition.task_type,
                 model_id=resolved_model_id,
-                categorical_preprocessor_id=self.categorical_preprocessor,
+                categorical_preprocessor_id=candidate.categorical_preprocessor,
             )
-            optimization = self.experiment.candidate.optimization
+            optimization = candidate.optimization
             if optimization.enabled:
                 if optimization.n_trials is None and optimization.timeout_seconds is None:
                     raise ValueError(
@@ -261,74 +272,15 @@ class AppConfig(BaseModel):
                         "Set experiment.candidate.optimization.n_trials or "
                         "experiment.candidate.optimization.timeout_seconds."
                     )
-                if not is_model_tunable(self.task_type, resolved_model_id):
-                    supported_tunable_model_families = get_tunable_model_ids(self.task_type)
+                if not is_model_tunable(competition.task_type, resolved_model_id):
+                    supported_tunable_model_families = get_tunable_model_ids(competition.task_type)
                     raise ValueError(
-                        f"Configured model_family '{self.model_family}' does not support optimization for task_type "
-                        f"'{self.task_type}'. Supported tunable model families: {supported_tunable_model_families}"
+                        f"Configured model_family '{candidate.model_family}' does not support optimization for "
+                        f"task_type '{competition.task_type}'. Supported tunable model families: "
+                        f"{supported_tunable_model_families}"
                     )
 
         return self
-
-    @property
-    def competition_slug(self) -> str:
-        return self.competition.slug
-
-    @property
-    def task_type(self) -> Literal["regression", "binary"]:
-        return self.competition.task_type
-
-    @property
-    def primary_metric(self) -> str:
-        return self.competition.primary_metric
-
-    @property
-    def positive_label(self) -> str | int | bool | None:
-        return self.competition.positive_label
-
-    @property
-    def id_column(self) -> str | None:
-        return self.competition.id_column
-
-    @property
-    def label_column(self) -> str | None:
-        return self.competition.label_column
-
-    @property
-    def force_categorical(self) -> list[str]:
-        return self.competition.features.force_categorical
-
-    @property
-    def force_numeric(self) -> list[str]:
-        return self.competition.features.force_numeric
-
-    @property
-    def drop_columns(self) -> list[str]:
-        return self.competition.features.drop_columns
-
-    @property
-    def low_cardinality_int_threshold(self) -> int | None:
-        return self.competition.features.low_cardinality_int_threshold
-
-    @property
-    def cv_n_splits(self) -> int:
-        return self.competition.cv.n_splits
-
-    @property
-    def cv_shuffle(self) -> bool:
-        return self.competition.cv.shuffle
-
-    @property
-    def cv_random_state(self) -> int:
-        return self.competition.cv.random_state
-
-    @property
-    def candidate_id(self) -> str:
-        return self.experiment.candidate.candidate_id
-
-    @property
-    def candidate_type(self) -> str:
-        return self.experiment.candidate.candidate_type
 
     @property
     def is_model_candidate(self) -> bool:
@@ -339,94 +291,14 @@ class AppConfig(BaseModel):
         return isinstance(self.experiment.candidate, BlendCandidateConfig)
 
     @property
-    def model_family(self) -> str:
-        if not self.is_model_candidate:
-            raise ValueError("model_family is only available for model candidates.")
-        return self.experiment.candidate.model_family
-
-    @property
-    def feature_recipe_id(self) -> str:
-        if not self.is_model_candidate:
-            raise ValueError("feature_recipe_id is only available for model candidates.")
-        return self.experiment.candidate.feature_recipe_id
-
-    @property
-    def numeric_preprocessor(self) -> str:
-        if not self.is_model_candidate or self.experiment.candidate.numeric_preprocessor is None:
-            raise ValueError("numeric_preprocessor is only available for model candidates.")
-        return self.experiment.candidate.numeric_preprocessor
-
-    @property
-    def categorical_preprocessor(self) -> str:
-        if not self.is_model_candidate or self.experiment.candidate.categorical_preprocessor is None:
-            raise ValueError("categorical_preprocessor is only available for model candidates.")
-        return self.experiment.candidate.categorical_preprocessor
-
-    @property
-    def preprocessing_scheme_id(self) -> str:
-        if not self.is_model_candidate:
-            raise ValueError("preprocessing_scheme_id is only available for model candidates.")
-        return build_preprocessing_scheme_id(
-            numeric_preprocessor_id=self.numeric_preprocessor,
-            categorical_preprocessor_id=self.categorical_preprocessor,
-        )
-
-    @property
     def resolved_model_id(self) -> str:
         if not self.is_model_candidate:
             raise ValueError("resolved_model_id is only available for model candidates.")
+        candidate = self.experiment.candidate
         return resolve_candidate_model_id(
-            task_type=self.task_type,
-            model_family=self.model_family,
+            task_type=self.competition.task_type,
+            model_family=candidate.model_family,
         )
-
-    @property
-    def model_parameter_overrides(self) -> dict[str, object] | None:
-        if not self.is_model_candidate:
-            raise ValueError("model_parameter_overrides is only available for model candidates.")
-        if not self.experiment.candidate.model_params:
-            return None
-        return dict(self.experiment.candidate.model_params)
-
-    @property
-    def base_candidate_ids(self) -> list[str]:
-        if not self.is_blend_candidate:
-            raise ValueError("base_candidate_ids is only available for blend candidates.")
-        return list(self.experiment.candidate.base_candidate_ids)
-
-    @property
-    def blend_weights(self) -> list[float] | None:
-        if not self.is_blend_candidate:
-            raise ValueError("blend_weights is only available for blend candidates.")
-        if self.experiment.candidate.weights is None:
-            return None
-        return list(self.experiment.candidate.weights)
-
-    @property
-    def submit_enabled(self) -> bool:
-        return self.experiment.submit.enabled
-
-    @property
-    def submit_message_prefix(self) -> str | None:
-        return self.experiment.submit.message_prefix
-
-    @property
-    def tracking_enabled(self) -> bool:
-        return self.experiment.tracking.enabled
-
-    @property
-    def tracking_uri(self) -> str:
-        if not self.tracking_enabled or self.experiment.tracking.tracking_uri is None:
-            raise ValueError("tracking_uri is only available when experiment.tracking.enabled=true.")
-        return self.experiment.tracking.tracking_uri
-
-    @property
-    def tracking_experiment_name(self) -> str:
-        if not self.tracking_enabled or self.experiment.tracking.experiment_name is None:
-            raise ValueError(
-                "tracking_experiment_name is only available when experiment.tracking.enabled=true."
-            )
-        return self.experiment.tracking.experiment_name
 
 
 def load_config(path: str = "config.yaml") -> AppConfig:

--- a/src/tabular_shenanigans/eda.py
+++ b/src/tabular_shenanigans/eda.py
@@ -83,6 +83,8 @@ def run_eda(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
 ) -> Path:
+    competition = config.competition
+    features = competition.features
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
     id_column = dataset_context.id_column
@@ -93,12 +95,12 @@ def run_eda(
         test_df=test_df,
         id_column=id_column,
         label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
+        force_categorical=features.force_categorical,
+        force_numeric=features.force_numeric,
+        drop_columns=features.drop_columns,
     )
 
-    report_dir = Path("reports") / config.competition_slug
+    report_dir = Path("reports") / competition.slug
     report_dir.mkdir(parents=True, exist_ok=True)
 
     _column_summary(train_df).to_csv(report_dir / "columns_train.csv", index=False)
@@ -111,9 +113,9 @@ def run_eda(
     _target_summary(train_df, label_column).to_csv(report_dir / "target_summary.csv", index=False)
     feature_type_counts = summarize_feature_types(
         x_train_raw=x_train_raw,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+        force_categorical=features.force_categorical,
+        force_numeric=features.force_numeric,
+        low_cardinality_int_threshold=features.low_cardinality_int_threshold,
     )
     feature_type_counts.to_csv(report_dir / "feature_type_counts.csv", index=False)
 

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -12,7 +12,6 @@ from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.models import build_model, build_model_fit_kwargs
 from tabular_shenanigans.preprocess import (
     ResolvedFeatureSchema,
-    build_preprocessing_scheme_id,
     build_preprocessor_from_schema,
     prepare_feature_frames,
     resolve_feature_schema,
@@ -98,6 +97,9 @@ def build_prepared_training_context(
     if not config.is_model_candidate:
         raise ValueError("Prepared training context is only supported for model candidates.")
 
+    competition = config.competition
+    features = competition.features
+    candidate = config.experiment.candidate
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
     id_column = dataset_context.id_column
@@ -108,15 +110,15 @@ def build_prepared_training_context(
         test_df=test_df,
         id_column=id_column,
         label_column=label_column,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        drop_columns=config.drop_columns,
+        force_categorical=features.force_categorical,
+        force_numeric=features.force_numeric,
+        drop_columns=features.drop_columns,
     )
 
-    positive_label = config.positive_label
+    positive_label = competition.positive_label
     observed_label_pair = None
     negative_label = None
-    if config.task_type == "binary":
+    if competition.task_type == "binary":
         negative_label, positive_label, observed_label_pair = resolve_positive_label(
             y_values=y_train,
             configured_positive_label=positive_label,
@@ -128,12 +130,12 @@ def build_prepared_training_context(
         expected_feature_columns=x_train_raw.columns.tolist(),
     )
     x_train_features, x_test_features = apply_feature_recipe(
-        recipe_id=config.feature_recipe_id,
+        recipe_id=candidate.feature_recipe_id,
         x_train_raw=x_train_raw,
         x_test_raw=x_test_raw,
     )
     target_summary = build_target_summary(
-        task_type=config.task_type,
+        task_type=competition.task_type,
         y_train=y_train,
         positive_label=positive_label,
         negative_label=negative_label,
@@ -141,9 +143,9 @@ def build_prepared_training_context(
     )
     feature_schema = resolve_feature_schema(
         x_train_raw=x_train_features,
-        force_categorical=config.force_categorical,
-        force_numeric=config.force_numeric,
-        low_cardinality_int_threshold=config.low_cardinality_int_threshold,
+        force_categorical=features.force_categorical,
+        force_numeric=features.force_numeric,
+        low_cardinality_int_threshold=features.low_cardinality_int_threshold,
     )
     return PreparedTrainingContext(
         id_column=id_column,
@@ -158,12 +160,9 @@ def build_prepared_training_context(
         observed_label_pair=observed_label_pair,
         target_summary=target_summary,
         feature_schema=feature_schema,
-        numeric_preprocessor=config.numeric_preprocessor,
-        categorical_preprocessor=config.categorical_preprocessor,
-        preprocessing_scheme_id=build_preprocessing_scheme_id(
-            numeric_preprocessor_id=config.numeric_preprocessor,
-            categorical_preprocessor_id=config.categorical_preprocessor,
-        ),
+        numeric_preprocessor=candidate.numeric_preprocessor,
+        categorical_preprocessor=candidate.categorical_preprocessor,
+        preprocessing_scheme_id=candidate.preprocessing_scheme_id,
     )
 
 

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -299,18 +299,21 @@ def run_submission(
     config: AppConfig,
     candidate_id: str | None = None,
 ) -> tuple[Path, str]:
-    resolved_candidate_id = candidate_id or config.candidate_id
+    competition = config.competition
+    candidate = config.experiment.candidate
+    submit_config = config.experiment.submit
+    resolved_candidate_id = candidate_id or candidate.candidate_id
     submission_context = _load_submission_context(
-        competition_slug=config.competition_slug,
+        competition_slug=competition.slug,
         candidate_id=resolved_candidate_id,
     )
     submission_path = _prepare_submission_file_from_context(submission_context)
     message = _build_submission_message_from_context(
         submission_context,
-        submit_message_prefix=config.submit_message_prefix,
+        submit_message_prefix=submit_config.message_prefix,
     )
 
-    if config.submit_enabled:
+    if submit_config.enabled:
         completed = subprocess.run(
             [
                 "kaggle",
@@ -344,7 +347,7 @@ def run_submission(
         "model_name": submission_context.model_name,
         "config_fingerprint": submission_context.config_fingerprint,
         "submission_path": str(submission_path),
-        "submit_enabled": config.submit_enabled,
+        "submit_enabled": submit_config.enabled,
         "status": status,
         "message": message,
     }

--- a/src/tabular_shenanigans/tracking.py
+++ b/src/tabular_shenanigans/tracking.py
@@ -9,7 +9,7 @@ from tabular_shenanigans.config import AppConfig
 
 
 def is_tracking_enabled(config: AppConfig) -> bool:
-    return config.tracking_enabled
+    return config.experiment.tracking.enabled
 
 
 def make_pipeline_invocation_id() -> str:
@@ -41,10 +41,11 @@ def _build_stage_run_name(
     stage: str,
     extra_tags: Mapping[str, object] | None = None,
 ) -> str:
-    run_name_parts = [stage, config.competition_slug]
+    run_name_parts = [stage, config.competition.slug]
     if extra_tags is not None and extra_tags.get("candidate_id") is not None:
         run_name_parts.append(str(extra_tags["candidate_id"]))
     return " | ".join(run_name_parts)
+
 
 @contextmanager
 def start_stage_run(
@@ -54,18 +55,22 @@ def start_stage_run(
     extra_tags: Mapping[str, object] | None = None,
 ) -> Iterator[None]:
     mlflow = _load_mlflow()
-    mlflow.set_tracking_uri(config.tracking_uri)
-    mlflow.set_experiment(config.tracking_experiment_name)
+    tracking = config.experiment.tracking
+    if tracking.tracking_uri is None or tracking.experiment_name is None:
+        raise ValueError("Tracking run setup requires experiment.tracking.enabled=true with both tracking fields set.")
+    mlflow.set_tracking_uri(tracking.tracking_uri)
+    mlflow.set_experiment(tracking.experiment_name)
     mlflow.start_run(run_name=_build_stage_run_name(config=config, stage=stage, extra_tags=extra_tags))
 
+    competition = config.competition
     base_tags = {
         "app": "tabular_shenanigans",
         "tracking_schema_version": "1",
         "pipeline_invocation_id": pipeline_invocation_id,
         "stage": stage,
-        "competition_slug": config.competition_slug,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
+        "competition_slug": competition.slug,
+        "task_type": competition.task_type,
+        "primary_metric": competition.primary_metric,
         "local_experiment_name": config.experiment.name,
     }
     mlflow.set_tags(_coerce_tags(base_tags))

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -36,9 +36,10 @@ def _resolve_training_model_spec(
 ) -> TrainingModelSpec:
     if model_spec is not None:
         return model_spec
+    candidate = config.experiment.candidate
     return TrainingModelSpec(
         model_id=config.resolved_model_id,
-        parameter_overrides=config.model_parameter_overrides,
+        parameter_overrides=candidate.model_params or None,
     )
 
 
@@ -50,6 +51,7 @@ def _build_config_snapshot(
     label_column: str,
     tuning_provenance: dict[str, object] | None = None,
 ) -> dict[str, object]:
+    candidate = config.experiment.candidate
     config_snapshot = build_base_config_snapshot(
         config=config,
         positive_label=positive_label,
@@ -57,9 +59,9 @@ def _build_config_snapshot(
         label_column=label_column,
     )
     config_snapshot["resolved_model_id"] = model_spec.model_id
-    config_snapshot["resolved_numeric_preprocessor"] = config.numeric_preprocessor
-    config_snapshot["resolved_categorical_preprocessor"] = config.categorical_preprocessor
-    config_snapshot["resolved_preprocessing_scheme_id"] = config.preprocessing_scheme_id
+    config_snapshot["resolved_numeric_preprocessor"] = candidate.numeric_preprocessor
+    config_snapshot["resolved_categorical_preprocessor"] = candidate.categorical_preprocessor
+    config_snapshot["resolved_preprocessing_scheme_id"] = candidate.preprocessing_scheme_id
     if model_spec.parameter_overrides:
         config_snapshot["resolved_model_parameter_overrides"] = model_spec.parameter_overrides
     if tuning_provenance is not None:
@@ -88,21 +90,23 @@ def _build_candidate_manifest(
     training_context: PreparedTrainingContext,
     tuning_provenance: dict[str, object] | None,
 ) -> dict[str, object]:
+    competition = config.competition
+    candidate = config.experiment.candidate
     manifest = {
         "artifact_type": "candidate",
-        "candidate_id": config.candidate_id,
-        "candidate_type": config.candidate_type,
+        "candidate_id": candidate.candidate_id,
+        "candidate_type": candidate.candidate_type,
         "generated_at_utc": generated_at_utc,
-        "competition_slug": config.competition_slug,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
+        "competition_slug": competition.slug,
+        "task_type": competition.task_type,
+        "primary_metric": competition.primary_metric,
         "config_fingerprint": config_fingerprint,
         "config_snapshot": config_snapshot,
-        "model_family": config.model_family,
-        "feature_recipe_id": config.feature_recipe_id,
+        "model_family": candidate.model_family,
+        "feature_recipe_id": candidate.feature_recipe_id,
         "feature_columns": training_context.x_train_features.columns.tolist(),
-        "numeric_preprocessor": config.numeric_preprocessor,
-        "categorical_preprocessor": config.categorical_preprocessor,
+        "numeric_preprocessor": candidate.numeric_preprocessor,
+        "categorical_preprocessor": candidate.categorical_preprocessor,
         "model_id": model_result.model_id,
         "model_name": model_result.model_name,
         "preprocessing_scheme_id": model_result.preprocessing_scheme_id,
@@ -126,8 +130,8 @@ def _build_candidate_manifest(
     }
     manifest.update(
         build_binary_accuracy_artifact_metadata(
-            task_type=config.task_type,
-            primary_metric=config.primary_metric,
+            task_type=competition.task_type,
+            primary_metric=competition.primary_metric,
         )
     )
     return manifest
@@ -161,8 +165,10 @@ def run_training(
     if not config.is_model_candidate:
         raise ValueError("run_training only supports experiment.candidate.candidate_type=model.")
 
+    competition = config.competition
+    candidate = config.experiment.candidate
     resolved_model_spec = _resolve_training_model_spec(config=config, model_spec=model_spec)
-    candidate_dir = resolve_candidate_dir(config.competition_slug, config.candidate_id)
+    candidate_dir = resolve_candidate_dir(competition.slug, candidate.candidate_id)
     if candidate_dir.exists():
         raise ValueError(
             "Candidate artifacts already exist for this candidate_id. "
@@ -177,20 +183,20 @@ def run_training(
         )
 
     evaluation_artifacts = evaluate_model_spec(
-        task_type=config.task_type,
-        primary_metric=config.primary_metric,
+        task_type=competition.task_type,
+        primary_metric=competition.primary_metric,
         model_spec=resolved_model_spec,
         training_context=training_context,
-        cv_random_state=config.cv_random_state,
+        cv_random_state=competition.cv.random_state,
     )
     model_result = evaluation_artifacts.model_result
     print(
-        f"Training candidate: {config.candidate_id} | "
-        f"feature_recipe={config.feature_recipe_id} | "
+        f"Training candidate: {candidate.candidate_id} | "
+        f"feature_recipe={candidate.feature_recipe_id} | "
         f"model={model_result.model_id} ({model_result.model_name}) | "
         f"preprocessing={model_result.preprocessing_scheme_id} | "
         f"features={training_context.x_train_features.shape[1]} | "
-        f"CV {config.primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
+        f"CV {competition.primary_metric}: mean={model_result.cv_summary.metric_mean:.6f}, "
         f"std={model_result.cv_summary.metric_std:.6f}"
     )
 
@@ -239,7 +245,9 @@ def run_training_workflow(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
 ) -> Path:
-    candidate_dir = resolve_candidate_dir(config.competition_slug, config.candidate_id)
+    competition = config.competition
+    candidate = config.experiment.candidate
+    candidate_dir = resolve_candidate_dir(competition.slug, candidate.candidate_id)
     if candidate_dir.exists():
         raise ValueError(
             "Candidate artifacts already exist for this candidate_id. "
@@ -282,7 +290,7 @@ def run_training_workflow(
     )
     print(
         f"Optimization complete: best_trial={optimization_result.best_trial_number}, "
-        f"best_{config.primary_metric}={optimization_result.best_value:.6f}, "
+        f"best_{competition.primary_metric}={optimization_result.best_value:.6f}, "
         f"candidate={candidate_dir.name}"
     )
     return candidate_dir

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -83,16 +83,18 @@ def _build_optimization_summary(
     target_summary: dict[str, object],
     best_parameter_overrides: dict[str, object],
 ) -> dict[str, object]:
+    competition = config.competition
+    candidate = config.experiment.candidate
     best_trial = study.best_trial
     return {
         "artifact_type": "candidate_optimization",
         "study_id": study_id,
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-        "competition_slug": config.competition_slug,
-        "candidate_id": config.candidate_id,
-        "task_type": config.task_type,
-        "primary_metric": config.primary_metric,
-        "optimization_method": config.experiment.candidate.optimization.method,
+        "competition_slug": competition.slug,
+        "candidate_id": candidate.candidate_id,
+        "task_type": competition.task_type,
+        "primary_metric": competition.primary_metric,
+        "optimization_method": candidate.optimization.method,
         "optimization_direction": study.direction.name.lower(),
         "config_snapshot": optimization_config_snapshot,
         "model_id": tuning_model_spec.model_id,
@@ -118,12 +120,14 @@ def run_optimization(
     if not config.is_model_candidate:
         raise ValueError("Optimization only supports experiment.candidate.candidate_type=model.")
 
-    optimization = config.experiment.candidate.optimization
+    competition = config.competition
+    candidate = config.experiment.candidate
+    optimization = candidate.optimization
     if not optimization.enabled:
         raise ValueError("Optimization requires experiment.candidate.optimization.enabled=true in config.yaml.")
 
-    task_type = config.task_type
-    primary_metric = config.primary_metric
+    task_type = competition.task_type
+    primary_metric = competition.primary_metric
     tuning_model_spec = TrainingModelSpec(model_id=config.resolved_model_id)
     model_definition = get_model_definition(task_type, tuning_model_spec.model_id)
 
@@ -156,7 +160,7 @@ def run_optimization(
                 parameter_overrides=parameter_overrides,
             ),
             training_context=training_context,
-            cv_random_state=config.cv_random_state,
+            cv_random_state=competition.cv.random_state,
         )
         metric_mean = cv_evaluation.model_result.cv_summary.metric_mean
         metric_std = cv_evaluation.model_result.cv_summary.metric_std


### PR DESCRIPTION
## Summary
- migrate runtime modules to read nested config sections directly instead of AppConfig pass-through properties
- keep AppConfig limited to validation plus minimal derived helpers and move preprocessing scheme lookup onto ModelCandidateConfig
- update the technical guide to document the thinner AppConfig contract

Closes #108

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/config.py src/tabular_shenanigans/tracking.py src/tabular_shenanigans/candidate_artifacts.py src/tabular_shenanigans/eda.py src/tabular_shenanigans/competition.py src/tabular_shenanigans/model_evaluation.py src/tabular_shenanigans/train.py src/tabular_shenanigans/tune.py src/tabular_shenanigans/blend.py src/tabular_shenanigans/submit.py`
- `PYTHONPATH=src .venv/bin/python - <<'PY' ... load_config() ... PY` against the current repository-root `config.yaml`
- disposable synthetic smoke workflow in `/tmp`: trained two model candidates, trained one blend candidate, and ran `run_submission()` dry-run from the blend artifact
