### PR TITLE
Add fr2 Telco churn feature recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ Current hard-invalid preprocessing combinations:
 Built-in `feature_recipe_id` values for model candidates:
 - `fr0`: default pass-through recipe for new competitions
 - `fr1`: first competition-specific feature set for `playground-series-s6e3`
+- `fr2`: expanded `playground-series-s6e3` feature set with broader service-count, contract, payment, and charge-consistency features
 
-Feature recipes live in tracked Python modules under `src/tabular_shenanigans/feature_recipes/`. They are intended for deterministic, leakage-safe competition-specific feature transforms. New competitions should start with `fr0`; add a tracked recipe module only when the generic baseline plateaus.
+Feature recipes live in tracked Python modules under `src/tabular_shenanigans/feature_recipes/`. They are intended for deterministic, leakage-safe competition-specific feature transforms. New competitions should start with `fr0`; add a tracked recipe module only when the generic baseline plateaus. For `playground-series-s6e3`, start with `fr1` as the first engineered Telco recipe and use `fr2` when you want the expanded service-count plus contract and payment feature set.
 
 `frequency` encodes each categorical value as its fold-local relative frequency in the training fold. Unseen categories at transform time map to `0.0`.
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -135,7 +135,7 @@ The config is validated by Pydantic with `extra="forbid"`. Unknown keys, schema 
 Configured metrics are normalized to the internal metric names during config validation.
 The old flat config layout is unsupported and fails fast.
 Runtime modules consume `config.competition` and `config.experiment` directly; `AppConfig` keeps only minimal derived helpers such as candidate-type checks and resolved model registry key lookup.
