### PR TITLE
Add fr3 reduced s6e3 feature recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Required top-level sections:
 - shared:
   - `candidate_type`: `model` or `blend`
 - model candidate:
-  - `feature_recipe_id`: built-in values are `fr0`, `fr1`, `fr2`, and the `fr2_ablate_*` grouped ablation variants for `playground-series-s6e3`
+  - `feature_recipe_id`: built-in values are `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*` grouped ablation variants for `playground-series-s6e3`
+    - `fr3` is the reduced stable `s6e3` engineered recipe
+    - `fr2_ablate_*` variants are study recipes used for grouped ablation work
   - `model_family`
     - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
     - binary: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -131,7 +131,7 @@ Stage notes:
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
 - [data.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/data.py): Kaggle downloads, zip access, schema inference, and sample-submission loading.
 - [eda.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/eda.py): local EDA report generation.
-- [feature_recipes](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, `fr2`, and the `fr2_ablate_*` grouped ablation variants used for `s6e3` recipe studies.
+- [feature_recipes](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*` grouped ablation variants used for `s6e3` recipe studies.
 - [model_evaluation.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/model_evaluation.py): shared prepared training context and reusable CV evaluation logic for train/tune.
 - [models.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/models.py): model registry, capability checks, estimator construction, and tuning space definitions.
 - [preprocess.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/preprocess.py): raw feature-frame preparation and split preprocessing components.

--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -198,6 +198,18 @@ def build_s6e3_v2_features(
     return _transform_v2_frame(x_train_raw), _transform_v2_frame(x_test_raw)
 
 
+def build_s6e3_v3_features(
+    x_train_raw: pd.DataFrame,
+    x_test_raw: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    return _build_s6e3_v2_ablation_features(
+        recipe_id="fr3",
+        dropped_columns=FR2_CONTRACT_PROFILE_COLUMNS,
+        x_train_raw=x_train_raw,
+        x_test_raw=x_test_raw,
+    )
+
+
 def _build_s6e3_v2_ablation_features(
     recipe_id: str,
     dropped_columns: list[str],
@@ -262,6 +274,16 @@ S6E3_V2_FEATURE_RECIPE = FeatureRecipeDefinition(
         "service-count, and charge-consistency features."
     ),
     transform=build_s6e3_v2_features,
+)
+
+S6E3_V3_FEATURE_RECIPE = FeatureRecipeDefinition(
+    recipe_id="fr3",
+    recipe_name="TelcoChurnFeatureSetV3",
+    recipe_description=(
+        "Reduced Playground Series S6E3 engineered feature set that keeps the charge-consistency "
+        "and service-count features from fr2 while dropping the contract/payment and profile-cross features."
+    ),
+    transform=build_s6e3_v3_features,
 )
 
 S6E3_V2_ABLATE_CHARGE_CONSISTENCY_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(

--- a/src/tabular_shenanigans/feature_recipes/registry.py
+++ b/src/tabular_shenanigans/feature_recipes/registry.py
@@ -5,6 +5,7 @@ from tabular_shenanigans.feature_recipes.playground_series_s6e3 import (
     S6E3_ABLATION_FEATURE_RECIPES,
     S6E3_V1_FEATURE_RECIPE,
     S6E3_V2_FEATURE_RECIPE,
+    S6E3_V3_FEATURE_RECIPE,
 )
 
 IDENTITY_FEATURE_RECIPE_ID = "fr0"
@@ -26,6 +27,7 @@ FEATURE_RECIPE_REGISTRY = {
     ),
     S6E3_V1_FEATURE_RECIPE.recipe_id: S6E3_V1_FEATURE_RECIPE,
     S6E3_V2_FEATURE_RECIPE.recipe_id: S6E3_V2_FEATURE_RECIPE,
+    S6E3_V3_FEATURE_RECIPE.recipe_id: S6E3_V3_FEATURE_RECIPE,
     **{definition.recipe_id: definition for definition in S6E3_ABLATION_FEATURE_RECIPES},
 }
 


### PR DESCRIPTION
## Summary
- add `fr3` as the reduced stable `playground-series-s6e3` engineered recipe
- register and document `fr3` while preserving `fr2` and the `fr2_ablate_*` study variants
- verify `fr3` with a real `s6e3` training run on the live MLflow server

Closes #149

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py src/tabular_shenanigans/feature_recipes/registry.py`
- direct recipe check confirming `fr3` drops exactly:
  - `is_monthly_contract`
  - `is_autopay`
  - `tenure_bucket`
  - `tenure_contract`
  - `internet_payment_profile`
  - `household_profile`
  - `senior_household_profile`
  - `paperless_payment_profile`
- real `playground-series-s6e3` live MLflow run:
  - candidate: `fr3--num_standardize__cat_onehot--logistic_regression--93cf804c`
  - experiment: `25`
  - run: `a00414997c5c4ee19eb9b77d70905207`
  - URL: `http://127.0.0.1:5000/#/experiments/25/runs/a00414997c5c4ee19eb9b77d70905207`
  - config shape: `feature_recipe_id=fr3`, `model_family=logistic_regression`, `numeric_preprocessor=standardize`, `categorical_preprocessor=onehot`, `model_params={tol: 0.01, l1_ratio: 0.0}`, `cv.n_splits=3`, `cv.random_state=42`
  - result: `cv roc_auc mean=0.911332`, `std=0.000681`, `feature_count=30`
