### PR TITLE
Remove experiment metadata config and derive candidate ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Stage behavior:
 - `submit`: downloads one candidate from MLflow, validates `test_predictions.csv` against `sample_submission.csv`, and when `experiment.submit.enabled=true` submits to Kaggle and records the submission event under that same candidate run.
 - `refresh-submissions`: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and appends new score observations back onto the matching candidate runs.
 
-`submit` defaults to `config.experiment.candidate.candidate_id`. Use `--candidate-id` when you want to submit another existing candidate for the same competition experiment.
+`submit` defaults to the derived `candidate_id` for the current config. Use `--candidate-id` when you want to submit another existing candidate for the same competition experiment.
 
 ## Config Overview
 Tracked example configs:
@@ -109,8 +109,6 @@ Required top-level sections:
   - `low_cardinality_int_threshold`
 
 `experiment` keys:
-- `name`
-- optional `notes`
 - required `tracking`
 - required `candidate`
 - optional `submit`
@@ -121,10 +119,6 @@ Required top-level sections:
 `experiment.candidate` keys:
 - shared:
   - `candidate_type`: `model` or `blend`
-  - `candidate_id`
-    - model candidates must follow `<feature_recipe_id>--<preprocessing_scheme_id>--<variant_token>--vN`
-    - blend candidates must follow `blend__vN`
-    - `candidate_id` must not repeat `competition.slug`
 - model candidate:
   - `feature_recipe_id`: built-in values are `fr0`, `fr1`, and `fr2`
   - `model_family`
@@ -132,11 +126,16 @@ Required top-level sections:
     - binary: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
   - `numeric_preprocessor`: `median`, `standardize`, or `kbins`
   - `categorical_preprocessor`: `onehot`, `ordinal`, `frequency`, or `native`
-  - optional `model_params`
+  - optional `model_params`: manual estimator overrides; when omitted, the runtime uses repo defaults plus the estimator library defaults
   - optional `optimization`
 - blend candidate:
   - `base_candidate_ids`: at least two existing compatible candidate IDs from the same competition experiment
   - optional `weights`
+
+`candidate_id` is derived automatically and is not configured directly:
+- model candidates derive `<feature_recipe_id>--<preprocessing_scheme_id>--<model_registry_key>--<hash8>`
+- blend candidates derive `blend__<hash8>`
+- rerunning the exact same candidate spec derives the same `candidate_id` and hard-fails if that run already exists in MLflow
 
 Hard-invalid preprocessing combination:
 - `categorical_preprocessor: native` with any `model_family` other than `catboost`
@@ -208,8 +207,8 @@ Preferred targets:
 Suggested checks:
 - run `uv run python main.py train` and confirm one MLflow candidate run appears under the competition experiment
 - inspect the candidate run and confirm `candidate/`, `config/`, and `context/` artifacts exist
-- train a second compatible candidate and confirm `uv run python main.py train` fails if you reuse the same `candidate_id`
-- train a `blend__vN` candidate and confirm it downloads base candidates from MLflow instead of reading local artifact directories
+- rerun the exact same candidate config and confirm `uv run python main.py train` fails because it derives the same `candidate_id`
+- train one blend candidate and confirm it downloads base candidates from MLflow instead of reading local artifact directories
 - run `uv run python main.py submit` with `experiment.submit.enabled: false` and confirm dry-run validation succeeds without creating local candidate artifacts or submission ledgers
 - run `uv run python main.py refresh-submissions` after at least one real Kaggle submission and confirm candidate-run submission metrics update in MLflow
 
@@ -218,4 +217,4 @@ Suggested checks:
 - Competition downloads still live under `data/<competition_slug>/`.
 - EDA reports still live under `reports/<competition_slug>/`.
 - Local temp directories are used during a running command, but candidate state is not kept there after the command finishes.
-- Candidate lookup is keyed by `candidate_id` inside the competition MLflow experiment. Reusing a `candidate_id` without deleting the existing run is a hard error.
+- Candidate lookup is keyed by derived `candidate_id` inside the competition MLflow experiment. Reusing the same candidate spec without deleting the existing run is a hard error.

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -29,24 +29,16 @@ competition:
   #   low_cardinality_int_threshold: 20
 
 experiment:
