### PR TITLE
Add fr3 raw feature ablation recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Required top-level sections:
 - shared:
   - `candidate_type`: `model` or `blend`
 - model candidate:
-  - `feature_recipe_id`: built-in values are `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*` grouped ablation variants for `playground-series-s6e3`
+  - `feature_recipe_id`: built-in values are `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*` / `fr3_ablate_*` study variants for `playground-series-s6e3`
     - `fr3` is the reduced stable `s6e3` engineered recipe
-    - `fr2_ablate_*` variants are study recipes used for grouped ablation work
+    - `fr2_ablate_*` and `fr3_ablate_*` variants are study recipes used for grouped ablation work
   - `model_family`
     - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`
     - binary: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `lightgbm`, `catboost`, `xgboost`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -131,7 +131,7 @@ Stage notes:
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
 - [data.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/data.py): Kaggle downloads, zip access, schema inference, and sample-submission loading.
 - [eda.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/eda.py): local EDA report generation.
-- [feature_recipes](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*` grouped ablation variants used for `s6e3` recipe studies.
+- [feature_recipes](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*` / `fr3_ablate_*` grouped ablation variants used for `s6e3` recipe studies.
 - [model_evaluation.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/model_evaluation.py): shared prepared training context and reusable CV evaluation logic for train/tune.
 - [models.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/models.py): model registry, capability checks, estimator construction, and tuning space definitions.
 - [preprocess.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/preprocess.py): raw feature-frame preparation and split preprocessing components.

--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -67,6 +67,44 @@ FR2_CONTRACT_PROFILE_COLUMNS = [
     *FR2_CONTRACT_PAYMENT_COLUMNS,
     *FR2_BUCKET_PROFILE_COLUMNS,
 ]
+FR3_DEMOGRAPHICS_COLUMNS = [
+    "SeniorCitizen",
+    "Partner",
+    "Dependents",
+]
+FR3_TENURE_CHARGES_COLUMNS = [
+    "tenure",
+    "MonthlyCharges",
+    "TotalCharges",
+    "charges_per_month",
+    "charges_gap",
+    "charges_per_tenure",
+    "total_vs_expected",
+    "tenure_monthlycharges_interaction",
+    "tenure_service_interaction",
+]
+FR3_SERVICE_COLUMNS = [
+    "PhoneService",
+    "MultipleLines",
+    "InternetService",
+    "OnlineSecurity",
+    "OnlineBackup",
+    "DeviceProtection",
+    "TechSupport",
+    "StreamingTV",
+    "StreamingMovies",
+    "has_internet_service",
+    "service_addon_count",
+    "streaming_count",
+    "support_count",
+    "service_count",
+    "tenure_service_interaction",
+]
+FR3_BILLING_CONTRACT_COLUMNS = [
+    "Contract",
+    "PaperlessBilling",
+    "PaymentMethod",
+]
 
 
 def _require_columns(
@@ -160,6 +198,18 @@ def _transform_v2_ablation_frame(
     return transformed.drop(columns=dropped_columns)
 
 
+def _transform_v3_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    return _transform_v2_ablation_frame(frame, dropped_columns=FR2_CONTRACT_PROFILE_COLUMNS)
+
+
+def _transform_v3_ablation_frame(
+    frame: pd.DataFrame,
+    dropped_columns: list[str],
+) -> pd.DataFrame:
+    transformed = _transform_v3_frame(frame)
+    return transformed.drop(columns=dropped_columns)
+
+
 def build_s6e3_v1_features(
     x_train_raw: pd.DataFrame,
     x_test_raw: pd.DataFrame,
@@ -202,12 +252,19 @@ def build_s6e3_v3_features(
     x_train_raw: pd.DataFrame,
     x_test_raw: pd.DataFrame,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    return _build_s6e3_v2_ablation_features(
+    _require_columns(
+        x_train_raw,
+        dataset_name="train features",
         recipe_id="fr3",
-        dropped_columns=FR2_CONTRACT_PROFILE_COLUMNS,
-        x_train_raw=x_train_raw,
-        x_test_raw=x_test_raw,
+        required_columns=FR2_REQUIRED_COLUMNS,
     )
+    _require_columns(
+        x_test_raw,
+        dataset_name="test features",
+        recipe_id="fr3",
+        required_columns=FR2_REQUIRED_COLUMNS,
+    )
+    return _transform_v3_frame(x_train_raw), _transform_v3_frame(x_test_raw)
 
 
 def _build_s6e3_v2_ablation_features(
@@ -259,6 +316,41 @@ def _make_s6e3_v2_ablation_recipe(
     )
 
 
+def _make_s6e3_v3_ablation_recipe(
+    recipe_id: str,
+    recipe_name: str,
+    recipe_description: str,
+    dropped_columns: list[str],
+) -> FeatureRecipeDefinition:
+    def _transform(
+        x_train_raw: pd.DataFrame,
+        x_test_raw: pd.DataFrame,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        _require_columns(
+            x_train_raw,
+            dataset_name="train features",
+            recipe_id=recipe_id,
+            required_columns=FR2_REQUIRED_COLUMNS,
+        )
+        _require_columns(
+            x_test_raw,
+            dataset_name="test features",
+            recipe_id=recipe_id,
+            required_columns=FR2_REQUIRED_COLUMNS,
+        )
+        return (
+            _transform_v3_ablation_frame(x_train_raw, dropped_columns=dropped_columns),
+            _transform_v3_ablation_frame(x_test_raw, dropped_columns=dropped_columns),
+        )
+
+    return FeatureRecipeDefinition(
+        recipe_id=recipe_id,
+        recipe_name=recipe_name,
+        recipe_description=recipe_description,
+        transform=_transform,
+    )
+
+
 S6E3_V1_FEATURE_RECIPE = FeatureRecipeDefinition(
     recipe_id="fr1",
     recipe_name="TelcoChurnFeatureSetV1",
@@ -284,6 +376,34 @@ S6E3_V3_FEATURE_RECIPE = FeatureRecipeDefinition(
         "and service-count features from fr2 while dropping the contract/payment and profile-cross features."
     ),
     transform=build_s6e3_v3_features,
+)
+
+S6E3_V3_ABLATE_DEMOGRAPHICS_FEATURE_RECIPE = _make_s6e3_v3_ablation_recipe(
+    recipe_id="fr3_ablate_demographics",
+    recipe_name="TelcoChurnFeatureSetV3AblateDemographics",
+    recipe_description="fr3 ablation variant with the demographics signal family removed.",
+    dropped_columns=FR3_DEMOGRAPHICS_COLUMNS,
+)
+
+S6E3_V3_ABLATE_TENURE_CHARGES_FEATURE_RECIPE = _make_s6e3_v3_ablation_recipe(
+    recipe_id="fr3_ablate_tenure_charges",
+    recipe_name="TelcoChurnFeatureSetV3AblateTenureCharges",
+    recipe_description="fr3 ablation variant with the tenure and charges signal family removed.",
+    dropped_columns=FR3_TENURE_CHARGES_COLUMNS,
+)
+
+S6E3_V3_ABLATE_SERVICES_FEATURE_RECIPE = _make_s6e3_v3_ablation_recipe(
+    recipe_id="fr3_ablate_services",
+    recipe_name="TelcoChurnFeatureSetV3AblateServices",
+    recipe_description="fr3 ablation variant with the services signal family removed.",
+    dropped_columns=FR3_SERVICE_COLUMNS,
+)
+
+S6E3_V3_ABLATE_BILLING_CONTRACT_FEATURE_RECIPE = _make_s6e3_v3_ablation_recipe(
+    recipe_id="fr3_ablate_billing_contract",
+    recipe_name="TelcoChurnFeatureSetV3AblateBillingContract",
+    recipe_description="fr3 ablation variant with the billing/contract raw signal family removed.",
+    dropped_columns=FR3_BILLING_CONTRACT_COLUMNS,
 )
 
 S6E3_V2_ABLATE_CHARGE_CONSISTENCY_FEATURE_RECIPE = _make_s6e3_v2_ablation_recipe(
@@ -327,4 +447,8 @@ S6E3_ABLATION_FEATURE_RECIPES = [
     S6E3_V2_ABLATE_CONTRACT_PAYMENT_FEATURE_RECIPE,
     S6E3_V2_ABLATE_BUCKET_PROFILE_FEATURE_RECIPE,
     S6E3_V2_ABLATE_CONTRACT_PROFILE_FEATURE_RECIPE,
+    S6E3_V3_ABLATE_DEMOGRAPHICS_FEATURE_RECIPE,
+    S6E3_V3_ABLATE_TENURE_CHARGES_FEATURE_RECIPE,
+    S6E3_V3_ABLATE_SERVICES_FEATURE_RECIPE,
+    S6E3_V3_ABLATE_BILLING_CONTRACT_FEATURE_RECIPE,
 ]


### PR DESCRIPTION
## Summary
- add dependency-aware `fr3_ablate_*` raw-feature study variants for `s6e3`
- document the `fr3_ablate_*` study surface
- run the live reduced-overhead raw-feature ablation matrix and post the results to `#145`

Closes #145

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py src/tabular_shenanigans/feature_recipes/registry.py`
- direct recipe check confirming:
  - `fr3_ablate_demographics` drops the three demographics columns
  - `fr3_ablate_tenure_charges` drops the raw tenure/charges columns plus their dependent engineered features
  - `fr3_ablate_services` drops the raw services columns plus their dependent engineered features
  - `fr3_ablate_billing_contract` drops the three billing/contract raw columns
- live MLflow study in experiment `25` at `http://127.0.0.1:5000/#/experiments/25` using:
  - baseline `fr3`
  - `fr3_ablate_demographics`
  - `fr3_ablate_tenure_charges`
  - `fr3_ablate_services`
  - `fr3_ablate_billing_contract`
  - seeds `42` and `123`
  - `logistic_regression` with `num_standardize__cat_onehot` and fixed `model_params={tol: 0.01, l1_ratio: 0.0}`
  - `lightgbm` with `num_median__cat_onehot`
- result: all four raw signal families produce consistent negative deltas across both model families and both seeds, so none of them is removable
