### PR TITLE
Log candidate run output to MLflow artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ candidate=<candidate_id> | submit=<submission_event_id> | <metric>=<value>
 
 ## Candidate Artifact Contract
 Each candidate MLflow run stores:
+- `logs/runtime.log`
 - `config/runtime_config.json`
 - `context/competition.json`
 - `context/folds.csv`
@@ -206,7 +207,8 @@ Preferred targets:
 
 Suggested checks:
 - run `uv run python main.py train` and confirm one MLflow candidate run appears under the competition experiment
-- inspect the candidate run and confirm `candidate/`, `config/`, and `context/` artifacts exist
+- inspect the candidate run and confirm `logs/`, `candidate/`, `config/`, and `context/` artifacts exist
+- trigger one intentionally failing candidate run and confirm the MLflow run is marked failed but still has `logs/runtime.log`
 - rerun the exact same candidate config and confirm `uv run python main.py train` fails because it derives the same `candidate_id`
 - train one blend candidate and confirm it downloads base candidates from MLflow instead of reading local artifact directories
 - run `uv run python main.py submit` with `experiment.submit.enabled: false` and confirm dry-run validation succeeds without creating local candidate artifacts or submission ledgers

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -87,6 +87,7 @@ Current candidate-run metrics:
 
 ### Artifacts
 Every candidate run stores:
+- `logs/runtime.log`
 - `config/runtime_config.json`
 - `context/competition.json`
 - `context/folds.csv`
@@ -248,6 +249,7 @@ Refresh behavior:
 - Reusing an existing derived `candidate_id` within a competition experiment is a hard error.
 - `prepare` is not a persisted source of truth anymore.
 - `train` and `blend` must produce exactly one candidate run keyed by `candidate_id`.
+- Candidate runs should upload `logs/runtime.log` on both success and failure once the run exists.
 - `submit` resolves candidates from MLflow, not from local artifact directories.
 - `refresh-submissions` updates existing candidate runs and does not create standalone tracking runs.
 - Feature recipes must be deterministic, leakage-safe, and schema-preserving across train/test.
@@ -262,6 +264,7 @@ Recommended manual checks:
 - one synthetic or smaller smoke workflow covering:
   - two model candidates
   - one blend candidate
+  - one intentionally failing candidate run with `logs/runtime.log` plus traceback uploaded before run termination
   - one dry-run submit
   - one submission-refresh path against seeded submission history
 

--- a/src/tabular_shenanigans/blend.py
+++ b/src/tabular_shenanigans/blend.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import time
+import traceback
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,9 +29,16 @@ from tabular_shenanigans.mlflow_store import (
     download_candidate_bundle,
     log_candidate_run,
     terminate_run,
+    upload_run_log,
 )
 from tabular_shenanigans.naming import normalize_blend_weights
 from tabular_shenanigans.preprocess import prepare_feature_frames
+from tabular_shenanigans.runtime_logging import (
+    append_runtime_log_message,
+    build_runtime_log_path,
+    capture_runtime_log,
+    emit_runtime_log_header,
+)
 
 BLEND_REGISTRY_KEY = "blend_weighted_average"
 BLEND_ESTIMATOR_NAME = "WeightedAverageBlend"