-  name: baseline-logreg
-  notes: onehot logistic-regression baseline for the default binary smoke test
-
   tracking:
     tracking_uri: http://localhost:5000
 
   candidate:
     candidate_type: model
-    candidate_id: fr0--num_standardize__cat_onehot--logreg--v1
     feature_recipe_id: fr0
     model_family: logistic_regression
     numeric_preprocessor: standardize
     categorical_preprocessor: onehot
     model_params: {}
-
-    # Candidate ids follow:
-    # <feature_recipe_id>--<preprocessing_scheme_id>--<variant_token>--vN
-    # Example competition-specific recipe token: fr1
 
     # Alternative binary model candidates:
     # numeric_preprocessor: kbins
@@ -61,7 +53,6 @@ experiment:
 
     # Alternative blend candidate shape:
     # candidate_type: blend
-    # candidate_id: blend__v1
     # base_candidate_ids:
     #   - existing_candidate_a
     #   - existing_candidate_b

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -25,24 +25,16 @@ competition:
   #   low_cardinality_int_threshold: 20
 
 experiment:
-  name: baseline-elasticnet
-  notes: onehot elastic-net baseline for the default regression smoke test
-
   tracking:
     tracking_uri: http://localhost:5000
 
   candidate:
     candidate_type: model
-    candidate_id: fr0--num_standardize__cat_onehot--elasticnet--v1
     feature_recipe_id: fr0
     model_family: elasticnet
     numeric_preprocessor: standardize
     categorical_preprocessor: onehot
     model_params: {}
-
-    # Candidate ids follow:
-    # <feature_recipe_id>--<preprocessing_scheme_id>--<variant_token>--vN
-    # Example competition-specific recipe token: fr1
 
     # Alternative regression model candidates:
     # numeric_preprocessor: kbins
@@ -57,7 +49,6 @@ experiment:
 
     # Alternative blend candidate shape:
     # candidate_type: blend
-    # candidate_id: blend__v1
     # base_candidate_ids:
     #   - existing_candidate_a
     #   - existing_candidate_b

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -52,7 +52,6 @@ Current candidate-run tags:
 
 ### Params
 Current candidate-run params:
-- `experiment_name`
 - `cv__n_splits`
 - `cv__shuffle`
 - `cv__random_state`
@@ -127,7 +126,7 @@ Stage notes:
 ## Module Responsibilities
 - [main.py](/Users/hs/dev/TabularShenanigans/main.py): CLI entrypoint and linear stage dispatch.
 - [competition.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/competition.py): in-memory competition preparation, fold assignment materialization, and prepared-context construction.
-- [config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/config.py): nested config validation, metric normalization, candidate naming checks, and resolved model lookup.
+- [config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/config.py): nested config validation, metric normalization, candidate-id derivation, and resolved model lookup.
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
 - [data.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/data.py): Kaggle downloads, zip access, schema inference, and sample-submission loading.
 - [eda.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/eda.py): local EDA report generation.
@@ -165,8 +164,6 @@ Required top-level keys:
 - optional `features`
 
 `experiment` keys:
-- `name`
-- optional `notes`
 - required `tracking`
 - required `candidate`
 - optional `submit`
@@ -176,24 +173,22 @@ Required top-level keys:
 
 Model candidate contract:
 - `candidate_type: model`
-- `candidate_id`
 - `feature_recipe_id`
 - `model_family`
 - `numeric_preprocessor`
 - `categorical_preprocessor`
-- optional `model_params`
+- optional `model_params` (manual estimator overrides; when omitted, the runtime uses repo defaults plus estimator library defaults)
 - optional `optimization`
 
 Blend candidate contract:
 - `candidate_type: blend`
-- `candidate_id`
 - `base_candidate_ids`
 - optional `weights`
 
 Naming contract:
-- model candidates: `<feature_recipe_id>--<preprocessing_scheme_id>--<variant_token>--vN`
-- blend candidates: `blend__vN`
-- `candidate_id` must not repeat `competition.slug`
+- model candidates derive `<feature_recipe_id>--<preprocessing_scheme_id>--<model_registry_key>--<hash8>`
+- blend candidates derive `blend__<hash8>`
+- identical candidate specs derive the same `candidate_id`
 
 Hard-invalid preprocessing combination:
 - `categorical_preprocessor: native` with any model family other than `catboost`
