### PR TITLE
Support sparse onehot preprocessing output

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Required top-level sections:
   - optional `optimization`
     - logistic regression Optuna trials fix `solver="saga"` and `max_iter=1000`
     - logistic regression Optuna trials tune `C`, `tol`, `class_weight`, and `l1_ratio`
+  - `categorical_preprocessor: onehot` is an internal matrix-output decision, not a config knob:
+    - sparse CSR output: `ridge`, `elasticnet`, `logistic_regression`, `random_forest`, `extra_trees`, `lightgbm`, `catboost`, `xgboost`
+    - dense array output: `hist_gradient_boosting`
+    - `numeric_preprocessor: kbins` follows the same sparse-versus-dense decision when combined with `onehot`
 - blend candidate:
   - `base_candidate_ids`: at least two existing compatible candidate IDs from the same competition experiment
   - optional `weights`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -200,6 +200,12 @@ Naming contract:
 Hard-invalid preprocessing combination:
 - `categorical_preprocessor: native` with any model family other than `catboost`
 
+Sparse onehot runtime contract:
+- `categorical_preprocessor: onehot` stays an internal runtime choice rather than a user-facing dense/sparse switch
+- sparse CSR output is used for `ridge`, `elasticnet`, `logistic_regression`, `random_forest`, `extra_trees`, `lightgbm`, `catboost`, and `xgboost`
+- dense array output remains in place for `hist_gradient_boosting`
+- `numeric_preprocessor: kbins` follows the same sparse-versus-dense output contract when composed with `onehot`
+
 ## Candidate Manifest Contract
 Model candidate manifests currently record:
 - identity: `candidate_id`, `candidate_type`, `competition_slug`, `task_type`, `primary_metric`

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
 from tabular_shenanigans.candidate_artifacts import build_target_summary
 from tabular_shenanigans.competition import ensure_prepared_competition_context
