### PR TITLE
Add combined fr2 contract/profile ablation recipe

### DIFF
--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -63,6 +63,10 @@ FR2_BUCKET_PROFILE_COLUMNS = [
     "senior_household_profile",
     "paperless_payment_profile",
 ]
+FR2_CONTRACT_PROFILE_COLUMNS = [
+    *FR2_CONTRACT_PAYMENT_COLUMNS,
+    *FR2_BUCKET_PROFILE_COLUMNS,
+]
 
 
 def _require_columns(
@@ -288,9 +292,17 @@ S6E3_V2_ABLATE_BUCKET_PROFILE_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
     dropped_columns=FR2_BUCKET_PROFILE_COLUMNS,
 )
 
+S6E3_V2_ABLATE_CONTRACT_PROFILE_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
+    recipe_id="fr2_ablate_contract_profiles",
+    recipe_name="TelcoChurnFeatureSetV2AblateContractProfiles",
+    recipe_description="fr2 ablation variant with contract/payment and tenure/profile engineered features removed.",
+    dropped_columns=FR2_CONTRACT_PROFILE_COLUMNS,
+)
+
 S6E3_ABLATION_FEATURE_RECIPES = [
     S6E3_V2_ABLATE_CHARGE_CONSISTENCY_FEATURE_RECIPE,
     S6E3_V2_ABLATE_SERVICE_COUNTS_FEATURE_RECIPE,
     S6E3_V2_ABLATE_CONTRACT_PAYMENT_FEATURE_RECIPE,
     S6E3_V2_ABLATE_BUCKET_PROFILE_FEATURE_RECIPE,
+    S6E3_V2_ABLATE_CONTRACT_PROFILE_FEATURE_RECIPE,
 ]


### PR DESCRIPTION
## Summary
- add `fr2_ablate_contract_profiles` as a temporary grouped ablation recipe
- run the narrowed second-pass `s6e3` ablation study against the live MLflow experiment on `localhost:5000`
- post the result summary back to `#147`

Closes #147

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py src/tabular_shenanigans/feature_recipes/registry.py`
- direct recipe check confirming `fr2_ablate_contract_profiles` drops exactly:
  - `is_monthly_contract`
  - `is_autopay`
  - `tenure_bucket`
  - `tenure_contract`
  - `internet_payment_profile`
  - `household_profile`
  - `senior_household_profile`
  - `paperless_payment_profile`
- live MLflow second-pass matrix in experiment `25` at `http://127.0.0.1:5000/#/experiments/25` using:
  - 3-fold CV
  - seeds `42` and `123`
  - `logistic_regression` with `num_standardize__cat_onehot` and fixed `model_params={tol: 0.01, l1_ratio: 0.0}`
  - `lightgbm` with `num_median__cat_onehot`
  - recipes `fr2`, `fr2_ablate_contract`, `fr2_ablate_profiles`, `fr2_ablate_contract_profiles`
- result: the combined contract/profile ablation is neutral enough across both model families and both seeds to justify a reduced `fr3` follow-up