@@ -250,7 +245,7 @@ Refresh behavior:
 ## Runtime Invariants
 - MLflow is required. The runtime does not support a no-tracking mode.
 - Candidate state is canonical in MLflow, not on local disk.
-- Reusing an existing `candidate_id` within a competition experiment is a hard error.
+- Reusing an existing derived `candidate_id` within a competition experiment is a hard error.
 - `prepare` is not a persisted source of truth anymore.
 - `train` and `blend` must produce exactly one candidate run keyed by `candidate_id`.
 - `submit` resolves candidates from MLflow, not from local artifact directories.

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--candidate-id",
         help=(
             "Optional candidate_id resolved in the current competition MLflow experiment. "
-            "Defaults to config.experiment.candidate.candidate_id."
+            "Defaults to the derived candidate_id for the current config."
         ),
     )
 
@@ -53,7 +53,7 @@ def _print_resolved_setup(config: AppConfig) -> None:
         print(
             "Resolved competition setup: "
             f"task_type={competition.task_type}, primary_metric={competition.primary_metric}, "
-            f"candidate_id={candidate.candidate_id}, candidate_type=blend, "
+            f"candidate_id={config.resolved_candidate_id}, candidate_type=blend, "
             f"base_candidates={candidate.base_candidate_ids}, weights={weight_summary}"
         )
         return