@@ -664,183 +672,209 @@ def run_blend_training(
     features = competition.features
     candidate = config.experiment.candidate
     candidate_id = config.resolved_candidate_id
-    train_df = dataset_context.train_df
-    test_df = dataset_context.test_df
-    id_column = dataset_context.id_column
-    label_column = dataset_context.label_column
-    y_train = train_df[label_column].reset_index(drop=True)
-
-    x_train_raw, x_test_raw, _ = prepare_feature_frames(
-        train_df=train_df,
-        test_df=test_df,
-        id_column=id_column,
-        label_column=label_column,
-        force_categorical=features.force_categorical,
-        force_numeric=features.force_numeric,
-        drop_columns=features.drop_columns,
-    )
-    prepared_context = ensure_prepared_competition_context(
-        config=config,
-        dataset_context=dataset_context,
-        expected_feature_columns=x_train_raw.columns.tolist(),
-    )
-    fold_assignments = prepared_context.fold_assignments
-
-    positive_label = competition.positive_label
-    negative_label = None
-    observed_label_pair = None
-    if competition.task_type == "binary":
-        negative_label, positive_label, observed_label_pair = resolve_positive_label(
-            y_values=y_train,
-            configured_positive_label=positive_label,
-        )
-
-    normalized_weights = config.resolved_blend_weights
-    fit_started = time.perf_counter()
-    with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-blend-components-") as component_dir:
-        components = [
-            _load_blend_component(
-                config=config,
-                candidate_id=base_candidate_id,
-                destination_dir=Path(component_dir) / base_candidate_id,
-                task_type=competition.task_type,
-                primary_metric=competition.primary_metric,
-                id_column=id_column,
-                label_column=label_column,
-                expected_y_train=y_train,
-                expected_fold_assignments=fold_assignments,
-                expected_test_ids=test_df[id_column],
-                positive_label=positive_label,
-                negative_label=negative_label,
-                observed_label_pair=observed_label_pair,
-            )
-            for base_candidate_id in candidate.base_candidate_ids
-        ]
-
-        component_oof_predictions = np.vstack([component.oof_predictions for component in components])
-        component_test_predictions = np.vstack([component.test_predictions for component in components])
-        weight_array = np.asarray(normalized_weights, dtype=float)
-        blended_oof_predictions = np.average(component_oof_predictions, axis=0, weights=weight_array)
-        blended_test_predictions = np.average(component_test_predictions, axis=0, weights=weight_array)
-        fit_wall_seconds = time.perf_counter() - fit_started
-
-    test_prediction_probabilities = None
-    if competition.task_type == "regression":
-        final_test_predictions: np.ndarray | list[object] = blended_test_predictions
-        if competition.primary_metric == "rmsle":
-            final_test_predictions = np.clip(blended_test_predictions, a_min=0.0, a_max=None)
-    elif get_binary_prediction_kind(competition.primary_metric) == "label":
-        if positive_label is None or negative_label is None:
-            raise ValueError("Binary label blends require resolved class metadata.")
-        test_prediction_probabilities = np.asarray(blended_test_predictions, dtype=float)
-        final_test_predictions = np.where(
-            blended_test_predictions >= 0.5,
-            positive_label,
-            negative_label,
-        )
-    else:
-        final_test_predictions = blended_test_predictions
-
-    fold_metrics_df = _build_fold_metrics(
-        task_type=competition.task_type,
-        primary_metric=competition.primary_metric,
-        y_train=y_train,
-        oof_predictions=blended_oof_predictions,
-        fold_assignments=fold_assignments,
-        positive_label=positive_label,
-    )
-    metric_mean = float(fold_metrics_df["metric_value"].mean())
-    metric_std = float(fold_metrics_df["metric_value"].std(ddof=0))
-    blend_summary_df = _build_blend_summary(
-        candidate_id=candidate_id,
-        metric_name=competition.primary_metric,
-        metric_mean=metric_mean,
-        metric_std=metric_std,
-        components=components,
-        normalized_weights=normalized_weights,
-    )
-    print(
-        f"Blend candidate: {candidate_id} | "
-        f"components={candidate.base_candidate_ids} | "
-        f"weights={normalized_weights} | "
-        f"CV {competition.primary_metric}: mean={metric_mean:.6f}, std={metric_std:.6f}"
-    )
-
-    target_summary = build_target_summary(
-        task_type=competition.task_type,
-        y_train=y_train,
-        positive_label=positive_label,
-        negative_label=negative_label,
-        observed_label_pair=observed_label_pair,
-    )
-    config_snapshot = _build_config_snapshot(
-        config=config,
-        positive_label=positive_label,
-        id_column=id_column,
-        label_column=label_column,
-        normalized_weights=normalized_weights,
-    )
-    config_fingerprint = _build_config_fingerprint(
-        config_snapshot=config_snapshot,
-        components=components,
-        normalized_weights=normalized_weights,
-    )
     candidate_run = create_candidate_run(
         config=config,
         candidate_id=candidate_id,
         candidate_type=candidate.candidate_type,
     )
-    candidate_manifest = _build_candidate_manifest(
-        config=config,
-        generated_at_utc=datetime.now(timezone.utc).isoformat(),
-        config_snapshot=config_snapshot,
-        config_fingerprint=config_fingerprint,
-        metric_mean=metric_mean,
-        metric_std=metric_std,
-        observed_label_pair=observed_label_pair,
-        negative_label=negative_label,
-        positive_label=positive_label,
-        id_column=id_column,
-        label_column=label_column,
-        target_summary=target_summary,
-        feature_columns=x_train_raw.columns.tolist(),
-        train_rows=int(train_df.shape[0]),
-        train_cols=int(x_train_raw.shape[1]),
-        test_rows=int(test_df.shape[0]),
-        test_cols=int(x_test_raw.shape[1]),
-        components=components,
-        normalized_weights=normalized_weights,
-        mlflow_run_id=candidate_run.run_id,
-    )
+    run_status = "FAILED"
+    train_df = dataset_context.train_df
+    test_df = dataset_context.test_df
+    id_column = dataset_context.id_column
+    label_column = dataset_context.label_column
+    y_train = train_df[label_column].reset_index(drop=True)
+    with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-blend-candidate-") as temp_dir:
+        bundle_root = Path(temp_dir)
+        log_path = build_runtime_log_path(bundle_root)
+        log_uploaded = False
+        try:
+            with capture_runtime_log(log_path):
+                emit_runtime_log_header(
+                    stage_name="blend",
+                    competition_slug=competition.slug,
+                    candidate_id=candidate_run.candidate_id,
+                    mlflow_run_id=candidate_run.run_id,
+                )
+                try:
+                    x_train_raw, x_test_raw, _ = prepare_feature_frames(
+                        train_df=train_df,
+                        test_df=test_df,
+                        id_column=id_column,
+                        label_column=label_column,
+                        force_categorical=features.force_categorical,
+                        force_numeric=features.force_numeric,
+                        drop_columns=features.drop_columns,
+                    )
+                    prepared_context = ensure_prepared_competition_context(
+                        config=config,
+                        dataset_context=dataset_context,
+                        expected_feature_columns=x_train_raw.columns.tolist(),
+                    )
+                    fold_assignments = prepared_context.fold_assignments
 
-    try:
-        with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-blend-candidate-") as temp_dir:
-            bundle_root = Path(temp_dir)
-            _stage_blend_bundle(
-                bundle_root=bundle_root,
+                    positive_label = competition.positive_label
+                    negative_label = None
+                    observed_label_pair = None
+                    if competition.task_type == "binary":
+                        negative_label, positive_label, observed_label_pair = resolve_positive_label(
+                            y_values=y_train,
+                            configured_positive_label=positive_label,
+                        )
+
+                    normalized_weights = config.resolved_blend_weights
+                    fit_started = time.perf_counter()
+                    with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-blend-components-") as component_dir:
+                        components = [
+                            _load_blend_component(
+                                config=config,
+                                candidate_id=base_candidate_id,
+                                destination_dir=Path(component_dir) / base_candidate_id,
+                                task_type=competition.task_type,
+                                primary_metric=competition.primary_metric,
+                                id_column=id_column,
+                                label_column=label_column,
+                                expected_y_train=y_train,
+                                expected_fold_assignments=fold_assignments,
+                                expected_test_ids=test_df[id_column],
+                                positive_label=positive_label,
+                                negative_label=negative_label,
+                                observed_label_pair=observed_label_pair,
+                            )
+                            for base_candidate_id in candidate.base_candidate_ids
+                        ]
+
+                        component_oof_predictions = np.vstack([component.oof_predictions for component in components])
+                        component_test_predictions = np.vstack([component.test_predictions for component in components])
+                        weight_array = np.asarray(normalized_weights, dtype=float)
+                        blended_oof_predictions = np.average(component_oof_predictions, axis=0, weights=weight_array)
+                        blended_test_predictions = np.average(component_test_predictions, axis=0, weights=weight_array)
+                        fit_wall_seconds = time.perf_counter() - fit_started
+
+                    test_prediction_probabilities = None
+                    if competition.task_type == "regression":
+                        final_test_predictions: np.ndarray | list[object] = blended_test_predictions
+                        if competition.primary_metric == "rmsle":
+                            final_test_predictions = np.clip(blended_test_predictions, a_min=0.0, a_max=None)
+                    elif get_binary_prediction_kind(competition.primary_metric) == "label":
+                        if positive_label is None or negative_label is None:
+                            raise ValueError("Binary label blends require resolved class metadata.")
+                        test_prediction_probabilities = np.asarray(blended_test_predictions, dtype=float)
+                        final_test_predictions = np.where(
+                            blended_test_predictions >= 0.5,
+                            positive_label,
+                            negative_label,
+                        )
+                    else:
+                        final_test_predictions = blended_test_predictions
+
+                    fold_metrics_df = _build_fold_metrics(
+                        task_type=competition.task_type,
+                        primary_metric=competition.primary_metric,
+                        y_train=y_train,
+                        oof_predictions=blended_oof_predictions,
+                        fold_assignments=fold_assignments,
+                        positive_label=positive_label,
+                    )
+                    metric_mean = float(fold_metrics_df["metric_value"].mean())
+                    metric_std = float(fold_metrics_df["metric_value"].std(ddof=0))
+                    blend_summary_df = _build_blend_summary(
+                        candidate_id=candidate_id,
+                        metric_name=competition.primary_metric,
+                        metric_mean=metric_mean,
+                        metric_std=metric_std,
+                        components=components,
+                        normalized_weights=normalized_weights,
+                    )
+                    print(
+                        f"Blend candidate: {candidate_id} | "
+                        f"components={candidate.base_candidate_ids} | "
+                        f"weights={normalized_weights} | "
+                        f"CV {competition.primary_metric}: mean={metric_mean:.6f}, std={metric_std:.6f}"
+                    )
+
+                    target_summary = build_target_summary(
+                        task_type=competition.task_type,
+                        y_train=y_train,
+                        positive_label=positive_label,
+                        negative_label=negative_label,
+                        observed_label_pair=observed_label_pair,
+                    )
+                    config_snapshot = _build_config_snapshot(
+                        config=config,
+                        positive_label=positive_label,
+                        id_column=id_column,
+                        label_column=label_column,
+                        normalized_weights=normalized_weights,
+                    )
+                    config_fingerprint = _build_config_fingerprint(
+                        config_snapshot=config_snapshot,
+                        components=components,
+                        normalized_weights=normalized_weights,
+                    )
+                    candidate_manifest = _build_candidate_manifest(
+                        config=config,
+                        generated_at_utc=datetime.now(timezone.utc).isoformat(),
+                        config_snapshot=config_snapshot,
+                        config_fingerprint=config_fingerprint,
+                        metric_mean=metric_mean,
+                        metric_std=metric_std,
+                        observed_label_pair=observed_label_pair,
+                        negative_label=negative_label,
+                        positive_label=positive_label,
+                        id_column=id_column,
+                        label_column=label_column,
+                        target_summary=target_summary,
+                        feature_columns=x_train_raw.columns.tolist(),
+                        train_rows=int(train_df.shape[0]),
+                        train_cols=int(x_train_raw.shape[1]),
+                        test_rows=int(test_df.shape[0]),
+                        test_cols=int(x_test_raw.shape[1]),
+                        components=components,
+                        normalized_weights=normalized_weights,
+                        mlflow_run_id=candidate_run.run_id,
+                    )
+
+                    _stage_blend_bundle(
+                        bundle_root=bundle_root,
+                        config=config,
+                        candidate_manifest=candidate_manifest,
+                        competition_manifest=prepared_context.manifest,
+                        fold_assignments=fold_assignments,
+                        fold_metrics_df=fold_metrics_df,
+                        y_train=y_train,
+                        oof_predictions=blended_oof_predictions,
+                        test_ids=test_df[id_column],
+                        test_predictions=np.asarray(final_test_predictions),
+                        id_column=id_column,
+                        label_column=label_column,
+                        blend_summary_df=blend_summary_df,
+                        test_prediction_probabilities=test_prediction_probabilities,
+                    )
+                    log_candidate_run(
+                        config=config,
+                        candidate_run=candidate_run,
+                        bundle_root=bundle_root,
+                        manifest=candidate_manifest,
+                        fit_wall_seconds=fit_wall_seconds,
+                    )
+                except Exception:
+                    append_runtime_log_message(log_path, "stderr", traceback.format_exc())
+                    raise
+            upload_run_log(
                 config=config,
-                candidate_manifest=candidate_manifest,
-                competition_manifest=prepared_context.manifest,
-                fold_assignments=fold_assignments,
-                fold_metrics_df=fold_metrics_df,
-                y_train=y_train,
-                oof_predictions=blended_oof_predictions,
-                test_ids=test_df[id_column],
-                test_predictions=np.asarray(final_test_predictions),
-                id_column=id_column,
-                label_column=label_column,
-                blend_summary_df=blend_summary_df,
-                test_prediction_probabilities=test_prediction_probabilities,
+                run_id=candidate_run.run_id,
+                log_path=log_path,
             )
-            log_candidate_run(
-                config=config,
-                candidate_run=candidate_run,
-                bundle_root=bundle_root,
-                manifest=candidate_manifest,
-                fit_wall_seconds=fit_wall_seconds,
-            )
-        terminate_run(config=config, run_id=candidate_run.run_id, status="FINISHED")
-        return candidate_run
-    except Exception:
-        terminate_run(config=config, run_id=candidate_run.run_id, status="FAILED")
-        raise
+            log_uploaded = True
+            run_status = "FINISHED"
+            return candidate_run
+        except Exception:
+            if log_path.exists() and not log_uploaded:
+                upload_run_log(
+                    config=config,
+                    run_id=candidate_run.run_id,
+                    log_path=log_path,
+                )
+            raise
+        finally:
+            terminate_run(config=config, run_id=candidate_run.run_id, status=run_status)

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -304,6 +304,17 @@ def log_candidate_run(
     )
 
 
+def upload_run_log(
+    config: AppConfig,
+    run_id: str,
+    log_path: Path,
+    artifact_dir: str = "logs",
+) -> None:
+    if not log_path.exists():
+        raise ValueError(f"Runtime log artifact does not exist: {log_path}")
+    _client(config).log_artifact(run_id, str(log_path), artifact_dir)
+
+
 def download_candidate_bundle(
     config: AppConfig,
     candidate_id: str,

--- a/src/tabular_shenanigans/runtime_logging.py
+++ b/src/tabular_shenanigans/runtime_logging.py
@@ -1,0 +1,136 @@
+import io
+import os
+import sys
+import warnings
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, TextIO
+
+RUNTIME_LOG_ARTIFACT_DIRNAME = "logs"
+RUNTIME_LOG_FILENAME = "runtime.log"
+
+
+def build_runtime_log_path(bundle_root: Path) -> Path:
+    return bundle_root / RUNTIME_LOG_ARTIFACT_DIRNAME / RUNTIME_LOG_FILENAME
+
+
+def _timestamp_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def append_runtime_log_message(log_path: Path, stream_name: str, message: str) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as log_file:
+        for raw_line in message.splitlines():
+            if not raw_line:
+                continue
+            log_file.write(f"{_timestamp_utc()} [{stream_name}] {raw_line}\n")
+        log_file.flush()
+
+
+class _TimestampedTeeStream(io.TextIOBase):
+    def __init__(self, console_stream: TextIO, log_file: TextIO, stream_name: str) -> None:
+        self._console_stream = console_stream
+        self._log_file = log_file
+        self._stream_name = stream_name
+        self._buffer = ""
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._console_stream, "encoding", "utf-8")
+
+    def write(self, text: str) -> int:
+        if not text:
+            return 0
+        self._console_stream.write(text)
+        for character in text:
+            if character in {"\n", "\r"}:
+                self._flush_buffered_line()
+                continue
+            self._buffer += character
+        return len(text)
+
+    def flush(self) -> None:
+        self._console_stream.flush()
+        if self._log_file.closed:
+            self._buffer = ""
+            return
+        self._flush_buffered_line()
+        self._log_file.flush()
+
+    def isatty(self) -> bool:
+        isatty = getattr(self._console_stream, "isatty", None)
+        return bool(isatty()) if callable(isatty) else False
+
+    def fileno(self) -> int:
+        return self._console_stream.fileno()
+
+    def writable(self) -> bool:
+        return True
+
+    def _flush_buffered_line(self) -> None:
+        if self._log_file.closed:
+            self._buffer = ""
+            return
+        if not self._buffer:
+            return
+        self._log_file.write(f"{_timestamp_utc()} [{self._stream_name}] {self._buffer}\n")
+        self._log_file.flush()
+        self._buffer = ""
+
+
+@contextmanager
+def capture_runtime_log(log_path: Path) -> Iterator[Path]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log_file:
+        stdout_tee = _TimestampedTeeStream(sys.stdout, log_file, "stdout")
+        stderr_tee = _TimestampedTeeStream(sys.stderr, log_file, "stderr")
+        original_stdout = sys.stdout
+        original_stderr = sys.stderr
+        original_showwarning = warnings.showwarning
+
+        def _showwarning(
+            message,
+            category,
+            filename,
+            lineno,
+            file=None,
+            line=None,
+        ) -> None:
+            formatted_warning = warnings.formatwarning(message, category, filename, lineno, line)
+            if file is not None:
+                file.write(formatted_warning)
+                file.flush()
+                return
+            stderr_tee.write(formatted_warning)
+            stderr_tee.flush()
+
+        sys.stdout = stdout_tee
+        sys.stderr = stderr_tee
+        warnings.showwarning = _showwarning
+        try:
+            yield log_path
+        finally:
+            stdout_tee.flush()
+            stderr_tee.flush()
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
+            warnings.showwarning = original_showwarning
+
+
+def emit_runtime_log_header(
+    stage_name: str,
+    competition_slug: str,
+    candidate_id: str,
+    mlflow_run_id: str,
+) -> None:
+    print(
+        "Runtime log started: "
+        f"stage={stage_name}, competition_slug={competition_slug}, "
+        f"candidate_id={candidate_id}, mlflow_run_id={mlflow_run_id}"
+    )
+    print(
+        "Runtime environment: "
+        f"pid={os.getpid()}, cwd={Path.cwd()}, python={sys.executable}, argv={sys.argv}"
+    )

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import time
+import traceback
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,6 +24,7 @@ from tabular_shenanigans.mlflow_store import (
     create_candidate_run,
     log_candidate_run,
     terminate_run,
+    upload_run_log,
 )
 from tabular_shenanigans.model_evaluation import (
     ModelRunResult,
@@ -30,6 +32,12 @@ from tabular_shenanigans.model_evaluation import (
     TrainingModelSpec,
     build_prepared_training_context,
     evaluate_model_spec,
+)
+from tabular_shenanigans.runtime_logging import (
+    append_runtime_log_message,
+    build_runtime_log_path,
+    capture_runtime_log,
+    emit_runtime_log_header,
 )
 
 
@@ -214,6 +222,8 @@ def _stage_candidate_bundle(
 def run_training(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
+    candidate_run: CandidateRunRef,
+    bundle_root: Path,
     model_spec: TrainingModelSpec | None = None,
     tuning_provenance: dict[str, object] | None = None,
     optimization_artifacts: OptimizationArtifacts | None = None,
@@ -266,11 +276,6 @@ def run_training(
         config_snapshot=config_snapshot,
         model_result=model_result,
     )
-    candidate_run = create_candidate_run(
-        config=config,
-        candidate_id=candidate_id,
-        candidate_type=candidate.candidate_type,
-    )
     candidate_manifest = _build_candidate_manifest(
         config=config,
         generated_at_utc=datetime.now(timezone.utc).isoformat(),
@@ -281,33 +286,25 @@ def run_training(
         tuning_provenance=tuning_provenance,
         mlflow_run_id=candidate_run.run_id,
     )
-
-    try:
-        with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-candidate-") as temp_dir:
-            bundle_root = Path(temp_dir)
-            _stage_candidate_bundle(
-                bundle_root=bundle_root,
-                config=config,
-                candidate_manifest=candidate_manifest,
-                training_context=training_context,
-                dataset_context=dataset_context,
-                evaluation_artifacts=evaluation_artifacts,
-                optimization_artifacts=optimization_artifacts,
-            )
-            optimization_summary = optimization_artifacts.summary if optimization_artifacts is not None else None
-            log_candidate_run(
-                config=config,
-                candidate_run=candidate_run,
-                bundle_root=bundle_root,
-                manifest=candidate_manifest,
-                fit_wall_seconds=fit_wall_seconds,
-                optimization_summary=optimization_summary,
-            )
-        terminate_run(config=config, run_id=candidate_run.run_id, status="FINISHED")
-        return candidate_run
-    except Exception:
-        terminate_run(config=config, run_id=candidate_run.run_id, status="FAILED")
-        raise
+    _stage_candidate_bundle(
+        bundle_root=bundle_root,
+        config=config,
+        candidate_manifest=candidate_manifest,
+        training_context=training_context,
+        dataset_context=dataset_context,
+        evaluation_artifacts=evaluation_artifacts,
+        optimization_artifacts=optimization_artifacts,
+    )
+    optimization_summary = optimization_artifacts.summary if optimization_artifacts is not None else None
+    log_candidate_run(
+        config=config,
+        candidate_run=candidate_run,
+        bundle_root=bundle_root,
+        manifest=candidate_manifest,
+        fit_wall_seconds=fit_wall_seconds,
+        optimization_summary=optimization_summary,
+    )
+    return candidate_run
 
 
 def run_training_workflow(
@@ -321,34 +318,82 @@ def run_training_workflow(
         return run_blend_training(config=config, dataset_context=dataset_context)
 
     optimization = config.experiment.candidate.optimization
-    if not optimization.enabled:
-        return run_training(config=config, dataset_context=dataset_context)
+    candidate = config.experiment.candidate
+    candidate_run = create_candidate_run(
+        config=config,
+        candidate_id=config.resolved_candidate_id,
+        candidate_type=candidate.candidate_type,
+    )
+    run_status = "FAILED"
 
-    from tabular_shenanigans.tune import run_optimization
+    with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-candidate-") as temp_dir:
+        bundle_root = Path(temp_dir)
+        log_path = build_runtime_log_path(bundle_root)
+        log_uploaded = False
+        try:
+            with capture_runtime_log(log_path):
+                emit_runtime_log_header(
+                    stage_name="train",
+                    competition_slug=competition.slug,
+                    candidate_id=candidate_run.candidate_id,
+                    mlflow_run_id=candidate_run.run_id,
+                )
+                try:
+                    if not optimization.enabled:
+                        run_training(
+                            config=config,
+                            dataset_context=dataset_context,
+                            candidate_run=candidate_run,
+                            bundle_root=bundle_root,
+                        )
+                    else:
+                        from tabular_shenanigans.tune import run_optimization
 
-    prepared_training_context = build_prepared_training_context(
-        config=config,
-        dataset_context=dataset_context,
-    )
-    optimization_result = run_optimization(
-        config=config,
-        dataset_context=dataset_context,
-        prepared_training_context=prepared_training_context,
-    )
-    candidate_run = run_training(
-        config=config,
-        dataset_context=dataset_context,
-        model_spec=optimization_result.best_model_spec,
-        tuning_provenance=optimization_result.tuning_provenance,
-        optimization_artifacts=OptimizationArtifacts(
-            summary=optimization_result.optimization_summary,
-            trials_df=optimization_result.trials_df,
-        ),
-        prepared_training_context=prepared_training_context,
-    )
-    print(
-        f"Optimization complete: best_trial={optimization_result.best_trial_number}, "
-        f"best_{competition.primary_metric}={optimization_result.best_value:.6f}, "
-        f"candidate={candidate_run.candidate_id}"
-    )
-    return candidate_run
+                        prepared_training_context = build_prepared_training_context(
+                            config=config,
+                            dataset_context=dataset_context,
+                        )
+                        optimization_result = run_optimization(
+                            config=config,
+                            dataset_context=dataset_context,
+                            prepared_training_context=prepared_training_context,
+                        )
+                        run_training(
+                            config=config,
+                            dataset_context=dataset_context,
+                            candidate_run=candidate_run,
+                            bundle_root=bundle_root,
+                            model_spec=optimization_result.best_model_spec,
+                            tuning_provenance=optimization_result.tuning_provenance,
+                            optimization_artifacts=OptimizationArtifacts(
+                                summary=optimization_result.optimization_summary,
+                                trials_df=optimization_result.trials_df,
+                            ),
+                            prepared_training_context=prepared_training_context,
+                        )
+                        print(
+                            f"Optimization complete: best_trial={optimization_result.best_trial_number}, "
+                            f"best_{competition.primary_metric}={optimization_result.best_value:.6f}, "
+                            f"candidate={candidate_run.candidate_id}"
+                        )
+                except Exception:
+                    append_runtime_log_message(log_path, "stderr", traceback.format_exc())
+                    raise
+            upload_run_log(
+                config=config,
+                run_id=candidate_run.run_id,
+                log_path=log_path,
+            )
+            log_uploaded = True
+            run_status = "FINISHED"
+            return candidate_run
+        except Exception:
+            if log_path.exists() and not log_uploaded:
+                upload_run_log(
+                    config=config,
+                    run_id=candidate_run.run_id,
+                    log_path=log_path,
+                )
+            raise
+        finally:
+            terminate_run(config=config, run_id=candidate_run.run_id, status=run_status)


### PR DESCRIPTION
Closes #133

## Summary
- add timestamped runtime log capture for candidate runs
- create candidate MLflow runs before model/blend work so failed runs can still upload logs
- upload `logs/runtime.log` on both successful and failed candidate runs

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile main.py src/tabular_shenanigans/*.py src/tabular_shenanigans/feature_recipes/*.py`
- created a disposable `issue-133-smoke-binary` competition zip under `data/`
- trained two model candidates into a fresh file-backed MLflow experiment and confirmed each run stored `logs/runtime.log`
- trained one blend candidate and confirmed its MLflow run also stored `logs/runtime.log`
- ran one intentionally invalid logistic-regression candidate (`solver=lbfgs`, `penalty=l1`) and confirmed the MLflow run was marked `FAILED` with `logs/runtime.log` containing the traceback
- removed the disposable smoke data and temp MLflow store after verification