@@ -9,7 +10,11 @@ from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.feature_recipes import apply_feature_recipe
-from tabular_shenanigans.models import build_model, build_model_fit_kwargs
+from tabular_shenanigans.models import (
+    build_model,
+    build_model_fit_kwargs,
+    resolve_model_matrix_output_kind,
+)
 from tabular_shenanigans.preprocess import (
     ResolvedFeatureSchema,
     build_preprocessor_from_schema,
@@ -89,6 +94,7 @@ class PreparedTrainingContext:
     numeric_preprocessor: str
     categorical_preprocessor: str
     preprocessing_scheme_id: str
+    matrix_output_kind: str
 
 
 def build_prepared_training_context(
@@ -148,6 +154,11 @@ def build_prepared_training_context(
         force_numeric=features.force_numeric,
         low_cardinality_int_threshold=features.low_cardinality_int_threshold,
     )
+    matrix_output_kind = resolve_model_matrix_output_kind(
+        task_type=competition.task_type,
+        model_id=config.resolved_model_registry_key,
+        categorical_preprocessor_id=candidate.categorical_preprocessor,
+    )
     return PreparedTrainingContext(
         id_column=id_column,
         label_column=label_column,
@@ -165,7 +176,18 @@ def build_prepared_training_context(
         numeric_preprocessor=candidate.numeric_preprocessor,
         categorical_preprocessor=candidate.categorical_preprocessor,
         preprocessing_scheme_id=candidate.preprocessing_scheme_id,
+        matrix_output_kind=matrix_output_kind,
     )
+
+
+def _coerce_processed_matrix(values: object, matrix_output_kind: str) -> object:
+    if matrix_output_kind == "native_frame":
+        if not isinstance(values, pd.DataFrame):
+            raise ValueError("Native categorical preprocessing must produce a pandas DataFrame.")
+        return values
+    if matrix_output_kind == "sparse_csr":
+        return sparse.csr_matrix(values)
+    return np.asarray(values)
 
 
 def _run_cv_evaluation(
@@ -185,6 +207,7 @@ def _run_cv_evaluation(
     resolved_model_registry_key = model_definition.model_id
     estimator_name = model_definition.model_name
     preprocessing_scheme_id = training_context.preprocessing_scheme_id
+    matrix_output_kind = training_context.matrix_output_kind
 
     oof_predictions = (
         np.zeros(training_context.x_train_features.shape[0], dtype=float)
@@ -193,7 +216,6 @@ def _run_cv_evaluation(
     )
     test_predictions_per_fold = [] if collect_prediction_artifacts else None
     fold_metrics: list[dict[str, object]] = []
-    use_named_columns = estimator_name.startswith("LGBM")
     binary_prediction_kind = None
     if task_type == "binary":
         binary_prediction_kind = get_binary_prediction_kind(primary_metric)
@@ -208,20 +230,18 @@ def _run_cv_evaluation(
             feature_schema=training_context.feature_schema,
             numeric_preprocessor_id=training_context.numeric_preprocessor,
             categorical_preprocessor_id=training_context.categorical_preprocessor,
+            matrix_output_kind=matrix_output_kind,
         )
-        if use_named_columns and hasattr(preprocessor, "set_output"):
-            preprocessor.set_output(transform="pandas")
         x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
         x_fold_valid_processed = preprocessor.transform(x_fold_valid)
         x_test_processed = None
         if collect_prediction_artifacts:
             x_test_processed = preprocessor.transform(training_context.x_test_features)
 
-        if training_context.categorical_preprocessor != "native" and not use_named_columns:
-            x_fold_train_processed = np.asarray(x_fold_train_processed)
-            x_fold_valid_processed = np.asarray(x_fold_valid_processed)
-            if x_test_processed is not None:
-                x_test_processed = np.asarray(x_test_processed)
+        x_fold_train_processed = _coerce_processed_matrix(x_fold_train_processed, matrix_output_kind)
+        x_fold_valid_processed = _coerce_processed_matrix(x_fold_valid_processed, matrix_output_kind)
+        if x_test_processed is not None:
+            x_test_processed = _coerce_processed_matrix(x_test_processed, matrix_output_kind)
 
         _, model, _ = build_model(
             task_type,
@@ -234,7 +254,7 @@ def _run_cv_evaluation(
             x_train_processed=x_fold_train_processed,
             numeric_columns=training_context.feature_schema.numeric_columns,
             categorical_columns=training_context.feature_schema.categorical_columns,
-            uses_native_categorical_preprocessing=training_context.categorical_preprocessor == "native",
+            uses_native_categorical_preprocessing=matrix_output_kind == "native_frame",
         )
         model.fit(x_fold_train_processed, y_fold_train, **model_fit_kwargs)
 

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -28,6 +28,7 @@ class ModelDefinition:
     fit_kwargs_builder: FitKwargsBuilder | None = None
     tuning_space_builder: TuningSpaceBuilder | None = None
     supports_native_categorical_preprocessing: bool = False
+    supports_sparse_preprocessed_input: bool = False
 
 
 class BinaryLabelEncodingClassifier:
@@ -519,23 +520,27 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_id="ridge",
             model_name="Ridge",
             builder=_build_ridge,
+            supports_sparse_preprocessed_input=True,
         ),
         "elasticnet": ModelDefinition(
             model_id="elasticnet",
             model_name="ElasticNet",
             builder=_build_elasticnet,
+            supports_sparse_preprocessed_input=True,
         ),
         "random_forest": ModelDefinition(
             model_id="random_forest",
             model_name="RandomForestRegressor",
             builder=_build_random_forest_regressor,
             tuning_space_builder=_build_random_forest_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "extra_trees": ModelDefinition(
             model_id="extra_trees",
             model_name="ExtraTreesRegressor",
             builder=_build_extra_trees_regressor,
             tuning_space_builder=_build_extra_trees_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "hist_gradient_boosting": ModelDefinition(
             model_id="hist_gradient_boosting",
@@ -548,6 +553,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LGBMRegressor",
             builder=_build_lightgbm_regressor,
             tuning_space_builder=_build_lightgbm_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "catboost": ModelDefinition(
             model_id="catboost",
@@ -556,12 +562,14 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             fit_kwargs_builder=_build_catboost_fit_kwargs,
             tuning_space_builder=_build_catboost_tuning_space,
             supports_native_categorical_preprocessing=True,
+            supports_sparse_preprocessed_input=True,
         ),
         "xgboost": ModelDefinition(
             model_id="xgboost",
             model_name="XGBRegressor",
             builder=_build_xgboost_regressor,
             tuning_space_builder=_build_xgboost_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
     },
     "binary": {
@@ -570,18 +578,21 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LogisticRegression",
             builder=_build_logreg,
             tuning_space_builder=_build_logreg_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "random_forest": ModelDefinition(
             model_id="random_forest",
             model_name="RandomForestClassifier",
             builder=_build_random_forest_classifier,
             tuning_space_builder=_build_random_forest_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "extra_trees": ModelDefinition(
             model_id="extra_trees",
             model_name="ExtraTreesClassifier",
             builder=_build_extra_trees_classifier,
             tuning_space_builder=_build_extra_trees_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "hist_gradient_boosting": ModelDefinition(
             model_id="hist_gradient_boosting",
@@ -594,6 +605,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LGBMClassifier",
             builder=_build_lightgbm_classifier,
             tuning_space_builder=_build_lightgbm_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
         "catboost": ModelDefinition(
             model_id="catboost",
@@ -602,12 +614,14 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             fit_kwargs_builder=_build_catboost_fit_kwargs,
             tuning_space_builder=_build_catboost_tuning_space,
             supports_native_categorical_preprocessing=True,
+            supports_sparse_preprocessed_input=True,
         ),
         "xgboost": ModelDefinition(
             model_id="xgboost",
             model_name="XGBClassifier",
             builder=_build_xgboost_classifier,
             tuning_space_builder=_build_xgboost_tuning_space,
+            supports_sparse_preprocessed_input=True,
         ),
     },
 }
@@ -669,6 +683,19 @@ def validate_model_preprocessing_compatibility(
         f"Model family '{model_definition.model_id}' does not support "
         "categorical_preprocessor='native'. Use model_family='catboost' for native categorical handling."
     )
+
+
+def resolve_model_matrix_output_kind(
+    task_type: str,
+    model_id: str,
+    categorical_preprocessor_id: str,
+) -> str:
+    model_definition = get_model_definition(task_type, model_id)
+    if categorical_preprocessor_id == "native":
+        return "native_frame"
+    if categorical_preprocessor_id == "onehot" and model_definition.supports_sparse_preprocessed_input:
+        return "sparse_csr"
+    return "dense_array"
 
 
 def resolve_model_id(task_type: str, model_id: str) -> str:

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -14,8 +14,9 @@ from sklearn.preprocessing import (
     StandardScaler,
 )
 
-NumericPreprocessorBuilder = Callable[[], object]
-CategoricalPreprocessorBuilder = Callable[[], object]
+MatrixOutputKind = str
+NumericPreprocessorBuilder = Callable[[MatrixOutputKind], object]
+CategoricalPreprocessorBuilder = Callable[[MatrixOutputKind], object]
 
 NUMERIC_PREPROCESSOR_IDS = tuple(["median", "standardize", "kbins"])
 CATEGORICAL_PREPROCESSOR_IDS = tuple(["onehot", "ordinal", "frequency", "native"])
@@ -306,11 +307,13 @@ def prepare_feature_frames(
     return x_train_raw, x_test_raw, y_train
 
 
-def _build_numeric_median_preprocessor() -> object:
+def _build_numeric_median_preprocessor(matrix_output_kind: MatrixOutputKind) -> object:
+    del matrix_output_kind
     return SimpleImputer(strategy="median")
 
 
-def _build_numeric_standardize_preprocessor() -> object:
+def _build_numeric_standardize_preprocessor(matrix_output_kind: MatrixOutputKind) -> object:
+    del matrix_output_kind
     return Pipeline(
         steps=[
             ("imputer", SimpleImputer(strategy="median")),
@@ -319,7 +322,10 @@ def _build_numeric_standardize_preprocessor() -> object:
     )
 
 
-def _build_numeric_kbins_preprocessor() -> object:
+def _build_numeric_kbins_preprocessor(matrix_output_kind: MatrixOutputKind) -> object:
+    kbins_encode = "onehot-dense"
+    if matrix_output_kind == "sparse_csr":
+        kbins_encode = "onehot"
     return Pipeline(
         steps=[
             ("imputer", SimpleImputer(strategy="median")),
@@ -327,7 +333,7 @@ def _build_numeric_kbins_preprocessor() -> object:
                 "kbins",
                 KBinsDiscretizer(
                     n_bins=5,
-                    encode="onehot-dense",
+                    encode=kbins_encode,
                     strategy="quantile",
                     quantile_method="averaged_inverted_cdf",
                 ),
@@ -336,17 +342,19 @@ def _build_numeric_kbins_preprocessor() -> object:
     )
 
 
-def _build_categorical_onehot_preprocessor() -> object:
+def _build_categorical_onehot_preprocessor(matrix_output_kind: MatrixOutputKind) -> object:
+    sparse_output = matrix_output_kind == "sparse_csr"
     return Pipeline(
         steps=[
             ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
             ("imputer", SimpleImputer(strategy="most_frequent")),
-            ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
+            ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=sparse_output)),
         ]
     )
 
 
-def _build_categorical_ordinal_preprocessor() -> object:
+def _build_categorical_ordinal_preprocessor(matrix_output_kind: MatrixOutputKind) -> object:
+    del matrix_output_kind
     return Pipeline(
         steps=[
             ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
@@ -431,13 +439,17 @@ def _build_column_transformer_preprocessor(
     feature_schema: ResolvedFeatureSchema,
     numeric_preprocessor: object,
     categorical_preprocessor: object,
+    matrix_output_kind: MatrixOutputKind,
 ) -> ColumnTransformer:
     transformers = []
     if feature_schema.numeric_columns:
         transformers.append(("num", numeric_preprocessor, feature_schema.numeric_columns))
     if feature_schema.categorical_columns:
         transformers.append(("cat", categorical_preprocessor, feature_schema.categorical_columns))
-    return ColumnTransformer(transformers=transformers, remainder="drop")
+    sparse_threshold = 0.0
+    if matrix_output_kind == "sparse_csr":
+        sparse_threshold = 1.0
+    return ColumnTransformer(transformers=transformers, remainder="drop", sparse_threshold=sparse_threshold)
 
 
 def build_preprocessor(
@@ -466,13 +478,14 @@ def build_preprocessor_from_schema(
     feature_schema: ResolvedFeatureSchema,
     numeric_preprocessor_id: str,
     categorical_preprocessor_id: str,
+    matrix_output_kind: MatrixOutputKind = "dense_array",
 ) -> object:
     if not feature_schema.numeric_columns and not feature_schema.categorical_columns:
         raise ValueError("No modeled features remain after excluding id_column and applying drop_columns.")
 
     numeric_definition = get_numeric_preprocessing_definition(numeric_preprocessor_id)
     categorical_definition = get_categorical_preprocessing_definition(categorical_preprocessor_id)
-    numeric_preprocessor = numeric_definition.builder()
+    numeric_preprocessor = numeric_definition.builder(matrix_output_kind)
 
     if categorical_definition.compose_mode == "column_transformer":
         if categorical_definition.builder is None:
@@ -480,7 +493,8 @@ def build_preprocessor_from_schema(
         return _build_column_transformer_preprocessor(
             feature_schema=feature_schema,
             numeric_preprocessor=numeric_preprocessor,
-            categorical_preprocessor=categorical_definition.builder(),
+            categorical_preprocessor=categorical_definition.builder(matrix_output_kind),
+            matrix_output_kind=matrix_output_kind,
         )
 
     if categorical_definition.compose_mode == "frequency_frame":


### PR DESCRIPTION
Closes #88

## Summary
- add sparse preprocessed-input capability metadata to model definitions
- make onehot and kbins preprocessing emit sparse CSR output for models that support sparse matrices
- route matrix output kind through the shared evaluation path instead of forcing onehot outputs through `np.asarray(...)`
- keep dense fallback for models that require dense input, especially HistGradientBoosting
- document the current sparse-versus-dense runtime behavior

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/models.py src/tabular_shenanigans/preprocess.py src/tabular_shenanigans/model_evaluation.py main.py`
- direct preprocessing probe confirms `build_preprocessor_from_schema(..., matrix_output_kind="sparse_csr")` now returns a CSR matrix for onehot and `dense_array` still returns an ndarray
- direct sparse fit probes succeeded for these families on CSR input: `ridge`, `elasticnet`, `logistic_regression`, `random_forest`, `extra_trees`, `lightgbm`, `catboost`, `xgboost`
- direct sparse fit probe confirmed `hist_gradient_boosting` still requires dense input and remains on the dense path
- real `playground-series-s6e3` matrix contract check on the first CV fold:
  - logistic onehot path: `csr_matrix`, shape `509309 x 103`, density `0.368932`, approx `223.4 MB`
  - HistGradientBoosting onehot control: dense `ndarray`, shape `509309 x 103`, approx `400.2 MB`

## Limitations
- I did not complete a full end-to-end `s6e3` training candidate as part of this issue because the runtime bottleneck on `saga` remains computationally heavy even after the sparse-output fix
- this issue fixes the matrix-output contract and memory behavior; it does not solve all remaining logistic optimization throughput concerns