@@ -61,7 +61,7 @@ def _print_resolved_setup(config: AppConfig) -> None:
     print(
         "Resolved competition setup: "
         f"task_type={competition.task_type}, primary_metric={competition.primary_metric}, "
-        f"candidate_id={candidate.candidate_id}, candidate_type=model, "
+        f"candidate_id={config.resolved_candidate_id}, candidate_type=model, "
         f"feature_recipe={candidate.feature_recipe_id}, model_family={candidate.model_family}, "
         f"numeric_preprocessor={candidate.numeric_preprocessor}, "
         f"categorical_preprocessor={candidate.categorical_preprocessor}"
@@ -128,7 +128,7 @@ def _run_submit_stage(
     config: AppConfig,
     candidate_id: str | None = None,
 ):
-    resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
+    resolved_candidate_id = candidate_id or config.resolved_candidate_id
     print(f"Using candidate_id: {resolved_candidate_id}")
     submission_result = run_submission(
         config=config,
@@ -209,7 +209,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.stage == "submit":
         _run_submit_stage(
             config=config,
-            candidate_id=args.candidate_id or config.experiment.candidate.candidate_id,
+            candidate_id=args.candidate_id or config.resolved_candidate_id,
         )
         return
 

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -29,6 +29,7 @@ from tabular_shenanigans.mlflow_store import (
     log_candidate_run,
     terminate_run,
 )
+from tabular_shenanigans.naming import normalize_blend_weights
 from tabular_shenanigans.preprocess import prepare_feature_frames
 
 BLEND_REGISTRY_KEY = "blend_weighted_average"
@@ -140,23 +141,6 @@ def _load_binary_accuracy_test_probabilities(
             f"Expected columns {expected_columns}, got {probability_df.columns.tolist()} in {probability_path}"
         )
     return probability_df
-
-
-def _resolve_blend_weights(
-    base_candidate_ids: list[str],
-    configured_weights: list[float] | None,
-) -> list[float]:
-    if configured_weights is None:
-        equal_weight = 1.0 / len(base_candidate_ids)
-        return [equal_weight] * len(base_candidate_ids)
-
-    if not np.isfinite(np.asarray(configured_weights, dtype=float)).all():
-        raise ValueError("Blend candidate weights must be finite.")
-
-    weight_sum = float(sum(configured_weights))
-    if not np.isfinite(weight_sum) or weight_sum <= 0:
-        raise ValueError("Blend candidate weights must sum to a positive value.")
-    return [float(weight / weight_sum) for weight in configured_weights]
 
 
 def _validate_binary_test_labels(
@@ -561,11 +545,10 @@ def _build_candidate_manifest(
     mlflow_run_id: str,
 ) -> dict[str, object]:
     competition = config.competition
-    candidate = config.experiment.candidate
     manifest = {
         "artifact_type": "candidate",
-        "candidate_id": candidate.candidate_id,
-        "candidate_type": candidate.candidate_type,
+        "candidate_id": config.resolved_candidate_id,
+        "candidate_type": config.experiment.candidate.candidate_type,
         "generated_at_utc": generated_at_utc,
         "competition_slug": competition.slug,
         "task_type": competition.task_type,
@@ -680,6 +663,7 @@ def run_blend_training(
     competition = config.competition
     features = competition.features
     candidate = config.experiment.candidate
+    candidate_id = config.resolved_candidate_id
     train_df = dataset_context.train_df
     test_df = dataset_context.test_df
     id_column = dataset_context.id_column
@@ -711,10 +695,7 @@ def run_blend_training(
             configured_positive_label=positive_label,
         )
 
-    normalized_weights = _resolve_blend_weights(
-        base_candidate_ids=candidate.base_candidate_ids,
-        configured_weights=candidate.weights,
-    )
+    normalized_weights = config.resolved_blend_weights
     fit_started = time.perf_counter()
     with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-blend-components-") as component_dir:
         components = [
@@ -771,7 +752,7 @@ def run_blend_training(
     metric_mean = float(fold_metrics_df["metric_value"].mean())
     metric_std = float(fold_metrics_df["metric_value"].std(ddof=0))
     blend_summary_df = _build_blend_summary(
-        candidate_id=candidate.candidate_id,
+        candidate_id=candidate_id,
         metric_name=competition.primary_metric,
         metric_mean=metric_mean,
         metric_std=metric_std,
@@ -779,7 +760,7 @@ def run_blend_training(
         normalized_weights=normalized_weights,
     )
     print(
-        f"Blend candidate: {candidate.candidate_id} | "
+        f"Blend candidate: {candidate_id} | "
         f"components={candidate.base_candidate_ids} | "
         f"weights={normalized_weights} | "
         f"CV {competition.primary_metric}: mean={metric_mean:.6f}, std={metric_std:.6f}"
@@ -806,7 +787,7 @@ def run_blend_training(
     )
     candidate_run = create_candidate_run(
         config=config,
-        candidate_id=candidate.candidate_id,
+        candidate_id=candidate_id,
         candidate_type=candidate.candidate_type,
     )
     candidate_manifest = _build_candidate_manifest(

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -13,7 +13,11 @@ from tabular_shenanigans.models import (
     resolve_candidate_model_id,
     validate_model_preprocessing_compatibility,
 )
-from tabular_shenanigans.naming import validate_blend_candidate_id, validate_model_candidate_id
+from tabular_shenanigans.naming import (
+    build_blend_candidate_id,
+    build_model_candidate_id,
+    normalize_blend_weights,
+)
 from tabular_shenanigans.preprocess import (
     CATEGORICAL_PREPROCESSOR_IDS,
     NUMERIC_PREPROCESSOR_IDS,
@@ -67,8 +71,6 @@ class CandidateOptimizationConfig(BaseModel):
 
 class BaseCandidateConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
-
-    candidate_id: str = Field(min_length=1)
 
 
 class ModelCandidateConfig(BaseCandidateConfig):
@@ -206,8 +208,6 @@ class ExperimentTrackingConfig(BaseModel):
 class ExperimentConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str = Field(min_length=1)
-    notes: str | None = None
     candidate: ExperimentCandidateConfig
     submit: ExperimentSubmitConfig = Field(default_factory=ExperimentSubmitConfig)
     tracking: ExperimentTrackingConfig = Field(default_factory=ExperimentTrackingConfig)
@@ -241,12 +241,6 @@ class AppConfig(BaseModel):
         if self.is_model_candidate:
             candidate = self.experiment.candidate
             candidate.feature_recipe_id = resolve_feature_recipe_id(candidate.feature_recipe_id)
-            validate_model_candidate_id(
-                candidate_id=candidate.candidate_id,
-                competition_slug=competition.slug,
-                feature_recipe_id=candidate.feature_recipe_id,
-                preprocessing_scheme_id=candidate.preprocessing_scheme_id,
-            )
             resolved_model_registry_key = self.resolved_model_registry_key
             validate_model_preprocessing_compatibility(
                 task_type=competition.task_type,
@@ -268,13 +262,6 @@ class AppConfig(BaseModel):
                         f"task_type '{competition.task_type}'. Supported tunable model families: "
                         f"{supported_tunable_model_families}"
                     )
-        else:
-            candidate = self.experiment.candidate
-            validate_blend_candidate_id(
-                candidate_id=candidate.candidate_id,
-                competition_slug=competition.slug,
-            )
-
         return self
 
     @property
@@ -293,6 +280,75 @@ class AppConfig(BaseModel):
         return resolve_candidate_model_id(
             task_type=self.competition.task_type,
             model_family=candidate.model_family,
+        )
+
+    @property
+    def resolved_blend_weights(self) -> list[float]:
+        if not self.is_blend_candidate:
+            raise ValueError("resolved_blend_weights is only available for blend candidates.")
+        candidate = self.experiment.candidate
+        return normalize_blend_weights(
+            base_candidate_ids=candidate.base_candidate_ids,
+            configured_weights=candidate.weights,
+        )
+
+    @property
+    def resolved_candidate_id(self) -> str:
+        competition = self.competition
+        candidate = self.experiment.candidate
+        if self.is_model_candidate:
+            optimization_payload: dict[str, object] = {"enabled": False}
+            if candidate.optimization.enabled:
+                optimization_payload = candidate.optimization.model_dump(mode="python")
+            fingerprint_payload = {
+                "competition": {
+                    "task_type": competition.task_type,
+                    "primary_metric": competition.primary_metric,
+                    "cv": competition.cv.model_dump(mode="python"),
+                    "features": competition.features.model_dump(mode="python"),
+                    "positive_label": competition.positive_label,
+                },
+                "candidate": {
+                    "feature_recipe_id": candidate.feature_recipe_id,
+                    "numeric_preprocessor": candidate.numeric_preprocessor,
+                    "categorical_preprocessor": candidate.categorical_preprocessor,
+                    "preprocessing_scheme_id": candidate.preprocessing_scheme_id,
+                    "model_family": candidate.model_family,
+                    "model_registry_key": self.resolved_model_registry_key,
+                    "model_params": candidate.model_params,
+                    "optimization": optimization_payload,
+                },
+            }
+            return build_model_candidate_id(
+                feature_recipe_id=candidate.feature_recipe_id,
+                preprocessing_scheme_id=candidate.preprocessing_scheme_id,
+                model_registry_key=self.resolved_model_registry_key,
+                fingerprint_payload=fingerprint_payload,
+            )
+
+        normalized_weights = self.resolved_blend_weights
+        fingerprint_payload = {
+            "competition": {
+                "task_type": competition.task_type,
+                "primary_metric": competition.primary_metric,
+                "cv": competition.cv.model_dump(mode="python"),
+                "features": competition.features.model_dump(mode="python"),
+            },
+            "components": [
+                {
+                    "candidate_id": component_candidate_id,
+                    "weight": weight,
+                }
+                for component_candidate_id, weight in sorted(
+                    zip(candidate.base_candidate_ids, normalized_weights, strict=True),
+                    key=lambda item: item[0],
+                )
+            ],
+        }
+        return build_blend_candidate_id(
+            base_candidate_ids=candidate.base_candidate_ids,
+            normalized_weights=normalized_weights,
+            fingerprint_payload=fingerprint_payload,
         )
 
 

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -155,7 +155,7 @@ def ensure_candidate_run_absent(config: AppConfig, candidate_id: str) -> None:
     if runs:
         raise ValueError(
             "Candidate already exists in MLflow for this competition. "
-            f"Choose a new experiment.candidate.candidate_id or delete candidate '{candidate_id}'."
+            f"Change the candidate config so it derives a new candidate_id or delete candidate '{candidate_id}'."
         )
 
 
@@ -170,8 +170,6 @@ def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: s
         "primary_metric": config.competition.primary_metric,
         **_git_metadata(),
     }
-    if config.experiment.notes:
-        tags["mlflow.note.content"] = config.experiment.notes
     return tags
 
 
@@ -207,7 +205,6 @@ def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dic
     competition = config.competition
     candidate = config.experiment.candidate
     params: dict[str, object] = {
-        "experiment_name": config.experiment.name,
         "cv__n_splits": competition.cv.n_splits,
         "cv__shuffle": competition.cv.shuffle,
         "cv__random_state": competition.cv.random_state,

--- a/src/tabular_shenanigans/naming.py
+++ b/src/tabular_shenanigans/naming.py
@@ -1,61 +1,51 @@
-import re
-
-MODEL_CANDIDATE_ID_SEPARATOR = "--"
-BLEND_CANDIDATE_ID_PATTERN = re.compile(r"^blend__v[1-9][0-9]*$")
-TOKEN_PATTERN = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
-VERSION_TOKEN_PATTERN = re.compile(r"^v[1-9][0-9]*$")
+import hashlib
+import json
 
 
-def _ensure_competition_slug_not_repeated(candidate_id: str, competition_slug: str) -> None:
-    if competition_slug in candidate_id:
-        raise ValueError(
-            "experiment.candidate.candidate_id must not repeat competition.slug because the competition already "
-            f"scopes artifact paths. Remove '{competition_slug}' from '{candidate_id}'."
-        )
+def _json_ready(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_ready(nested_value) for key, nested_value in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    return value
 
 
-def validate_model_candidate_id(
-    candidate_id: str,
-    competition_slug: str,
+def _short_hash(payload: dict[str, object]) -> str:
+    payload_json = json.dumps(_json_ready(payload), sort_keys=True)
+    return hashlib.sha256(payload_json.encode("utf-8")).hexdigest()[:8]
+
+
+def normalize_blend_weights(
+    base_candidate_ids: list[str],
+    configured_weights: list[float] | None,
+) -> list[float]:
+    if configured_weights is None:
+        equal_weight = 1.0 / len(base_candidate_ids)
+        return [equal_weight] * len(base_candidate_ids)
+
+    weight_sum = float(sum(configured_weights))
+    return [float(weight / weight_sum) for weight in configured_weights]
+
+
+def build_model_candidate_id(
     feature_recipe_id: str,
     preprocessing_scheme_id: str,
-) -> None:
-    _ensure_competition_slug_not_repeated(candidate_id, competition_slug)
-
-    expected_prefix = f"{feature_recipe_id}{MODEL_CANDIDATE_ID_SEPARATOR}{preprocessing_scheme_id}{MODEL_CANDIDATE_ID_SEPARATOR}"
-    if not candidate_id.startswith(expected_prefix):
-        raise ValueError(
-            "Model candidate_id must follow "
-            "<feature_recipe_id>--<preprocessing_scheme_id>--<variant_token>--vN and start with "
-            f"'{expected_prefix}'. Got '{candidate_id}'."
-        )
-
-    suffix = candidate_id.removeprefix(expected_prefix)
-    suffix_parts = suffix.split(MODEL_CANDIDATE_ID_SEPARATOR)
-    if len(suffix_parts) != 2:
-        raise ValueError(
-            "Model candidate_id must end with exactly one variant token and one version token after the "
-            f"feature recipe and preprocessing prefix. Got '{candidate_id}'."
-        )
-
-    variant_token, version_token = suffix_parts
-    if not TOKEN_PATTERN.fullmatch(variant_token):
-        raise ValueError(
-            "Model candidate_id variant token must use lowercase letters, digits, and single underscores only. "
-            f"Got '{variant_token}' in '{candidate_id}'."
-        )
-    if not VERSION_TOKEN_PATTERN.fullmatch(version_token):
-        raise ValueError(
-            "Model candidate_id must end with a version token like 'v1'. "
-            f"Got '{version_token}' in '{candidate_id}'."
-        )
-
-
-def validate_blend_candidate_id(candidate_id: str, competition_slug: str) -> None:
-    _ensure_competition_slug_not_repeated(candidate_id, competition_slug)
-    if BLEND_CANDIDATE_ID_PATTERN.fullmatch(candidate_id):
-        return
-    raise ValueError(
-        "Blend candidate_id must follow the simple sequential contract 'blend__vN'. "
-        f"Got '{candidate_id}'."
+    model_registry_key: str,
+    fingerprint_payload: dict[str, object],
+) -> str:
+    return (
+        f"{feature_recipe_id}--{preprocessing_scheme_id}--{model_registry_key}--"
+        f"{_short_hash(fingerprint_payload)}"
     )
+
+
+def build_blend_candidate_id(
+    base_candidate_ids: list[str],
+    normalized_weights: list[float],
+    fingerprint_payload: dict[str, object],
+) -> str:
+    if len(base_candidate_ids) != len(normalized_weights):
+        raise ValueError("Blend candidate id building requires one normalized weight per base candidate.")
+    return f"blend__{_short_hash(fingerprint_payload)}"

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -342,7 +342,7 @@ def run_submission(
     candidate_id: str | None = None,
 ) -> SubmissionRunResult:
     submit_config = config.experiment.submit
-    resolved_candidate_id = candidate_id or config.experiment.candidate.candidate_id
+    resolved_candidate_id = candidate_id or config.resolved_candidate_id
 
     with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-submit-") as temp_dir:
         temp_root = Path(temp_dir)

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -104,8 +104,8 @@ def _build_candidate_manifest(
     candidate = config.experiment.candidate
     manifest = {
         "artifact_type": "candidate",
-        "candidate_id": candidate.candidate_id,
-        "candidate_type": candidate.candidate_type,
+        "candidate_id": config.resolved_candidate_id,
+        "candidate_type": config.experiment.candidate.candidate_type,
         "generated_at_utc": generated_at_utc,
         "competition_slug": competition.slug,
         "task_type": competition.task_type,
@@ -224,6 +224,7 @@ def run_training(
 
     competition = config.competition
     candidate = config.experiment.candidate
+    candidate_id = config.resolved_candidate_id
     resolved_model_spec = _resolve_training_model_spec(config=config, model_spec=model_spec)
 
     training_context = prepared_training_context
@@ -244,7 +245,7 @@ def run_training(
     fit_wall_seconds = time.perf_counter() - fit_started
     model_result = evaluation_artifacts.model_result
     print(
-        f"Training candidate: {candidate.candidate_id} | "
+        f"Training candidate: {candidate_id} | "
         f"feature_recipe={candidate.feature_recipe_id} | "
         f"estimator={model_result.estimator_name} | "
         f"preprocessing={model_result.preprocessing_scheme_id} | "
@@ -267,7 +268,7 @@ def run_training(
     )
     candidate_run = create_candidate_run(
         config=config,
-        candidate_id=candidate.candidate_id,
+        candidate_id=candidate_id,
         candidate_type=candidate.candidate_type,
     )
     candidate_manifest = _build_candidate_manifest(

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -91,7 +91,7 @@ def _build_optimization_summary(
         "study_id": study_id,
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
         "competition_slug": competition.slug,
-        "candidate_id": candidate.candidate_id,
+        "candidate_id": config.resolved_candidate_id,
         "task_type": competition.task_type,
         "primary_metric": competition.primary_metric,
         "optimization_method": candidate.optimization.method,


### PR DESCRIPTION
Closes #131

## Summary
- remove experiment.name and experiment.notes from the runtime config contract
- derive model and blend candidate ids deterministically from the candidate spec instead of configuring them manually
- update submit/train/blend/MLflow paths and docs to use the derived candidate id

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/*.py src/tabular_shenanigans/feature_recipes/*.py`
- created a disposable `issue-131-smoke-binary` competition zip under `data/`
- trained one model candidate and confirmed MLflow run creation under a derived id
- reran the exact same config and confirmed duplicate derived candidate id failure
- changed one `model_params` value, retrained, and confirmed a different derived candidate id
- trained one blend candidate and confirmed a derived `blend__<hash8>` id
- ran `PYTHONPATH=src .venv/bin/python main.py submit` with no `--candidate-id` and confirmed dry-run submit resolved the derived blend candidate id automatically