### PR TITLE
Track Kaggle submission outcomes (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ The repository is developed and manually verified primarily against these Playgr
 - Exclude the resolved `id_column` from modeled features by default; identifier columns are treated as metadata, not training signal.
 - Generate terminal and CSV EDA summaries under `reports/<competition_slug>/`, including missingness, categorical cardinality, target summary, and feature-type counts.
 - Freeze CV assignments once per prepared competition context and reuse them across `train`.
-- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `train`, and submit-only flows.
+- Run stage-specific CLI entrypoints for `fetch`, `prepare`, `eda`, `train`, `submit`, and `refresh-submissions`.
 - Materialize one explicit experiment candidate at a time:
   - train one cross-validated model candidate using an optional config-selected feature recipe plus split numeric and categorical preprocessing choices on top of one config-selected model family
   - or build one blend candidate from existing compatible candidate artifacts under the same prepared competition context
 - Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/`, including `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, and `test_predictions.csv`, plus optional candidate-type-specific metadata such as `blend_summary.csv`, binary-accuracy blend probabilities, or optimization files.
 - When `experiment.candidate.optimization.enabled=true` for a model candidate, run Optuna inside `train`, retrain the best trial into the candidate artifact directory, and keep optimization metadata next to that candidate.
 - Validate predictions against `sample_submission.csv`, including exact ID content and order, with task-aware binary prediction checks, and optionally submit to Kaggle from the current candidate artifact selected by `candidate_id`.
-- Optionally publish `prepare`, `train`, and `submit` runs plus generated artifacts to a remote MLflow tracking server while preserving the current local file-based workflow.
+- Record real Kaggle submission events in `artifacts/<competition_slug>/submissions.csv`, record remote submission outcomes in `artifacts/<competition_slug>/submission_scores.csv`, and support later backfill through `refresh-submissions`.
+- Optionally publish `prepare`, `train`, `submit`, and `refresh-submissions` runs plus generated artifacts to a remote MLflow tracking server while preserving the current local file-based workflow.
 
 ## Tooling
 - Python for orchestration
@@ -72,13 +73,15 @@ Available stage-specific commands:
 - `uv run python main.py train`
 - `uv run python main.py submit`
 - `uv run python main.py submit --candidate-id <candidate_id>`
+- `uv run python main.py refresh-submissions`
 
 Stage behavior:
 - `fetch`: ensures competition data is present locally
 - `prepare`: fetches if needed, writes EDA report CSVs, persists `competition.json`, and freezes `folds.csv`
 - `eda`: fetches if needed, then writes EDA report CSVs
 - `train`: fetches if needed, prepares competition context when it is missing, then writes one candidate artifact directory on the frozen folds; model candidates train on raw data plus preprocessing, while blend candidates combine existing compatible candidate artifacts without retraining base models; when optimization is enabled for a model candidate, `train` first runs Optuna and stores optimization metadata inside that candidate directory
-- `submit`: resolves one candidate artifact by `candidate_id` and never retrains implicitly
+- `submit`: resolves one candidate artifact by `candidate_id`, writes `submission.csv`, and when `experiment.submit.enabled=true` submits to Kaggle, appends one submission event row, and attempts an immediate submission-outcome refresh for that event
+- `refresh-submissions`: scans Kaggle submission history for locally tracked submission events and appends any new remote status/score observations
 
 `submit` defaults to `config.experiment.candidate.candidate_id`. Use `--candidate-id` only when you want to submit another existing candidate for the same competition.
 
@@ -124,7 +127,7 @@ Required top-level sections:
 - optional `tracking` block
 
 Current `experiment.tracking` keys:
-- `enabled`: if `true`, publish `prepare`, `train`, and `submit` runs to MLflow (default `false`)
+- `enabled`: if `true`, publish `prepare`, `train`, `submit`, and `refresh-submissions` runs to MLflow (default `false`)
 - `tracking_uri`: remote MLflow tracking URI; required when tracking is enabled
 - `experiment_name`: remote MLflow experiment name; required when tracking is enabled
 
@@ -178,6 +181,8 @@ Current `experiment.submit` keys:
 - `enabled`: if `true`, submit to Kaggle after training (default `false`)
 - `message_prefix`: optional prefix used in auto-generated submission messages
 
+When `experiment.submit.enabled=true`, the runtime submits with a message shaped like `candidate=<candidate_id> | submit=<submission_event_id> | <metric>=<value>`, optionally prefixed by `message_prefix`. Only successful Kaggle submissions create `submission_event_id` values and append `submissions.csv` rows.
+
 Binary prediction artifact contract:
 - `roc_auc` and `log_loss`: `test_predictions.csv` and `submission.csv` contain positive-class probabilities in `[0, 1]`
 - `accuracy`: `test_predictions.csv` and `submission.csv` contain predicted class labels from the observed binary label set
@@ -211,6 +216,10 @@ Manual verification for each target:
 - for binary `accuracy` candidates, confirm `candidate.json` records the probability-average blend rule and sidecar path, and `artifacts/<competition_slug>/candidates/<candidate_id>/test_prediction_probabilities.csv` is also written
 - run `uv run python main.py submit`
 - confirm `artifacts/<competition_slug>/candidates/<candidate_id>/submission.csv` is written and validated against `sample_submission.csv`, including exact ID values and order
+- with `experiment.submit.enabled: false`, confirm neither `artifacts/<competition_slug>/submissions.csv` nor `artifacts/<competition_slug>/submission_scores.csv` is written
+- with `experiment.submit.enabled: true`, confirm `artifacts/<competition_slug>/submissions.csv` appends one row with `submission_event_id`
+- run `uv run python main.py refresh-submissions`
+- confirm `artifacts/<competition_slug>/submission_scores.csv` appends remote status and public-score observations without duplicating unchanged rows
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 
 Manual verification for optimization:
@@ -247,11 +256,13 @@ Manual verification for blend candidates:
   - model candidates record the selected `feature_recipe_id`, `model_registry_key`, `estimator_name`, engineered `feature_columns`, and optional `tuning_provenance`
   - blend candidates also include `blend_summary.csv` and record their component candidates plus normalized weights in `candidate.json`
   - optimized model candidates also include `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json`
-- Submission ledger: `artifacts/<competition_slug>/submissions.csv` as an append-only submission event table keyed by `candidate_id`
+- Submission event ledger: `artifacts/<competition_slug>/submissions.csv`
+- Submission outcome ledger: `artifacts/<competition_slug>/submission_scores.csv`
 - Optional remote MLflow artifacts:
   - `prepare` uploads `competition.json`, `folds.csv`, and reports
   - `train` uploads the full candidate artifact directory
-  - `submit` uploads `submission.csv` plus submission metadata
+  - `submit` uploads `submission.csv` plus submission metadata and submission ledgers when present
+  - `refresh-submissions` uploads the submission outcome ledger plus refresh metadata
 
 ## Current Assumptions
 - Kaggle CLI is installed, authenticated, and has access to the configured competition.
@@ -270,9 +281,10 @@ Manual verification for blend candidates:
 - Feature recipes are deterministic and leakage-safe; fold-learned transforms still belong in preprocessing, not in the recipe layer.
 - Submission uses `candidate.json` as the schema/task source of truth.
 - Submission defaults to `config.experiment.candidate.candidate_id`; `submit --candidate-id <candidate_id>` overrides that selection explicitly.
-- Submission messages lead with `candidate_id`; internal `model_registry_key` remains provenance only.
+- Submission messages lead with `candidate_id` and include `submit=<submission_event_id>` for real Kaggle submissions; internal `model_registry_key` remains provenance only.
 - Submission validation requires the selected candidate artifact `test_predictions.csv[id_column]` to match `sample_submission.csv[id_column]` exactly in both values and row order.
 - Submission requires the current candidate artifact layout under `artifacts/<competition_slug>/candidates/<candidate_id>/`.
+- Dry-run submission preparation does not mutate `submissions.csv` or `submission_scores.csv`.
 - Binary classification supports any two-class labels accepted by scikit-learn.
 - For binary `roc_auc` and `log_loss`, prediction artifacts use probabilities aligned to the resolved positive class.
 - For binary `accuracy`, prediction artifacts use class labels from the observed binary label set.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -26,8 +26,9 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 10. For blend candidates, load compatible base candidate artifacts from `artifacts/<competition_slug>/candidates/<base_candidate_id>/`, validate shared schema plus frozen-fold alignment, validate the binary probability label contract when `primary_metric` is `roc_auc` or `log_loss`, and materialize blended OOF plus test predictions without retraining the base candidates.
 11. When `experiment.candidate.optimization.enabled=true` for a model candidate, `train` builds one prepared training context, runs an Optuna study on the frozen fold assignments through the shared evaluation core, reuses that prepared context for the final best-trial retrain, and writes optimization metadata inside the candidate directory.
 12. Write one candidate artifact directory under `artifacts/<competition_slug>/candidates/<candidate_id>/` with `candidate.json`, `fold_metrics.csv`, `oof_predictions.csv`, `test_predictions.csv`, and optional candidate-type-specific files such as `blend_summary.csv` or optimization metadata.
-13. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle.
-14. When `experiment.tracking.enabled=true`, publish stage-local artifacts and metadata for `prepare`, `train`, and `submit` to the configured MLflow server after the stage succeeds.
+13. Validate predictions against `sample_submission.csv`, including exact ID content and order, using `candidate.json` as the submission metadata contract, apply metric-aware binary prediction validation, write `submission.csv` in the selected candidate directory, and optionally submit to Kaggle with a generated `submission_event_id`.
+14. For real Kaggle submissions only, append one local submission event row to `artifacts/<competition_slug>/submissions.csv`, then attempt an immediate refresh of matching remote submission outcomes into `artifacts/<competition_slug>/submission_scores.csv`.
+15. When `experiment.tracking.enabled=true`, publish stage-local artifacts and metadata for `prepare`, `train`, `submit`, and `refresh-submissions` to the configured MLflow server after the stage succeeds.
 
 ## CLI Stages
 - `uv run python main.py`: default full pipeline (`fetch` -> `prepare` -> `train` -> `submit`)
@@ -37,11 +38,12 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 - `uv run python main.py train`: fetch if needed, load the shared dataset context, auto-run `prepare` when needed, then either train one model candidate or materialize one blend candidate on the frozen folds; when optimization is enabled for a model candidate, run Optuna plus candidate-local optimization artifact writing before the final retrain
 - `uv run python main.py submit`: prepare or submit the configured `candidate_id`
 - `uv run python main.py submit --candidate-id <candidate_id>`: prepare or submit another existing candidate for the configured competition
+- `uv run python main.py refresh-submissions`: fetch remote Kaggle submission outcomes for locally tracked submission events
 
 The default `submit` path supports current candidate artifacts only. Unsupported or missing candidate artifacts fail directly.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, training, and submission.
+- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, training, submission, and submission refresh.
 - `src/tabular_shenanigans/competition.py`: competition-level preparation, `competition.json` persistence, `folds.csv` persistence, prepared-context validation, and split reconstruction from frozen folds.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, runtime contract validation, and a small set of derived helpers on `AppConfig`.
 - `src/tabular_shenanigans/candidate_artifacts.py`: shared candidate artifact path resolution, manifest loading, config fingerprint helpers, target-summary generation, and common candidate file writing.
@@ -55,8 +57,9 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/blend.py`: blend-candidate validation, base-candidate artifact compatibility checks, weighted prediction combination, blend-specific manifest fields, and `blend_summary.csv` writing on top of the shared candidate-artifact layer.
 - `src/tabular_shenanigans/train.py`: config-selected model training orchestration, candidate artifact writing, model-specific manifest fields, and optimization-aware workflow control on top of the shared candidate-artifact and model-evaluation layers.
 - `src/tabular_shenanigans/tune.py`: internal Optuna orchestration used by `train` when candidate optimization is enabled, consuming the shared prepared training context and shared evaluation functions.
-- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and submission ledger updates using the shared candidate manifest loader.
-- `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, tag/metric logging, config snapshot logging, and post-stage artifact publishing using the shared candidate manifest loader.
+- `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and stage-level submission orchestration.
+- `src/tabular_shenanigans/submission_history.py`: append-only submission event and outcome ledger helpers, `submission_event_id` generation, Kaggle submission-history refresh, and duplicate-observation suppression.
+- `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, tag/metric logging, config snapshot logging, and post-stage artifact publishing using the shared candidate manifest and submission-history contracts.
 
 ## Configuration Contract
 Input:
@@ -116,6 +119,7 @@ Input:
 - Current `experiment.submit` keys:
   - `enabled` (boolean, default false)
   - `message_prefix` (string, optional)
+- Real Kaggle submissions use auto-generated messages shaped like `candidate=<candidate_id> | submit=<submission_event_id> | <metric>=<value>`, optionally prefixed by `message_prefix`
 - Current `experiment.tracking` keys:
   - `enabled` (boolean, default false)
   - `tracking_uri` (string, required when enabled)
@@ -160,6 +164,10 @@ Manual verification steps for each target:
 - for binary `accuracy` candidates, confirm `candidate.json` records `binary_accuracy_blend_rule` plus `binary_accuracy_test_probability_path`, and `test_prediction_probabilities.csv` is also generated in the candidate directory
 - run `uv run python main.py submit`
 - confirm `submission.csv` validates against `sample_submission.csv`, including exact ID values and order, for the selected candidate directory
+- with `experiment.submit.enabled: false`, confirm `submissions.csv` and `submission_scores.csv` are unchanged
+- with `experiment.submit.enabled: true`, confirm `submissions.csv` appends one row with `submission_event_id`
+- run `uv run python main.py refresh-submissions`
+- confirm `submission_scores.csv` appends only new remote status/score observations for locally tracked `submission_event_id` values
 - confirm binary outputs match the configured metric contract: probabilities for `roc_auc`/`log_loss`, labels for `accuracy`
 - when optimization is enabled, run `uv run python main.py train` and confirm `optimization_summary.json`, `optimization_trials.csv`, and `optimization_best_params.json` are generated in the candidate directory
 - when optimization is enabled, confirm the best-trial retrain writes a standard candidate artifact and records `tuning_provenance` in `candidate.json`
@@ -193,11 +201,13 @@ Manual verification steps for each target:
   - `optimization_summary.json`
   - `optimization_trials.csv`
   - `optimization_best_params.json`
-- Append-only submission ledger at `artifacts/<competition_slug>/submissions.csv` keyed by `candidate_id`
+- Append-only submission event ledger at `artifacts/<competition_slug>/submissions.csv`
+- Append-only submission outcome ledger at `artifacts/<competition_slug>/submission_scores.csv`
 - Optional MLflow-published stage artifacts:
   - `prepare`: config snapshot, `competition.json`, `folds.csv`, and reports
   - `train`: config snapshot and the full candidate artifact directory
-  - `submit`: config snapshot, `submission.csv`, and submission metadata JSON
+  - `submit`: config snapshot, `submission.csv`, submission metadata JSON, and submission ledgers when present
+  - `refresh-submissions`: config snapshot, submission outcome ledger, and refresh summary JSON
 
 ## Runtime Invariants And Failure Behavior
 - One runtime config source only: local repository-root `config.yaml`
@@ -224,6 +234,8 @@ Manual verification steps for each target:
 - enabled optimization is part of `train`, applies to model candidates only, reuses one prepared training context for scoring and retraining, and retrains exactly one tuned candidate into the normal candidate artifact layout
 - enabled optimization must have at least one stopping condition: `experiment.candidate.optimization.n_trials` or `experiment.candidate.optimization.timeout_seconds`
 - `submit` must resolve one candidate by `candidate_id`, defaulting to `config.experiment.candidate.candidate_id`
+- `submit` must write `submission.csv` for both dry-run and real-submit paths, but only real Kaggle submissions may append `submissions.csv`
+- `refresh-submissions` must scan Kaggle submission history and append only new remote observations for locally tracked `submission_event_id` values
 - `categorical_preprocessor: native` must preserve categorical feature positions through preprocessing so CatBoost can receive `cat_features`
 - Kaggle CLI and authentication are expected to be preconfigured
 - Competition zip contents are expected to include `train.csv`, `test.csv`, and `sample_submission.csv`
@@ -240,6 +252,7 @@ Manual verification steps for each target:
 - `sample_submission.csv` must match the resolved schema exactly as `[id_column, label_column]`
 - The selected candidate artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
 - Submission requires the current candidate prediction layout at `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv`
+- Dry-run submission preparation must not append either submission ledger
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
@@ -288,6 +301,7 @@ Hard-error cases include:
 - Binary probability artifact outside `[0, 1]` for `roc_auc` or `log_loss` -> hard error
 - Binary label artifact containing values outside the observed label pair for `accuracy` -> hard error
 - Kaggle submission command failure when `experiment.submit.enabled=true` -> hard error
+- Kaggle submission-history refresh failure during explicit `refresh-submissions` -> hard error
 
 ## Design Guardrails
 - Keep implementation simple and avoid speculative abstractions.

--- a/main.py
+++ b/main.py
@@ -9,10 +9,11 @@ from tabular_shenanigans.competition import prepare_competition
 from tabular_shenanigans.config import AppConfig, load_config
 from tabular_shenanigans.data import fetch_competition_data, load_competition_dataset_context
 from tabular_shenanigans.eda import run_eda
-from tabular_shenanigans.submit import build_submission_message, run_submission
+from tabular_shenanigans.submit import run_submission, run_submission_refresh
 from tabular_shenanigans.tracking import (
     is_tracking_enabled,
     log_prepare_outputs,
+    log_submission_refresh_outputs,
     log_runtime_config,
     log_submit_outputs,
     log_train_outputs,
@@ -32,6 +33,10 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("prepare", help="Persist EDA reports, competition metadata, and frozen folds.")
     subparsers.add_parser("eda", help="Run EDA reports only.")
     subparsers.add_parser("train", help="Train the current candidate, with optional optimization.")
+    subparsers.add_parser(
+        "refresh-submissions",
+        help="Fetch Kaggle submission outcomes for locally tracked submission events.",
+    )
 
     submit_parser = subparsers.add_parser("submit", help="Prepare or submit from a candidate artifact.")
     submit_parser.add_argument(
@@ -181,22 +186,33 @@ def _run_train_stage_with_tracking(
 def _run_submit_stage(
     config: AppConfig,
     candidate_id: str | None = None,
-) -> tuple[Path, str]:
+):
     resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
     print(f"Using candidate_id: {resolved_candidate_id}")
-    submission_path, submission_status = run_submission(
+    submission_result = run_submission(
         config=config,
         candidate_id=resolved_candidate_id,
     )
-    print(f"Submission file ready: {submission_path} ({submission_status})")
-    return submission_path, submission_status
+    print(f"Submission file ready: {submission_result.submission_path} ({submission_result.submission_status})")
+    if submission_result.submission_event is not None:
+        print(
+            "Submission event recorded: "
+            f"{submission_result.submission_event.submission_event_id}"
+        )
+    if submission_result.submission_refresh_result is not None:
+        print(
+            "Submission score refresh: "
+            f"matched_events={submission_result.submission_refresh_result.matched_submission_event_count}, "
+            f"appended_observations={submission_result.submission_refresh_result.appended_observation_count}"
+        )
+    return submission_result
 
 
 def _run_submit_stage_with_tracking(
     config: AppConfig,
     pipeline_invocation_id: str,
     candidate_id: str | None = None,
-) -> tuple[Path, str]:
+):
     resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
     tracking_context = nullcontext()
     if is_tracking_enabled(config):
@@ -210,27 +226,46 @@ def _run_submit_stage_with_tracking(
     with tracking_context:
         if is_tracking_enabled(config):
             log_runtime_config(config)
-            submission_message = build_submission_message(
-                competition_slug=config.competition.slug,
-                candidate_id=resolved_candidate_id,
-                submit_message_prefix=config.experiment.submit.message_prefix,
-            )
-        else:
-            submission_message = ""
-        submission_path, submission_status = _run_submit_stage(
+        submission_result = _run_submit_stage(
             config=config,
             candidate_id=resolved_candidate_id,
         )
         if is_tracking_enabled(config):
-            log_submit_outputs(
-                competition_slug=config.competition.slug,
-                candidate_id=resolved_candidate_id,
-                submission_path=submission_path,
-                submission_status=submission_status,
-                message=submission_message,
-                submit_enabled=config.experiment.submit.enabled,
-            )
-        return submission_path, submission_status
+            log_submit_outputs(submission_result=submission_result)
+        return submission_result
+
+
+def _run_submission_refresh_stage(config: AppConfig):
+    refresh_result = run_submission_refresh(config)
+    print(
+        "Submission scores refreshed: "
+        f"tracked_events={refresh_result.tracked_submission_event_count}, "
+        f"matched_events={refresh_result.matched_submission_event_count}, "
+        f"appended_observations={refresh_result.appended_observation_count}, "
+        f"scanned_remote_submissions={refresh_result.scanned_remote_submission_count}"
+    )
+    return refresh_result
+
+
+def _run_submission_refresh_stage_with_tracking(
+    config: AppConfig,
+    pipeline_invocation_id: str,
+):
+    tracking_context = nullcontext()
+    if is_tracking_enabled(config):
+        tracking_context = start_stage_run(
+            config=config,
+            stage="refresh-submissions",
+            pipeline_invocation_id=pipeline_invocation_id,
+        )
+
+    with tracking_context:
+        if is_tracking_enabled(config):
+            log_runtime_config(config)
+        refresh_result = _run_submission_refresh_stage(config)
+        if is_tracking_enabled(config):
+            log_submission_refresh_outputs(refresh_result)
+        return refresh_result
 
 
 def _run_full_pipeline(
@@ -280,6 +315,13 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.stage == "train":
         _run_train_stage_with_tracking(
+            config=config,
+            pipeline_invocation_id=pipeline_invocation_id,
+        )
+        return
+
+    if args.stage == "refresh-submissions":
+        _run_submission_refresh_stage_with_tracking(
             config=config,
             pipeline_invocation_id=pipeline_invocation_id,
         )

--- a/src/tabular_shenanigans/candidate_artifacts.py
+++ b/src/tabular_shenanigans/candidate_artifacts.py
@@ -18,6 +18,8 @@ def json_ready(value: object) -> object:
         return [json_ready(item) for item in value]
     if isinstance(value, tuple):
         return [json_ready(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
     if isinstance(value, np.generic):
         return value.item()
     return value

--- a/src/tabular_shenanigans/submission_history.py
+++ b/src/tabular_shenanigans/submission_history.py
@@ -1,0 +1,420 @@
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pandas as pd
+
+SUBMISSION_EVENT_COLUMNS = [
+    "submission_event_id",
+    "submitted_at_utc",
+    "competition_slug",
+    "candidate_id",
+    "candidate_type",
+    "config_fingerprint",
+    "feature_recipe_id",
+    "preprocessing_scheme_id",
+    "model_registry_key",
+    "estimator_name",
+    "cv_metric_name",
+    "cv_metric_mean",
+    "cv_metric_std",
+    "submission_path",
+    "submit_message",
+    "submit_response_message",
+]
+
+SUBMISSION_SCORE_COLUMNS = [
+    "observed_at_utc",
+    "submission_event_id",
+    "competition_slug",
+    "candidate_id",
+    "kaggle_submitted_at",
+    "kaggle_file_name",
+    "kaggle_description",
+    "kaggle_status",
+    "public_score",
+    "private_score",
+    "observation_source",
+]
+
+SUBMISSION_SCORE_DEDUP_COLUMNS = [
+    "submission_event_id",
+    "kaggle_submitted_at",
+    "kaggle_file_name",
+    "kaggle_status",
+    "public_score",
+    "private_score",
+]
+
+SUBMISSION_EVENT_ID_PATTERN = re.compile(r"(?:^|\s\|\s)submit=(?P<submission_event_id>[a-z0-9_-]+)(?:\s\|\s|$)")
+
+
+@dataclass(frozen=True)
+class SubmissionEvent:
+    submission_event_id: str
+    submitted_at_utc: str
+    competition_slug: str
+    candidate_id: str
+    candidate_type: str
+    config_fingerprint: str | None
+    feature_recipe_id: str | None
+    preprocessing_scheme_id: str | None
+    model_registry_key: str
+    estimator_name: str
+    cv_metric_name: str
+    cv_metric_mean: float
+    cv_metric_std: float
+    submission_path: str
+    submit_message: str
+    submit_response_message: str
+
+    def to_row(self) -> dict[str, object]:
+        return {
+            "submission_event_id": self.submission_event_id,
+            "submitted_at_utc": self.submitted_at_utc,
+            "competition_slug": self.competition_slug,
+            "candidate_id": self.candidate_id,
+            "candidate_type": self.candidate_type,
+            "config_fingerprint": self.config_fingerprint,
+            "feature_recipe_id": self.feature_recipe_id,
+            "preprocessing_scheme_id": self.preprocessing_scheme_id,
+            "model_registry_key": self.model_registry_key,
+            "estimator_name": self.estimator_name,
+            "cv_metric_name": self.cv_metric_name,
+            "cv_metric_mean": self.cv_metric_mean,
+            "cv_metric_std": self.cv_metric_std,
+            "submission_path": self.submission_path,
+            "submit_message": self.submit_message,
+            "submit_response_message": self.submit_response_message,
+        }
+
+
+@dataclass(frozen=True)
+class SubmissionScoreObservation:
+    observed_at_utc: str
+    submission_event_id: str
+    competition_slug: str
+    candidate_id: str
+    kaggle_submitted_at: str
+    kaggle_file_name: str
+    kaggle_description: str
+    kaggle_status: str
+    public_score: float | None
+    private_score: float | None
+    observation_source: str
+
+    def to_row(self) -> dict[str, object]:
+        return {
+            "observed_at_utc": self.observed_at_utc,
+            "submission_event_id": self.submission_event_id,
+            "competition_slug": self.competition_slug,
+            "candidate_id": self.candidate_id,
+            "kaggle_submitted_at": self.kaggle_submitted_at,
+            "kaggle_file_name": self.kaggle_file_name,
+            "kaggle_description": self.kaggle_description,
+            "kaggle_status": self.kaggle_status,
+            "public_score": self.public_score,
+            "private_score": self.private_score,
+            "observation_source": self.observation_source,
+        }
+
+
+@dataclass(frozen=True)
+class SubmissionRefreshResult:
+    competition_slug: str
+    submission_score_ledger_path: Path
+    tracked_submission_event_count: int
+    matched_submission_event_count: int
+    appended_observation_count: int
+    scanned_remote_submission_count: int
+    observation_source: str
+
+
+@dataclass(frozen=True)
+class KaggleSubmissionRecord:
+    kaggle_submitted_at: str
+    kaggle_file_name: str
+    kaggle_description: str
+    kaggle_status: str
+    public_score: float | None
+    private_score: float | None
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def make_submission_event_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dt%H%M%S%f")
+    return f"sub_{timestamp}_{uuid4().hex[:6]}"
+
+
+def submission_event_ledger_path(competition_slug: str) -> Path:
+    return Path("artifacts") / competition_slug / "submissions.csv"
+
+
+def submission_score_ledger_path(competition_slug: str) -> Path:
+    return Path("artifacts") / competition_slug / "submission_scores.csv"
+
+
+def extract_submission_event_id(kaggle_description: str) -> str | None:
+    match = SUBMISSION_EVENT_ID_PATTERN.search(kaggle_description)
+    if match is None:
+        return None
+    return match.group("submission_event_id")
+
+
+def _read_ledger(ledger_path: Path, required_columns: list[str]) -> pd.DataFrame:
+    ledger_df = pd.read_csv(ledger_path)
+    missing_columns = [column for column in required_columns if column not in ledger_df.columns]
+    if missing_columns:
+        raise ValueError(
+            f"Ledger {ledger_path} is missing required columns {missing_columns}. "
+            f"Present columns: {ledger_df.columns.tolist()}"
+        )
+    return ledger_df
+
+
+def _merged_columns(*column_groups: list[str]) -> list[str]:
+    merged_columns: list[str] = []
+    for group in column_groups:
+        for column in group:
+            if column not in merged_columns:
+                merged_columns.append(column)
+    return merged_columns
+
+
+def _write_ledger_rows(
+    ledger_path: Path,
+    required_columns: list[str],
+    row_dicts: list[dict[str, object]],
+) -> None:
+    row_df = pd.DataFrame(row_dicts)
+    if ledger_path.exists():
+        existing_df = _read_ledger(ledger_path=ledger_path, required_columns=required_columns)
+        merged_columns = _merged_columns(existing_df.columns.tolist(), required_columns, row_df.columns.tolist())
+        combined_df = pd.concat(
+            [
+                existing_df.reindex(columns=merged_columns),
+                row_df.reindex(columns=merged_columns),
+            ],
+            ignore_index=True,
+            sort=False,
+        )
+        combined_df.to_csv(ledger_path, index=False)
+        return
+
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    merged_columns = _merged_columns(required_columns, row_df.columns.tolist())
+    row_df.reindex(columns=merged_columns).to_csv(ledger_path, index=False)
+
+
+def append_submission_event(submission_event: SubmissionEvent) -> Path:
+    ledger_path = submission_event_ledger_path(submission_event.competition_slug)
+    if ledger_path.exists():
+        existing_df = _read_ledger(ledger_path=ledger_path, required_columns=SUBMISSION_EVENT_COLUMNS)
+        existing_event_ids = set(existing_df["submission_event_id"].astype(str))
+        if submission_event.submission_event_id in existing_event_ids:
+            raise ValueError(
+                "Submission ledger already contains submission_event_id "
+                f"'{submission_event.submission_event_id}'."
+            )
+    _write_ledger_rows(
+        ledger_path=ledger_path,
+        required_columns=SUBMISSION_EVENT_COLUMNS,
+        row_dicts=[submission_event.to_row()],
+    )
+    return ledger_path
+
+
+def _row_signature(row: dict[str, object], signature_columns: list[str]) -> tuple[object, ...]:
+    normalized_values: list[object] = []
+    for column in signature_columns:
+        value = row.get(column)
+        if pd.isna(value):
+            normalized_values.append(None)
+            continue
+        normalized_values.append(value)
+    return tuple(normalized_values)
+
+
+def append_submission_score_observations(
+    competition_slug: str,
+    observations: list[SubmissionScoreObservation],
+) -> tuple[Path, int]:
+    ledger_path = submission_score_ledger_path(competition_slug)
+    if not observations:
+        return ledger_path, 0
+
+    existing_signatures: set[tuple[object, ...]] = set()
+    if ledger_path.exists():
+        existing_df = _read_ledger(ledger_path=ledger_path, required_columns=SUBMISSION_SCORE_COLUMNS)
+        for row in existing_df[SUBMISSION_SCORE_DEDUP_COLUMNS].to_dict(orient="records"):
+            existing_signatures.add(_row_signature(row, SUBMISSION_SCORE_DEDUP_COLUMNS))
+
+    new_rows: list[dict[str, object]] = []
+    for observation in observations:
+        row = observation.to_row()
+        row_signature = _row_signature(row, SUBMISSION_SCORE_DEDUP_COLUMNS)
+        if row_signature in existing_signatures:
+            continue
+        existing_signatures.add(row_signature)
+        new_rows.append(row)
+
+    if not new_rows:
+        return ledger_path, 0
+
+    _write_ledger_rows(
+        ledger_path=ledger_path,
+        required_columns=SUBMISSION_SCORE_COLUMNS,
+        row_dicts=new_rows,
+    )
+    return ledger_path, len(new_rows)
+
+
+def _parse_optional_float(raw_value: object) -> float | None:
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, str):
+        normalized = raw_value.strip()
+        if normalized == "" or normalized.lower() in {"none", "nan"}:
+            return None
+        return float(normalized)
+    return float(raw_value)
+
+
+def _iter_kaggle_submissions(competition_slug: str, page_size: int = 100):
+    try:
+        from kaggle.api.kaggle_api_extended import KaggleApi
+        from kagglesdk.competitions.types.competition_api_service import ApiListSubmissionsRequest
+        from kagglesdk.competitions.types.competition_enums import SubmissionGroup, SubmissionSortBy
+    except ImportError as exc:
+        raise ImportError(
+            "Submission refresh requires the Kaggle CLI Python package and its SDK dependencies."
+        ) from exc
+
+    api = KaggleApi()
+    api.authenticate()
+    page_token = ""
+
+    with api.build_kaggle_client() as kaggle:
+        while True:
+            request = ApiListSubmissionsRequest()
+            request.competition_name = competition_slug
+            request.group = SubmissionGroup.SUBMISSION_GROUP_ALL
+            request.sort_by = SubmissionSortBy.SUBMISSION_SORT_BY_DATE
+            request.page = -1
+            request.page_token = page_token
+            request.page_size = page_size
+
+            response = kaggle.competitions.competition_api_client.list_submissions(request)
+            submissions = getattr(response, "submissions", None) or []
+            for submission in submissions:
+                yield KaggleSubmissionRecord(
+                    kaggle_submitted_at=str(getattr(submission, "date", "") or ""),
+                    kaggle_file_name=str(getattr(submission, "file_name", "") or ""),
+                    kaggle_description=str(getattr(submission, "description", "") or ""),
+                    kaggle_status=str(getattr(submission, "status", "") or ""),
+                    public_score=_parse_optional_float(getattr(submission, "public_score", None)),
+                    private_score=_parse_optional_float(getattr(submission, "private_score", None)),
+                )
+
+            next_page_token = str(getattr(response, "next_page_token", "") or "")
+            if not next_page_token:
+                return
+            page_token = next_page_token
+
+
+def refresh_submission_scores(
+    competition_slug: str,
+    target_submission_event_ids: set[str] | None = None,
+    observation_source: str = "refresh_submissions",
+) -> SubmissionRefreshResult:
+    event_ledger_path = submission_event_ledger_path(competition_slug)
+    score_ledger_path = submission_score_ledger_path(competition_slug)
+    if not event_ledger_path.exists():
+        return SubmissionRefreshResult(
+            competition_slug=competition_slug,
+            submission_score_ledger_path=score_ledger_path,
+            tracked_submission_event_count=0,
+            matched_submission_event_count=0,
+            appended_observation_count=0,
+            scanned_remote_submission_count=0,
+            observation_source=observation_source,
+        )
+
+    submission_event_df = _read_ledger(
+        ledger_path=event_ledger_path,
+        required_columns=SUBMISSION_EVENT_COLUMNS,
+    )
+    submission_events_by_id = {
+        str(row["submission_event_id"]): row
+        for row in submission_event_df.to_dict(orient="records")
+    }
+    tracked_submission_event_ids = set(submission_events_by_id)
+    if target_submission_event_ids is not None:
+        unknown_submission_event_ids = sorted(target_submission_event_ids - tracked_submission_event_ids)
+        if unknown_submission_event_ids:
+            raise ValueError(
+                "Submission refresh got unknown submission_event_id values. "
+                f"Unknown IDs: {unknown_submission_event_ids}"
+            )
+        tracked_submission_event_ids = set(target_submission_event_ids)
+
+    if not tracked_submission_event_ids:
+        return SubmissionRefreshResult(
+            competition_slug=competition_slug,
+            submission_score_ledger_path=score_ledger_path,
+            tracked_submission_event_count=0,
+            matched_submission_event_count=0,
+            appended_observation_count=0,
+            scanned_remote_submission_count=0,
+            observation_source=observation_source,
+        )
+
+    observed_at_utc = utc_now_iso()
+    matched_submission_event_ids: set[str] = set()
+    scanned_remote_submission_count = 0
+    observations: list[SubmissionScoreObservation] = []
+
+    for kaggle_submission in _iter_kaggle_submissions(competition_slug=competition_slug):
+        scanned_remote_submission_count += 1
+        submission_event_id = extract_submission_event_id(kaggle_submission.kaggle_description)
+        if submission_event_id is None or submission_event_id not in tracked_submission_event_ids:
+            continue
+
+        event_row = submission_events_by_id[submission_event_id]
+        matched_submission_event_ids.add(submission_event_id)
+        observations.append(
+            SubmissionScoreObservation(
+                observed_at_utc=observed_at_utc,
+                submission_event_id=submission_event_id,
+                competition_slug=competition_slug,
+                candidate_id=str(event_row["candidate_id"]),
+                kaggle_submitted_at=kaggle_submission.kaggle_submitted_at,
+                kaggle_file_name=kaggle_submission.kaggle_file_name,
+                kaggle_description=kaggle_submission.kaggle_description,
+                kaggle_status=kaggle_submission.kaggle_status,
+                public_score=kaggle_submission.public_score,
+                private_score=kaggle_submission.private_score,
+                observation_source=observation_source,
+            )
+        )
+        if target_submission_event_ids is not None and matched_submission_event_ids == tracked_submission_event_ids:
+            break
+
+    _, appended_observation_count = append_submission_score_observations(
+        competition_slug=competition_slug,
+        observations=observations,
+    )
+    return SubmissionRefreshResult(
+        competition_slug=competition_slug,
+        submission_score_ledger_path=score_ledger_path,
+        tracked_submission_event_count=len(tracked_submission_event_ids),
+        matched_submission_event_count=len(matched_submission_event_ids),
+        appended_observation_count=appended_observation_count,
+        scanned_remote_submission_count=scanned_remote_submission_count,
+        observation_source=observation_source,
+    )

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -1,6 +1,5 @@
 import subprocess
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -12,31 +11,30 @@ from tabular_shenanigans.candidate_artifacts import (
 )
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.data import get_binary_prediction_kind, load_sample_submission_template, validate_sample_submission_schema
-
-SUBMISSION_LEDGER_COLUMNS = [
-    "timestamp_utc",
-    "competition_slug",
-    "candidate_id",
-    "model_registry_key",
-    "estimator_name",
-    "config_fingerprint",
-    "submission_path",
-    "submit_enabled",
-    "status",
-    "message",
-]
+from tabular_shenanigans.submission_history import (
+    SubmissionEvent,
+    SubmissionRefreshResult,
+    append_submission_event,
+    make_submission_event_id,
+    refresh_submission_scores,
+    utc_now_iso,
+)
 
 
 @dataclass(frozen=True)
 class SubmissionContext:
     candidate_id: str
+    candidate_type: str
     competition_slug: str
     task_type: str
     primary_metric: str
+    feature_recipe_id: str | None
+    preprocessing_scheme_id: str | None
     model_registry_key: str
     estimator_name: str
-    metric_name: str
-    metric_mean: float
+    cv_metric_name: str
+    cv_metric_mean: float
+    cv_metric_std: float
     id_column: str
     label_column: str
     observed_label_pair: tuple[object, object] | None
@@ -44,30 +42,16 @@ class SubmissionContext:
     prediction_path: Path
 
 
-def _submission_ledger_path(competition_slug: str) -> Path:
-    return Path("artifacts") / competition_slug / "submissions.csv"
+@dataclass(frozen=True)
+class SubmissionRunResult:
+    submission_path: Path
+    submission_status: str
+    submission_message: str
+    submission_event: SubmissionEvent | None
+    submission_event_ledger_path: Path | None
+    submission_refresh_result: SubmissionRefreshResult | None
+    immediate_refresh_error: str | None = None
 
-
-def _read_submission_ledger(ledger_path: Path) -> pd.DataFrame:
-    ledger_df = pd.read_csv(ledger_path)
-    ledger_columns = ledger_df.columns.tolist()
-    if ledger_columns != SUBMISSION_LEDGER_COLUMNS:
-        raise ValueError(
-            "Submission ledger does not match the supported schema. "
-            f"Expected columns {SUBMISSION_LEDGER_COLUMNS}, got {ledger_columns}"
-        )
-    return ledger_df
-
-
-def _append_submission_ledger(ledger_path: Path, row: dict[str, object]) -> None:
-    ledger_df = pd.DataFrame([row]).reindex(columns=SUBMISSION_LEDGER_COLUMNS)
-    if ledger_path.exists():
-        existing_df = _read_submission_ledger(ledger_path)
-        merged_df = pd.concat([existing_df, ledger_df], ignore_index=True, sort=False)
-        merged_df = merged_df.reindex(columns=SUBMISSION_LEDGER_COLUMNS)
-        merged_df.to_csv(ledger_path, index=False)
-        return
-    ledger_df.to_csv(ledger_path, index=False)
 
 def _require_manifest_value(manifest: dict[str, object], field_name: str) -> object:
     field_value = manifest.get(field_name)
@@ -113,13 +97,25 @@ def _load_submission_context(
 
     return SubmissionContext(
         candidate_id=str(_require_manifest_value(candidate_manifest, "candidate_id")),
+        candidate_type=str(_require_manifest_value(candidate_manifest, "candidate_type")),
         competition_slug=str(_require_manifest_value(candidate_manifest, "competition_slug")),
         task_type=str(_require_manifest_value(candidate_manifest, "task_type")),
         primary_metric=str(_require_manifest_value(candidate_manifest, "primary_metric")),
+        feature_recipe_id=(
+            str(candidate_manifest["feature_recipe_id"])
+            if candidate_manifest.get("feature_recipe_id") is not None
+            else None
+        ),
+        preprocessing_scheme_id=(
+            str(candidate_manifest["preprocessing_scheme_id"])
+            if candidate_manifest.get("preprocessing_scheme_id") is not None
+            else None
+        ),
         model_registry_key=str(_require_manifest_value(candidate_manifest, "model_registry_key")),
         estimator_name=str(_require_manifest_value(candidate_manifest, "estimator_name")),
-        metric_name=str(cv_summary["metric_name"]),
-        metric_mean=float(cv_summary["metric_mean"]),
+        cv_metric_name=str(cv_summary["metric_name"]),
+        cv_metric_mean=float(cv_summary["metric_mean"]),
+        cv_metric_std=float(cv_summary["metric_std"]),
         id_column=str(_require_manifest_value(candidate_manifest, "id_column")),
         label_column=str(_require_manifest_value(candidate_manifest, "label_column")),
         observed_label_pair=_parse_observed_label_pair(candidate_manifest),
@@ -272,32 +268,31 @@ def prepare_submission_file(
 
 def _build_submission_message_from_context(
     submission_context: SubmissionContext,
+    submission_event_id: str,
     submit_message_prefix: str | None = None,
 ) -> str:
     message_parts = []
     if submit_message_prefix:
         message_parts.append(submit_message_prefix.strip())
     message_parts.append(f"candidate={submission_context.candidate_id}")
-    message_parts.append(f"{submission_context.metric_name}={submission_context.metric_mean:.6f}")
+    message_parts.append(f"submit={submission_event_id}")
+    message_parts.append(f"{submission_context.cv_metric_name}={submission_context.cv_metric_mean:.6f}")
     return " | ".join(message_parts)
 
 
-def build_submission_message(
-    competition_slug: str,
-    candidate_id: str,
-    submit_message_prefix: str | None = None,
-) -> str:
-    submission_context = _load_submission_context(
-        competition_slug=competition_slug,
-        candidate_id=candidate_id,
-    )
-    return _build_submission_message_from_context(submission_context, submit_message_prefix=submit_message_prefix)
+def _collect_submit_response_message(completed: subprocess.CompletedProcess[str]) -> str:
+    response_parts = []
+    if completed.stdout.strip():
+        response_parts.append(completed.stdout.strip())
+    if completed.stderr.strip():
+        response_parts.append(completed.stderr.strip())
+    return "\n".join(response_parts)
 
 
 def run_submission(
     config: AppConfig,
     candidate_id: str | None = None,
-) -> tuple[Path, str]:
+) -> SubmissionRunResult:
     competition = config.competition
     candidate = config.experiment.candidate
     submit_config = config.experiment.submit
@@ -307,12 +302,14 @@ def run_submission(
         candidate_id=resolved_candidate_id,
     )
     submission_path = _prepare_submission_file_from_context(submission_context)
-    message = _build_submission_message_from_context(
-        submission_context,
-        submit_message_prefix=submit_config.message_prefix,
-    )
 
     if submit_config.enabled:
+        submission_event_id = make_submission_event_id()
+        submission_message = _build_submission_message_from_context(
+            submission_context,
+            submission_event_id=submission_event_id,
+            submit_message_prefix=submit_config.message_prefix,
+        )
         completed = subprocess.run(
             [
                 "kaggle",
@@ -323,7 +320,7 @@ def run_submission(
                 "-f",
                 str(submission_path),
                 "-m",
-                message,
+                submission_message,
             ],
             check=True,
             capture_output=True,
@@ -333,23 +330,66 @@ def run_submission(
             print(completed.stdout.strip())
         if completed.stderr.strip():
             print(completed.stderr.strip())
-        status = "submitted"
-    else:
-        print("Submission dry-run mode: validation complete, Kaggle submit skipped.")
-        status = "prepared"
+        submit_response_message = _collect_submit_response_message(completed)
+        submission_event = SubmissionEvent(
+            submission_event_id=submission_event_id,
+            submitted_at_utc=utc_now_iso(),
+            competition_slug=submission_context.competition_slug,
+            candidate_id=submission_context.candidate_id,
+            candidate_type=submission_context.candidate_type,
+            config_fingerprint=submission_context.config_fingerprint,
+            feature_recipe_id=submission_context.feature_recipe_id,
+            preprocessing_scheme_id=submission_context.preprocessing_scheme_id,
+            model_registry_key=submission_context.model_registry_key,
+            estimator_name=submission_context.estimator_name,
+            cv_metric_name=submission_context.cv_metric_name,
+            cv_metric_mean=submission_context.cv_metric_mean,
+            cv_metric_std=submission_context.cv_metric_std,
+            submission_path=str(submission_path),
+            submit_message=submission_message,
+            submit_response_message=submit_response_message,
+        )
+        submission_event_ledger_path = append_submission_event(submission_event)
+        immediate_refresh_error = None
+        try:
+            # The Kaggle submit already succeeded; avoid turning a refresh problem into a
+            # misleading stage failure that encourages a duplicate external submission.
+            submission_refresh_result = refresh_submission_scores(
+                competition_slug=submission_context.competition_slug,
+                target_submission_event_ids={submission_event_id},
+                observation_source="submit_immediate_refresh",
+            )
+        except Exception as exc:
+            immediate_refresh_error = str(exc)
+            submission_refresh_result = None
+            print(
+                "Immediate submission score refresh failed after a successful Kaggle submission. "
+                "Run `uv run python main.py refresh-submissions` later. "
+                f"Original error: {exc}"
+            )
+        return SubmissionRunResult(
+            submission_path=submission_path,
+            submission_status="submitted",
+            submission_message=submission_message,
+            submission_event=submission_event,
+            submission_event_ledger_path=submission_event_ledger_path,
+            submission_refresh_result=submission_refresh_result,
+            immediate_refresh_error=immediate_refresh_error,
+        )
 
-    ledger_row = {
-        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-        "competition_slug": submission_context.competition_slug,
-        "candidate_id": submission_context.candidate_id,
-        "model_registry_key": submission_context.model_registry_key,
-        "estimator_name": submission_context.estimator_name,
-        "config_fingerprint": submission_context.config_fingerprint,
-        "submission_path": str(submission_path),
-        "submit_enabled": submit_config.enabled,
-        "status": status,
-        "message": message,
-    }
-    ledger_path = _submission_ledger_path(submission_context.competition_slug)
-    _append_submission_ledger(ledger_path=ledger_path, row=ledger_row)
-    return submission_path, status
+    print("Submission dry-run mode: validation complete, Kaggle submit skipped.")
+    return SubmissionRunResult(
+        submission_path=submission_path,
+        submission_status="prepared",
+        submission_message="",
+        submission_event=None,
+        submission_event_ledger_path=None,
+        submission_refresh_result=None,
+    )
+
+
+def run_submission_refresh(config: AppConfig) -> SubmissionRefreshResult:
+    return refresh_submission_scores(
+        competition_slug=config.competition.slug,
+        observation_source="manual_refresh",
+    )

--- a/src/tabular_shenanigans/tracking.py
+++ b/src/tabular_shenanigans/tracking.py
@@ -1,11 +1,13 @@
 import json
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-from tabular_shenanigans.candidate_artifacts import load_candidate_manifest
+from tabular_shenanigans.candidate_artifacts import json_ready, load_candidate_manifest
 from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.submission_history import SubmissionRefreshResult
 
 
 def is_tracking_enabled(config: AppConfig) -> bool:
@@ -157,15 +159,9 @@ def log_train_outputs(candidate_dir: Path) -> None:
     mlflow.log_artifacts(str(candidate_dir), "candidate")
 
 
-def log_submit_outputs(
-    competition_slug: str,
-    candidate_id: str,
-    submission_path: Path,
-    submission_status: str,
-    message: str,
-    submit_enabled: bool,
-) -> None:
+def log_submit_outputs(submission_result) -> None:
     mlflow = _load_mlflow()
+    submission_path = submission_result.submission_path
     candidate_dir = submission_path.parent
     manifest = load_candidate_manifest(candidate_dir_path=candidate_dir)
     cv_summary = manifest.get("cv_summary")
@@ -173,31 +169,75 @@ def log_submit_outputs(
         raise ValueError(f"Candidate manifest cv_summary must be a mapping: {candidate_dir / 'candidate.json'}")
 
     submit_tags = {
-        "competition_slug": competition_slug,
-        "candidate_id": candidate_id,
+        "competition_slug": manifest.get("competition_slug"),
+        "candidate_id": manifest.get("candidate_id"),
         "candidate_type": manifest.get("candidate_type"),
         "config_fingerprint": manifest.get("config_fingerprint"),
         "model_registry_key": manifest.get("model_registry_key"),
         "estimator_name": manifest.get("estimator_name"),
-        "submission_status": submission_status,
+        "submission_status": submission_result.submission_status,
         "cv_metric_name": cv_summary.get("metric_name"),
     }
+    if submission_result.submission_event is not None:
+        submit_tags["submission_event_id"] = submission_result.submission_event.submission_event_id
     mlflow.set_tags(_coerce_tags(submit_tags))
     if cv_summary.get("metric_mean") is not None:
         mlflow.log_metric("candidate_cv_metric_mean", float(cv_summary["metric_mean"]))
     if cv_summary.get("metric_std") is not None:
         mlflow.log_metric("candidate_cv_metric_std", float(cv_summary["metric_std"]))
+    if submission_result.submission_refresh_result is not None:
+        mlflow.log_metric(
+            "submit_refresh_appended_observation_count",
+            float(submission_result.submission_refresh_result.appended_observation_count),
+        )
+        mlflow.log_metric(
+            "submit_refresh_matched_submission_event_count",
+            float(submission_result.submission_refresh_result.matched_submission_event_count),
+        )
 
-    submission_event = {
-        "competition_slug": competition_slug,
-        "candidate_id": candidate_id,
-        "model_registry_key": manifest.get("model_registry_key"),
-        "estimator_name": manifest.get("estimator_name"),
-        "config_fingerprint": manifest.get("config_fingerprint"),
+    submit_summary = {
+        "competition_slug": manifest.get("competition_slug"),
+        "candidate_id": manifest.get("candidate_id"),
         "submission_filename": submission_path.name,
-        "submit_enabled": submit_enabled,
-        "status": submission_status,
-        "message": message,
+        "submission_status": submission_result.submission_status,
+        "submission_message": submission_result.submission_message,
+        "immediate_refresh_error": submission_result.immediate_refresh_error,
     }
     mlflow.log_artifact(str(submission_path), "submission")
-    mlflow.log_dict(submission_event, "submission/submission_event.json")
+    if (
+        submission_result.submission_event_ledger_path is not None
+        and submission_result.submission_event_ledger_path.exists()
+    ):
+        mlflow.log_artifact(str(submission_result.submission_event_ledger_path), "submission")
+    if (
+        submission_result.submission_refresh_result is not None
+        and submission_result.submission_refresh_result.submission_score_ledger_path.exists()
+    ):
+        mlflow.log_artifact(str(submission_result.submission_refresh_result.submission_score_ledger_path), "submission")
+    if submission_result.submission_event is not None:
+        mlflow.log_dict(json_ready(asdict(submission_result.submission_event)), "submission/submission_event.json")
+    if submission_result.submission_refresh_result is not None:
+        mlflow.log_dict(json_ready(asdict(submission_result.submission_refresh_result)), "submission/submission_refresh.json")
+    mlflow.log_dict(submit_summary, "submission/submission_summary.json")
+
+
+def log_submission_refresh_outputs(refresh_result: SubmissionRefreshResult) -> None:
+    mlflow = _load_mlflow()
+    mlflow.set_tags(
+        _coerce_tags(
+            {
+                "competition_slug": refresh_result.competition_slug,
+                "submission_refresh_observation_source": refresh_result.observation_source,
+            }
+        )
+    )
+    mlflow.log_metric("tracked_submission_event_count", float(refresh_result.tracked_submission_event_count))
+    mlflow.log_metric("matched_submission_event_count", float(refresh_result.matched_submission_event_count))
+    mlflow.log_metric("appended_submission_score_count", float(refresh_result.appended_observation_count))
+    mlflow.log_metric("scanned_remote_submission_count", float(refresh_result.scanned_remote_submission_count))
+    if refresh_result.submission_score_ledger_path.exists():
+        mlflow.log_artifact(str(refresh_result.submission_score_ledger_path), "submission_refresh")
+    mlflow.log_dict(
+        json_ready(asdict(refresh_result)),
+        "submission_refresh/submission_refresh.json",
+    )


### PR DESCRIPTION
Closes #15

## Summary
- split submission history into append-only local submission event and remote outcome ledgers
- add a refresh-submissions stage and immediate post-submit outcome refresh using submission_event_id matching
- upload the new submission history artifacts through tracking and document the current contract

## Verification
- PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/candidate_artifacts.py src/tabular_shenanigans/submit.py src/tabular_shenanigans/submission_history.py src/tabular_shenanigans/tracking.py
- focused synthetic smoke run covering dry-run submit, real submit with fake Kaggle boundary, idempotent refresh, and updated remote score append behavior