### PR TITLE
Add s6e3 fr2 ablation recipes and run grouped scout

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Required top-level sections:
 - shared:
   - `candidate_type`: `model` or `blend`
 - model candidate:
-  - `feature_recipe_id`: built-in values are `fr0`, `fr1`, and `fr2`
+  - `feature_recipe_id`: built-in values are `fr0`, `fr1`, `fr2`, and the `fr2_ablate_*` grouped ablation variants for `playground-series-s6e3`
   - `model_family`
     - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
     - binary: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -131,7 +131,7 @@ Stage notes:
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
 - [data.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/data.py): Kaggle downloads, zip access, schema inference, and sample-submission loading.
 - [eda.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/eda.py): local EDA report generation.
-- [feature_recipes](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, and `fr2`.
+- [feature_recipes](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, `fr2`, and the `fr2_ablate_*` grouped ablation variants used for `s6e3` recipe studies.
 - [model_evaluation.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/model_evaluation.py): shared prepared training context and reusable CV evaluation logic for train/tune.
 - [models.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/models.py): model registry, capability checks, estimator construction, and tuning space definitions.
 - [preprocess.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/preprocess.py): raw feature-frame preparation and split preprocessing components.

--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -37,6 +37,32 @@ SERVICE_ADDON_COLUMNS = [
 STREAMING_COLUMNS = ["StreamingTV", "StreamingMovies"]
 SUPPORT_COLUMNS = ["OnlineSecurity", "OnlineBackup", "DeviceProtection", "TechSupport"]
 SERVICE_COLUMNS = ["PhoneService", "MultipleLines", *SERVICE_ADDON_COLUMNS]
+FR2_CHARGE_CONSISTENCY_COLUMNS = [
+    "charges_per_month",
+    "charges_gap",
+    "charges_per_tenure",
+    "total_vs_expected",
+    "tenure_monthlycharges_interaction",
+]
+FR2_SERVICE_COUNT_COLUMNS = [
+    "service_addon_count",
+    "streaming_count",
+    "support_count",
+    "service_count",
+    "tenure_service_interaction",
+]
+FR2_CONTRACT_PAYMENT_COLUMNS = [
+    "is_monthly_contract",
+    "is_autopay",
+]
+FR2_BUCKET_PROFILE_COLUMNS = [
+    "tenure_bucket",
+    "tenure_contract",
+    "internet_payment_profile",
+    "household_profile",
+    "senior_household_profile",
+    "paperless_payment_profile",
+]
 
 
 def _require_columns(
@@ -122,6 +148,14 @@ def _transform_v2_frame(frame: pd.DataFrame) -> pd.DataFrame:
     return transformed
 
 
+def _transform_v2_ablation_frame(
+    frame: pd.DataFrame,
+    dropped_columns: list[str],
+) -> pd.DataFrame:
+    transformed = _transform_v2_frame(frame)
+    return transformed.drop(columns=dropped_columns)
+
+
 def build_s6e3_v1_features(
     x_train_raw: pd.DataFrame,
     x_test_raw: pd.DataFrame,
@@ -160,6 +194,55 @@ def build_s6e3_v2_features(
     return _transform_v2_frame(x_train_raw), _transform_v2_frame(x_test_raw)
 
 
+def _build_s6e3_v2_ablation_features(
+    recipe_id: str,
+    dropped_columns: list[str],
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    _require_columns(
+        x_train_raw,
+        dataset_name="train features",
+        recipe_id=recipe_id,
+        required_columns=FR2_REQUIRED_COLUMNS,
+    )
+    _require_columns(
+        x_test_raw,
+        dataset_name="test features",
+        recipe_id=recipe_id,
+        required_columns=FR2_REQUIRED_COLUMNS,
+    )
+    return (
+        _transform_v2_ablation_frame(x_train_raw, dropped_columns=dropped_columns),
+        _transform_v2_ablation_frame(x_test_raw, dropped_columns=dropped_columns),
+    )
+
+
+def _make_s6e3_v2_ablation_recipe(
+    recipe_id: str,
+    recipe_name: str,
+    recipe_description: str,
+    dropped_columns: list[str],
+) -> FeatureRecipeDefinition:
+    def _transform(
+        x_train_raw: pd.DataFrame,
+        x_test_raw: pd.DataFrame,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        return _build_s6e3_v2_ablation_features(
+            recipe_id=recipe_id,
+            dropped_columns=dropped_columns,
+            x_train_raw=x_train_raw,
+            x_test_raw=x_test_raw,
+        )
+
+    return FeatureRecipeDefinition(
+        recipe_id=recipe_id,
+        recipe_name=recipe_name,
+        recipe_description=recipe_description,
+        transform=_transform,
+    )
+
+
 S6E3_V1_FEATURE_RECIPE = FeatureRecipeDefinition(
     recipe_id="fr1",
     recipe_name="TelcoChurnFeatureSetV1",
@@ -176,3 +259,38 @@ S6E3_V2_FEATURE_RECIPE = FeatureRecipeDefinition(
     ),
     transform=build_s6e3_v2_features,
 )
+
+S6E3_V2_ABLATE_CHARGE_CONSISTENCY_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
+    recipe_id="fr2_ablate_charge",
+    recipe_name="TelcoChurnFeatureSetV2AblateChargeConsistency",
+    recipe_description="fr2 ablation variant with charge-consistency engineered features removed.",
+    dropped_columns=FR2_CHARGE_CONSISTENCY_COLUMNS,
+)
+
+S6E3_V2_ABLATE_SERVICE_COUNTS_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
+    recipe_id="fr2_ablate_service",
+    recipe_name="TelcoChurnFeatureSetV2AblateServiceCounts",
+    recipe_description="fr2 ablation variant with service-count engineered features removed.",
+    dropped_columns=FR2_SERVICE_COUNT_COLUMNS,
+)
+
+S6E3_V2_ABLATE_CONTRACT_PAYMENT_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
+    recipe_id="fr2_ablate_contract",
+    recipe_name="TelcoChurnFeatureSetV2AblateContractPayment",
+    recipe_description="fr2 ablation variant with contract/payment engineered features removed.",
+    dropped_columns=FR2_CONTRACT_PAYMENT_COLUMNS,
+)
+
+S6E3_V2_ABLATE_BUCKET_PROFILE_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
+    recipe_id="fr2_ablate_profiles",
+    recipe_name="TelcoChurnFeatureSetV2AblateBucketProfiles",
+    recipe_description="fr2 ablation variant with tenure/profile cross engineered features removed.",
+    dropped_columns=FR2_BUCKET_PROFILE_COLUMNS,
+)
+
+S6E3_ABLATION_FEATURE_RECIPES = [
+    S6E3_V2_ABLATE_CHARGE_CONSISTENCY_FEATURE_RECIPE,
+    S6E3_V2_ABLATE_SERVICE_COUNTS_FEATURE_RECIPE,
+    S6E3_V2_ABLATE_CONTRACT_PAYMENT_FEATURE_RECIPE,
+    S6E3_V2_ABLATE_BUCKET_PROFILE_FEATURE_RECIPE,
+]

--- a/src/tabular_shenanigans/feature_recipes/registry.py
+++ b/src/tabular_shenanigans/feature_recipes/registry.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from tabular_shenanigans.feature_recipes.base import FeatureRecipeDefinition
 from tabular_shenanigans.feature_recipes.playground_series_s6e3 import (
+    S6E3_ABLATION_FEATURE_RECIPES,
     S6E3_V1_FEATURE_RECIPE,
     S6E3_V2_FEATURE_RECIPE,
 )
@@ -25,6 +26,7 @@ FEATURE_RECIPE_REGISTRY = {
     ),
     S6E3_V1_FEATURE_RECIPE.recipe_id: S6E3_V1_FEATURE_RECIPE,
     S6E3_V2_FEATURE_RECIPE.recipe_id: S6E3_V2_FEATURE_RECIPE,
+    **{definition.recipe_id: definition for definition in S6E3_ABLATION_FEATURE_RECIPES},
 }
 
 


### PR DESCRIPTION
## Summary
- add explicit `fr2_ablate_*` grouped ablation recipes for `playground-series-s6e3`
- register and document the ablation recipe variants so MLflow candidate runs stay reproducible
- run the grouped ablation scout and record the outcome on `#144`

Closes #144

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py src/tabular_shenanigans/feature_recipes/registry.py`
- `PYTHONPATH=src .venv/bin/python - <<'PY' ...` recipe check confirming each ablation recipe drops the intended feature group from `fr2`
- grouped MLflow ablation scout on `playground-series-s6e3` using:
  - 3-fold CV
  - `logistic_regression` with `num_standardize__cat_onehot` and fixed `model_params={tol: 0.01, l1_ratio: 0.0}`
  - `lightgbm` with `num_median__cat_onehot`
  - recipes `fr2`, `fr2_ablate_charge`, `fr2_ablate_service`, `fr2_ablate_contract`, `fr2_ablate_profiles`
- results summary posted on `#144`: charge-consistency stays, contract/payment looks dead, bucket/profile crosses look removable, service counts remain neutral in this scout