-The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe for model candidates; built-in recipe IDs are `fr0` and `fr1`.
+The current runtime resolves `experiment.candidate.feature_recipe_id` to one tracked feature recipe for model candidates; built-in recipe IDs are `fr0`, `fr1`, and `fr2`. `fr1` is the first `playground-series-s6e3` Telco churn recipe, and `fr2` extends that path with additional service-count, contract, payment, and charge-consistency features.
 Model candidates configure preprocessing with split selectors:
 - `numeric_preprocessor`: `median`, `standardize`, or `kbins`
 - `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
@@ -320,6 +320,6 @@ Hard-error cases include:
 - If the user-facing config workflow changes, update `config.binary.example.yaml` and `config.regression.example.yaml` alongside the docs.
 - New metrics should be normalized and validated during config loading, then scored in `cv.py`.
 - New model families should be introduced in `models.py` with explicit task compatibility, capability metadata, and matching artifact outputs.
-- New feature recipes should be added under `src/tabular_shenanigans/feature_recipes/`, registered explicitly, and kept deterministic plus leakage-safe.
+- New feature recipes should be added under `src/tabular_shenanigans/feature_recipes/`, registered explicitly, and kept deterministic plus leakage-safe. Keep fold-fitted transforms such as learned binning in preprocessing rather than feature recipes.
 - New preprocessing modes should be added in `preprocess.py` without breaking the existing feature-frame contract or the preprocessing-first recipe naming convention.
 - New candidate or submission artifacts should be reflected in both the artifact contract above and the corresponding ledger rows.

--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from tabular_shenanigans.feature_recipes.base import FeatureRecipeDefinition
 
-REQUIRED_COLUMNS = [
+FR1_REQUIRED_COLUMNS = [
     "SeniorCitizen",
     "Partner",
     "Dependents",
@@ -23,6 +23,8 @@ REQUIRED_COLUMNS = [
     "TotalCharges",
 ]
 
+FR2_REQUIRED_COLUMNS = FR1_REQUIRED_COLUMNS + ["PhoneService"]
+
 SERVICE_ADDON_COLUMNS = [
     "OnlineSecurity",
     "OnlineBackup",
@@ -34,13 +36,19 @@ SERVICE_ADDON_COLUMNS = [
 
 STREAMING_COLUMNS = ["StreamingTV", "StreamingMovies"]
 SUPPORT_COLUMNS = ["OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"]
+SERVICE_COLUMNS = ["PhoneService", "MultipleLines", *SERVICE_ADDON_COLUMNS]
 
 
-def _require_columns(frame: pd.DataFrame, dataset_name: str) -> None:
-    missing_columns = [column for column in REQUIRED_COLUMNS if column not in frame.columns]
+def _require_columns(
+    frame: pd.DataFrame,
+    dataset_name: str,
+    recipe_id: str,
+    required_columns: list[str],
+) -> None:
+    missing_columns = [column for column in required_columns if column not in frame.columns]
     if missing_columns:
         raise ValueError(
-            "Feature recipe 'fr1' requires the Telco churn columns used by "
+            f"Feature recipe '{recipe_id}' requires the Telco churn columns used by "
             f"playground-series-s6e3. Missing columns in {dataset_name}: {missing_columns}"
         )
 
@@ -63,7 +71,11 @@ def _build_tenure_bucket(series: pd.Series) -> pd.Series:
     return buckets.astype(str)
 
 
-def _transform_frame(frame: pd.DataFrame) -> pd.DataFrame:
+def _automatic_payment_flag(series: pd.Series) -> pd.Series:
+    return series.astype(str).str.contains("automatic", case=False, regex=False).astype(int)
+
+
+def _transform_v1_frame(frame: pd.DataFrame) -> pd.DataFrame:
     transformed = frame.copy()
 
     tenure = transformed["tenure"].astype(float)
@@ -93,13 +105,59 @@ def _transform_frame(frame: pd.DataFrame) -> pd.DataFrame:
     return transformed
 
 
+def _transform_v2_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    transformed = _transform_v1_frame(frame)
+
+    tenure = transformed["tenure"].astype(float)
+    monthly_charges = transformed["MonthlyCharges"].astype(float)
+    total_charges = transformed["TotalCharges"].astype(float)
+    service_count = _build_service_count(transformed, SERVICE_COLUMNS).astype(float)
+
+    transformed["service_count"] = service_count
+    transformed["is_monthly_contract"] = transformed["Contract"].astype(str).eq("Month-to-month").astype(int)
+    transformed["is_autopay"] = _automatic_payment_flag(transformed["PaymentMethod"])
+    transformed["charges_per_tenure"] = monthly_charges / (tenure + 1.0)
+    transformed["total_vs_expected"] = total_charges / ((tenure * monthly_charges) + 1.0)
+    transformed["tenure_service_interaction"] = tenure * service_count
+    return transformed
+
+
 def build_s6e3_v1_features(
     x_train_raw: pd.DataFrame,
     x_test_raw: pd.DataFrame,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    _require_columns(x_train_raw, dataset_name="train features")
-    _require_columns(x_test_raw, dataset_name="test features")
-    return _transform_frame(x_train_raw), _transform_frame(x_test_raw)
+    _require_columns(
+        x_train_raw,
+        dataset_name="train features",
+        recipe_id="fr1",
+        required_columns=FR1_REQUIRED_COLUMNS,
+    )
+    _require_columns(
+        x_test_raw,
+        dataset_name="test features",
+        recipe_id="fr1",
+        required_columns=FR1_REQUIRED_COLUMNS,
+    )
+    return _transform_v1_frame(x_train_raw), _transform_v1_frame(x_test_raw)
+
+
+def build_s6e3_v2_features(
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    _require_columns(
+        x_train_raw,
+        dataset_name="train features",
+        recipe_id="fr2",
+        required_columns=FR2_REQUIRED_COLUMNS,
+    )
+    _require_columns(
+        x_test_raw,
+        dataset_name="test features",
+        recipe_id="fr2",
+        required_columns=FR2_REQUIRED_COLUMNS,
+    )
+    return _transform_v2_frame(x_train_raw), _transform_v2_frame(x_test_raw)
 
 
 S6E3_V1_FEATURE_RECIPE = FeatureRecipeDefinition(
@@ -107,4 +165,14 @@ S6E3_V1_FEATURE_RECIPE = FeatureRecipeDefinition(
     recipe_name="TelcoChurnFeatureSetV1",
     recipe_description="Playground Series S6E3 engineered feature set for the Telco churn schema.",
     transform=build_s6e3_v1_features,
+)
+
+S6E3_V2_FEATURE_RECIPE = FeatureRecipeDefinition(
+    recipe_id="fr2",
+    recipe_name="TelcoChurnFeatureSetV2",
+    recipe_description=(
+        "Expanded Playground Series S6E3 engineered feature set with contract, payment, "
+        "service-count, and charge-consistency features."
+    ),
+    transform=build_s6e3_v2_features,
 )

--- a/src/tabular_shenanigans/feature_recipes/registry.py
+++ b/src/tabular_shenanigans/feature_recipes/registry.py
@@ -1,7 +1,10 @@
 import pandas as pd
 
 from tabular_shenanigans.feature_recipes.base import FeatureRecipeDefinition
-from tabular_shenanigans.feature_recipes.playground_series_s6e3 import S6E3_V1_FEATURE_RECIPE
+from tabular_shenanigans.feature_recipes.playground_series_s6e3 import (
+    S6E3_V1_FEATURE_RECIPE,
+    S6E3_V2_FEATURE_RECIPE,
+)
 
 IDENTITY_FEATURE_RECIPE_ID = "fr0"
 
@@ -21,6 +24,7 @@ FEATURE_RECIPE_REGISTRY = {
         transform=_identity_recipe,
     ),
     S6E3_V1_FEATURE_RECIPE.recipe_id: S6E3_V1_FEATURE_RECIPE,
+    S6E3_V2_FEATURE_RECIPE.recipe_id: S6E3_V2_FEATURE_RECIPE,
 }
 
 


### PR DESCRIPTION
## Summary
- add `fr2` as an expanded Telco churn recipe for `playground-series-s6e3`
- keep `fr1` unchanged and register `fr2` as a separate tracked built-in recipe
- document when to choose `fr1` versus `fr2`

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py src/tabular_shenanigans/feature_recipes/registry.py`
- `PYTHONPATH=src .venv/bin/python - <<'PY' ... apply_feature_recipe('fr1'/'fr2') ... PY` to confirm `fr2` adds only `charges_per_tenure`, `is_autopay`, `is_monthly_contract`, `service_count`, `tenure_service_interaction`, and `total_vs_expected`
- `PYTHONPATH=src .venv/bin/python main.py train` on local `playground-series-s6e3` data with a temporary `fr2--num_standardize__cat_onehot--logreg_liblinear_l1_smoke--v1` config; completed successfully with `CV roc_auc mean=0.911613`, `std=0.001164`, and wrote candidate artifacts under `artifacts/playground-series-s6e3/candidates/fr2--num_standardize__cat_onehot--logreg_liblinear_l1_smoke--v1`

Closes #127
