### PR TITLE
Isolate tracking orchestration (#111)

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -43,7 +43,7 @@ The intended operating scope is Kaggle Playground Series tabular competitions. C
 The default `submit` path supports current candidate artifacts only. Unsupported or missing candidate artifacts fail directly.
 
 ## Module Responsibilities
-- `main.py`: orchestration entrypoint for config loading plus stage-specific CLI dispatch across fetch, prepare, EDA, training, submission, and submission refresh.
+- `main.py`: orchestration entrypoint for config loading plus thin stage-specific CLI dispatch across fetch, prepare, EDA, training, submission, and submission refresh.
 - `src/tabular_shenanigans/competition.py`: competition-level preparation, `competition.json` persistence, `folds.csv` persistence, prepared-context validation, and split reconstruction from frozen folds.
 - `src/tabular_shenanigans/config.py`: Pydantic-backed nested config schema for `competition` plus `experiment`, metric normalization, candidate-to-model resolution, runtime contract validation, and a small set of derived helpers on `AppConfig`.
 - `src/tabular_shenanigans/candidate_artifacts.py`: shared candidate artifact path resolution, manifest loading, config fingerprint helpers, target-summary generation, and common candidate file writing.
@@ -59,7 +59,7 @@ The default `submit` path supports current candidate artifacts only. Unsupported
 - `src/tabular_shenanigans/tune.py`: internal Optuna orchestration used by `train` when candidate optimization is enabled, consuming the shared prepared training context and shared evaluation functions.
 - `src/tabular_shenanigans/submit.py`: submission schema validation, candidate selection by `candidate_id`, submission message creation, Kaggle submission, and stage-level submission orchestration.
 - `src/tabular_shenanigans/submission_history.py`: append-only submission event and outcome ledger helpers, `submission_event_id` generation, Kaggle submission-history refresh, and duplicate-observation suppression.
-- `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, tag/metric logging, config snapshot logging, and post-stage artifact publishing using the shared candidate manifest and submission-history contracts.
+- `src/tabular_shenanigans/tracking.py`: optional MLflow run creation, shared tracked-stage orchestration, tag/metric logging, config snapshot logging, and post-stage artifact publishing using the shared candidate manifest and submission-history contracts.
 
 ## Configuration Contract
 Input:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import argparse
 import sys
-from contextlib import nullcontext
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
@@ -11,14 +10,13 @@ from tabular_shenanigans.data import fetch_competition_data, load_competition_da
 from tabular_shenanigans.eda import run_eda
 from tabular_shenanigans.submit import run_submission, run_submission_refresh
 from tabular_shenanigans.tracking import (
-    is_tracking_enabled,
-    log_prepare_outputs,
+    build_train_tracking_tags,
+    log_prepare_stage_outputs,
     log_submission_refresh_outputs,
-    log_runtime_config,
     log_submit_outputs,
     log_train_outputs,
     make_pipeline_invocation_id,
-    start_stage_run,
+    run_stage_with_tracking,
 )
 from tabular_shenanigans.train import run_training_workflow
 
@@ -101,46 +99,6 @@ def _prepare_competition_stage(config: AppConfig):
     return dataset_context, prepared_context
 
 
-def _build_train_tracking_tags(config: AppConfig) -> dict[str, object]:
-    candidate = config.experiment.candidate
-    tags: dict[str, object] = {
-        "candidate_id": candidate.candidate_id,
-        "candidate_type": candidate.candidate_type,
-    }
-    if config.is_model_candidate:
-        tags["model_registry_key"] = config.resolved_model_registry_key
-        tags["model_family"] = candidate.model_family
-        tags["feature_recipe_id"] = candidate.feature_recipe_id
-        tags["numeric_preprocessor"] = candidate.numeric_preprocessor
-        tags["categorical_preprocessor"] = candidate.categorical_preprocessor
-        tags["preprocessing_scheme_id"] = candidate.preprocessing_scheme_id
-        return tags
-
-    tags["base_candidate_count"] = len(candidate.base_candidate_ids)
-    return tags
-
-
-def _run_prepare_stage_with_tracking(
-    config: AppConfig,
-    pipeline_invocation_id: str,
-):
-    tracking_context = nullcontext()
-    if is_tracking_enabled(config):
-        tracking_context = start_stage_run(
-            config=config,
-            stage="prepare",
-            pipeline_invocation_id=pipeline_invocation_id,
-        )
-
-    with tracking_context:
-        if is_tracking_enabled(config):
-            log_runtime_config(config)
-        dataset_context, prepared_context = _prepare_competition_stage(config)
-        if is_tracking_enabled(config):
-            log_prepare_outputs(prepared_context)
-        return dataset_context, prepared_context
-
-
 def _run_eda_stage(config: AppConfig) -> None:
     _ensure_data_ready(config)
     dataset_context = _load_shared_dataset_context(config)
@@ -158,29 +116,6 @@ def _run_train_stage(
     candidate_dir = run_training_workflow(config=config, dataset_context=dataset_context)
     print(f"Candidate artifacts ready: {candidate_dir}")
     return candidate_dir
-
-
-def _run_train_stage_with_tracking(
-    config: AppConfig,
-    pipeline_invocation_id: str,
-    dataset_context=None,
-):
-    tracking_context = nullcontext()
-    if is_tracking_enabled(config):
-        tracking_context = start_stage_run(
-            config=config,
-            stage="train",
-            pipeline_invocation_id=pipeline_invocation_id,
-            extra_tags=_build_train_tracking_tags(config),
-        )
-
-    with tracking_context:
-        if is_tracking_enabled(config):
-            log_runtime_config(config)
-        candidate_dir = _run_train_stage(config=config, dataset_context=dataset_context)
-        if is_tracking_enabled(config):
-            log_train_outputs(candidate_dir=candidate_dir)
-        return candidate_dir
 
 
 def _run_submit_stage(
@@ -208,33 +143,6 @@ def _run_submit_stage(
     return submission_result
 
 
-def _run_submit_stage_with_tracking(
-    config: AppConfig,
-    pipeline_invocation_id: str,
-    candidate_id: str | None = None,
-):
-    resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
-    tracking_context = nullcontext()
-    if is_tracking_enabled(config):
-        tracking_context = start_stage_run(
-            config=config,
-            stage="submit",
-            pipeline_invocation_id=pipeline_invocation_id,
-            extra_tags={"candidate_id": resolved_candidate_id},
-        )
-
-    with tracking_context:
-        if is_tracking_enabled(config):
-            log_runtime_config(config)
-        submission_result = _run_submit_stage(
-            config=config,
-            candidate_id=resolved_candidate_id,
-        )
-        if is_tracking_enabled(config):
-            log_submit_outputs(submission_result=submission_result)
-        return submission_result
-
-
 def _run_submission_refresh_stage(config: AppConfig):
     refresh_result = run_submission_refresh(config)
     print(
@@ -247,43 +155,32 @@ def _run_submission_refresh_stage(config: AppConfig):
     return refresh_result
 
 
-def _run_submission_refresh_stage_with_tracking(
-    config: AppConfig,
-    pipeline_invocation_id: str,
-):
-    tracking_context = nullcontext()
-    if is_tracking_enabled(config):
-        tracking_context = start_stage_run(
-            config=config,
-            stage="refresh-submissions",
-            pipeline_invocation_id=pipeline_invocation_id,
-        )
-
-    with tracking_context:
-        if is_tracking_enabled(config):
-            log_runtime_config(config)
-        refresh_result = _run_submission_refresh_stage(config)
-        if is_tracking_enabled(config):
-            log_submission_refresh_outputs(refresh_result)
-        return refresh_result
-
-
 def _run_full_pipeline(
     config: AppConfig,
     pipeline_invocation_id: str,
 ) -> None:
-    dataset_context, _ = _run_prepare_stage_with_tracking(
+    dataset_context, _ = run_stage_with_tracking(
         config=config,
+        stage="prepare",
         pipeline_invocation_id=pipeline_invocation_id,
+        stage_fn=lambda: _prepare_competition_stage(config),
+        result_logger=log_prepare_stage_outputs,
     )
-    _run_train_stage_with_tracking(
+    run_stage_with_tracking(
         config=config,
+        stage="train",
         pipeline_invocation_id=pipeline_invocation_id,
-        dataset_context=dataset_context,
+        stage_fn=lambda: _run_train_stage(config=config, dataset_context=dataset_context),
+        extra_tags=build_train_tracking_tags(config),
+        result_logger=log_train_outputs,
     )
-    _run_submit_stage_with_tracking(
+    run_stage_with_tracking(
         config=config,
+        stage="submit",
         pipeline_invocation_id=pipeline_invocation_id,
+        stage_fn=lambda: _run_submit_stage(config=config),
+        extra_tags={"candidate_id": config.experiment.candidate.candidate_id},
+        result_logger=log_submit_outputs,
     )
 
 
@@ -303,9 +200,12 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if args.stage == "prepare":
-        _run_prepare_stage_with_tracking(
+        run_stage_with_tracking(
             config=config,
+            stage="prepare",
             pipeline_invocation_id=pipeline_invocation_id,
+            stage_fn=lambda: _prepare_competition_stage(config),
+            result_logger=log_prepare_stage_outputs,
         )
         return
 
@@ -314,24 +214,38 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if args.stage == "train":
-        _run_train_stage_with_tracking(
+        run_stage_with_tracking(
             config=config,
+            stage="train",
             pipeline_invocation_id=pipeline_invocation_id,
+            stage_fn=lambda: _run_train_stage(config=config),
+            extra_tags=build_train_tracking_tags(config),
+            result_logger=log_train_outputs,
         )
         return
 
     if args.stage == "refresh-submissions":
-        _run_submission_refresh_stage_with_tracking(
+        run_stage_with_tracking(
             config=config,
+            stage="refresh-submissions",
             pipeline_invocation_id=pipeline_invocation_id,
+            stage_fn=lambda: _run_submission_refresh_stage(config),
+            result_logger=log_submission_refresh_outputs,
         )
         return
 
     if args.stage == "submit":
-        _run_submit_stage_with_tracking(
+        resolved_candidate_id = args.candidate_id or config.experiment.candidate.candidate_id
+        run_stage_with_tracking(
             config=config,
+            stage="submit",
             pipeline_invocation_id=pipeline_invocation_id,
-            candidate_id=args.candidate_id,
+            stage_fn=lambda: _run_submit_stage(
+                config=config,
+                candidate_id=resolved_candidate_id,
+            ),
+            extra_tags={"candidate_id": resolved_candidate_id},
+            result_logger=log_submit_outputs,
         )
         return
 

--- a/src/tabular_shenanigans/tracking.py
+++ b/src/tabular_shenanigans/tracking.py
@@ -1,17 +1,16 @@
 import json
-from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager, nullcontext
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TypeVar
 
 from tabular_shenanigans.candidate_artifacts import json_ready, load_candidate_manifest
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.submission_history import SubmissionRefreshResult
 
-
-def is_tracking_enabled(config: AppConfig) -> bool:
-    return config.experiment.tracking.enabled
+StageResult = TypeVar("StageResult")
 
 
 def make_pipeline_invocation_id() -> str:
@@ -92,6 +91,52 @@ def start_stage_run(
         mlflow.end_run(status="FINISHED")
 
 
+def build_train_tracking_tags(config: AppConfig) -> dict[str, object]:
+    candidate = config.experiment.candidate
+    tags: dict[str, object] = {
+        "candidate_id": candidate.candidate_id,
+        "candidate_type": candidate.candidate_type,
+    }
+    if config.is_model_candidate:
+        tags["model_registry_key"] = config.resolved_model_registry_key
+        tags["model_family"] = candidate.model_family
+        tags["feature_recipe_id"] = candidate.feature_recipe_id
+        tags["numeric_preprocessor"] = candidate.numeric_preprocessor
+        tags["categorical_preprocessor"] = candidate.categorical_preprocessor
+        tags["preprocessing_scheme_id"] = candidate.preprocessing_scheme_id
+        return tags
+
+    tags["base_candidate_count"] = len(candidate.base_candidate_ids)
+    return tags
+
+
+def run_stage_with_tracking(
+    config: AppConfig,
+    stage: str,
+    pipeline_invocation_id: str,
+    stage_fn: Callable[[], StageResult],
+    extra_tags: Mapping[str, object] | None = None,
+    result_logger: Callable[[StageResult], None] | None = None,
+) -> StageResult:
+    tracking_enabled = config.experiment.tracking.enabled
+    tracking_context = nullcontext()
+    if tracking_enabled:
+        tracking_context = start_stage_run(
+            config=config,
+            stage=stage,
+            pipeline_invocation_id=pipeline_invocation_id,
+            extra_tags=extra_tags,
+        )
+
+    with tracking_context:
+        if tracking_enabled:
+            log_runtime_config(config)
+        stage_result = stage_fn()
+        if tracking_enabled and result_logger is not None:
+            result_logger(stage_result)
+        return stage_result
+
+
 def log_runtime_config(config: AppConfig) -> None:
     mlflow = _load_mlflow()
     mlflow.log_dict(config.model_dump(mode="json"), "config/runtime_config.json")
@@ -106,6 +151,11 @@ def log_prepare_outputs(prepared_context) -> None:
     mlflow.log_artifact(str(prepared_context.manifest_path), "prepared_context")
     mlflow.log_artifact(str(prepared_context.folds_path), "prepared_context")
     mlflow.log_artifacts(str(prepared_context.report_dir), "reports")
+
+
+def log_prepare_stage_outputs(stage_result: tuple[object, object]) -> None:
+    _, prepared_context = stage_result
+    log_prepare_outputs(prepared_context)
 
 
 def log_train_outputs(candidate_dir: Path) -> None:


### PR DESCRIPTION
Closes #111

## Summary
- add one shared tracked-stage runner in tracking.py and move train tracking-tag assembly there
- remove the four bespoke tracking wrappers from main.py so tracked stages use one consistent pattern
- keep stage behavior and artifacts unchanged while documenting the thinner orchestration boundary

## Verification
- PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/tracking.py
- focused synthetic verification covering tracking-enabled and tracking-disabled shared-runner behavior plus prepare/train/submit/refresh-submissions dispatch through the shared helper