### PR TITLE
Validate regression submission artifacts (#68)

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -253,6 +253,7 @@ Manual verification steps for each target:
 - The selected candidate artifact `test_predictions.csv[id_column]` must match `sample_submission.csv[id_column]` exactly in both values and row order
 - Submission requires the current candidate prediction layout at `artifacts/<competition_slug>/candidates/<candidate_id>/test_predictions.csv`
 - Dry-run submission preparation must not append either submission ledger
+- Regression submission artifacts must be numeric, non-missing, and finite before `submission.csv` is written
 - Feature override columns must exist and cannot overlap between forced numeric and forced categorical sets
 - Configured metric must normalize to a supported metric compatible with the configured task type
 - CV splitter construction must support both `cv_shuffle=true` and `cv_shuffle=false`
@@ -298,6 +299,7 @@ Hard-error cases include:
 - Missing configured candidate artifacts at submit time -> hard error
 - Requested `candidate_id` with no matching candidate artifact directory -> hard error
 - Submission schema or ID mismatch against `sample_submission.csv` -> hard error
+- Regression submission artifact with non-numeric, missing, `inf`, or `-inf` values -> hard error
 - Binary probability artifact outside `[0, 1]` for `roc_auc` or `log_loss` -> hard error
 - Binary label artifact containing values outside the observed label pair for `accuracy` -> hard error
 - Kaggle submission command failure when `experiment.submit.enabled=true` -> hard error

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -211,6 +211,15 @@ def _validate_binary_label_predictions(
         )
 
 
+def _validate_regression_predictions(prediction_values: pd.Series) -> None:
+    if not pd.api.types.is_numeric_dtype(prediction_values):
+        raise ValueError("Regression submissions must be numeric.")
+    if not prediction_values.map(pd.notna).all():
+        raise ValueError("Regression submissions contain missing values.")
+    if not np.isfinite(prediction_values.to_numpy(dtype=float)).all():
+        raise ValueError("Regression submissions must be finite.")
+
+
 def _prepare_submission_file_from_context(submission_context: SubmissionContext) -> Path:
     prediction_df = pd.read_csv(submission_context.prediction_path)
     sample_submission_df = load_sample_submission_template(submission_context.competition_slug)
@@ -233,8 +242,10 @@ def _prepare_submission_file_from_context(submission_context: SubmissionContext)
             f"Expected {sample_submission_df.shape[0]}, got {prediction_df.shape[0]}"
         )
 
-    if submission_context.task_type == "binary":
-        prediction_values = prediction_df[submission_context.label_column]
+    prediction_values = prediction_df[submission_context.label_column]
+    if submission_context.task_type == "regression":
+        _validate_regression_predictions(prediction_values)
+    elif submission_context.task_type == "binary":
         binary_prediction_kind = get_binary_prediction_kind(submission_context.primary_metric)
         if binary_prediction_kind == "probability":
             _validate_binary_probability_predictions(prediction_values)


### PR DESCRIPTION
Closes #68

## Summary
- add regression-specific submission validation for numeric dtype, missing values, and finiteness
- keep existing schema, row-count, ID, and binary submission validation behavior unchanged
- document the new regression submission invariant in the technical guide

## Verification
- PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/submit.py
- focused synthetic smoke run covering valid regression output, regression NaN/inf/non-numeric failures before write, and unchanged binary submission preparation