### PR TITLE
Fix logistic Optuna max_iter default

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -181,6 +181,9 @@ Model candidate contract:
 - optional `model_params` (manual estimator overrides; when omitted, the runtime uses repo defaults plus estimator library defaults)
 - optional `optimization`
 
+Optimization note:
+- logistic regression Optuna trials fix `max_iter=5000` and do not sample `max_iter`
+
 Blend candidate contract:
 - `candidate_type: blend`
 - `base_candidate_ids`

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -363,7 +363,7 @@ def _build_logreg_tuning_space(trial: object) -> dict[str, object]:
     params: dict[str, object] = {
         "C": trial.suggest_float("C", 1e-4, 1e3, log=True),
         "class_weight": trial.suggest_categorical("class_weight", [None, "balanced"]),
-        "max_iter": trial.suggest_categorical("max_iter", [1000, 2000, 4000]),
+        "max_iter": 5000,
         "solver": solver,
     }
 


### PR DESCRIPTION
Closes #135

## Summary
- stop sampling `max_iter` in the logistic-regression Optuna tuning space
- force `max_iter=5000` in logistic-regression Optuna trial parameter overrides
- document the fixed logistic Optuna default in the technical guide

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/models.py`
- direct builder check with a stub trial confirmed `trial.params` no longer includes `max_iter` while the returned logistic overrides still include `max_iter=5000`
- verified output shape: `trial_params={solver: lbfgs, C: 0.0001, class_weight: None}`, `returned_params={C: 0.0001, class_weight: None, max_iter: 5000, solver: lbfgs, penalty: l2}`