### PR TITLE
Add config-driven runtime execution scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ cp config.regression.example.yaml config.yaml
 
 `config.yaml` is the only runtime config source. It is intentionally ignored by Git.
 
-`main.py` is a thin wrapper around a stdlib-only bootstrap module. The bootstrap runs
-before the runtime imports application modules so future accelerator hooks can patch
-imports safely without changing the user-facing command.
+`main.py` is a thin wrapper around a bootstrap module. The bootstrap runs before the
+runtime imports application modules that depend on `pandas` or `sklearn`, so future
+accelerator hooks can patch imports safely without changing the user-facing command.
 
 ## Stage Commands
 `uv run python main.py` runs the default pipeline: `fetch -> prepare -> train -> submit`.
@@ -114,11 +114,18 @@ Required top-level sections:
 
 `experiment` keys:
 - required `tracking`
+- optional `runtime`
 - required `candidate`
 - optional `submit`
 
 `experiment.tracking` keys:
 - `tracking_uri`: MLflow tracking URI. This is required.
+
+`experiment.runtime` keys:
+- `compute_target`: `auto`, `cpu`, or `gpu`
+  - `auto`: prefer GPU when the runtime exposes visible NVIDIA devices, otherwise fall back to CPU
+  - `cpu`: force CPU execution
+  - `gpu`: require GPU execution and fail fast when no GPU runtime is available
 
 `experiment.candidate` keys:
 - shared:

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -32,6 +32,9 @@ experiment:
   tracking:
     tracking_uri: http://localhost:5000
 
+  runtime:
+    compute_target: auto
+
   candidate:
     candidate_type: model
     feature_recipe_id: fr0

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -28,6 +28,9 @@ experiment:
   tracking:
     tracking_uri: http://localhost:5000
 
+  runtime:
+    compute_target: auto
+
   candidate:
     candidate_type: model
     feature_recipe_id: fr0

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -4,24 +4,25 @@ Technical reference for the current repository design. Use GitHub issues and pul
 
 ## System Flow
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Load and validate the repository-root `config.yaml`.
-3. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
-4. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
-5. Download the competition zip into `data/<competition_slug>/` when it is missing.
-6. Load one shared dataset context from `train.csv`, `test.csv`, and `sample_submission.csv`.
-7. Resolve `id_column` and `label_column`, then prepare raw feature frames with the resolved ID column excluded from modeled features.
-8. For model candidates, apply the selected deterministic feature recipe.
-9. Build the competition fold assignments in memory from the configured CV settings.
-10. For model candidates, fit the selected preprocessing + model combination fold-locally and produce OOF/test predictions.
-11. For blend candidates, download compatible base candidates from the competition MLflow experiment, validate compatibility, and combine their saved predictions without retraining the base candidates.
-12. Stage the candidate bundle into a temp directory:
+2. Read `experiment.runtime.compute_target` from repository-root `config.yaml` and resolve the requested execution mode to CPU or GPU for the current machine.
+3. Load and validate the repository-root `config.yaml`.
+4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
+5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
+6. Download the competition zip into `data/<competition_slug>/` when it is missing.
+7. Load one shared dataset context from `train.csv`, `test.csv`, and `sample_submission.csv`.
+8. Resolve `id_column` and `label_column`, then prepare raw feature frames with the resolved ID column excluded from modeled features.
+9. For model candidates, apply the selected deterministic feature recipe.
+10. Build the competition fold assignments in memory from the configured CV settings.
+11. For model candidates, fit the selected preprocessing + model combination fold-locally and produce OOF/test predictions.
+12. For blend candidates, download compatible base candidates from the competition MLflow experiment, validate compatibility, and combine their saved predictions without retraining the base candidates.
+13. Stage the candidate bundle into a temp directory:
     - `config/runtime_config.json`
     - `context/competition.json`
     - `context/folds.csv`
     - `candidate/*`
-13. Create one MLflow run for the candidate and upload the staged bundle.
-14. For real Kaggle submissions, download the candidate from MLflow, validate `test_predictions.csv` against `sample_submission.csv`, submit `submission.csv`, and append submission history artifacts back onto that same candidate run.
-15. For submission refresh, scan Kaggle submissions once, match `submit=<submission_event_id>` descriptions, and update candidate-run submission history plus scoreboard metrics in place.
+14. Create one MLflow run for the candidate and upload the staged bundle.
+15. For real Kaggle submissions, download the candidate from MLflow, validate `test_predictions.csv` against `sample_submission.csv`, submit `submission.csv`, and append submission history artifacts back onto that same candidate run.
+16. For submission refresh, scan Kaggle submissions once, match `submit=<submission_event_id>` descriptions, and update candidate-run submission history plus scoreboard metrics in place.
 
 ## Canonical Storage Model
 - MLflow is the canonical experiment store.
@@ -47,6 +48,8 @@ Current candidate-run tags:
 - `candidate_type`
 - `task_type`
 - `primary_metric`
+- `runtime_requested_compute_target`
+- `runtime_resolved_compute_target`
 - `config_fingerprint`
 - `git_commit` when available
 - `git_branch` when available
@@ -56,6 +59,10 @@ Current candidate-run params:
 - `cv__n_splits`
 - `cv__shuffle`
 - `cv__random_state`
+- `runtime__requested_compute_target`
+- `runtime__resolved_compute_target`
+- `runtime__gpu_available`
+- `runtime__fallback_reason` when CPU fallback happened under `compute_target=auto`
 - model candidates:
   - `feature_recipe_id`
   - `numeric_preprocessor`
@@ -122,14 +129,17 @@ Submission artifacts on the same candidate run:
 
 Stage notes:
 - `main.py` keeps the existing user-facing command but now delegates into a bootstrap module before the runtime imports `pandas`- or `sklearn`-dependent modules.
+- bootstrap resolves `experiment.runtime.compute_target` for the current machine before the CLI imports the training stack.
 - `prepare` no longer persists canonical competition metadata. It only prepares the context in memory and writes EDA reports.
 - `train` is the only stage that creates candidate runs.
 - `submit` and `refresh-submissions` mutate existing candidate runs by appending submission history and score metrics.
 
 ## Module Responsibilities
 - [main.py](/Users/hs/dev/TabularShenanigans/main.py): thin repository-root wrapper that inserts `src/` on `sys.path` and forwards into the bootstrap entrypoint.
-- [bootstrap.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap.py): stdlib-only bootstrap hook point that runs before runtime modules import `pandas` or `sklearn`.
+- [bootstrap.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap.py): pre-runtime bootstrap hook point that resolves execution mode before runtime modules import `pandas` or `sklearn`.
+- [bootstrap_config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap_config.py): lightweight YAML reader for the bootstrap-only runtime settings loaded before the full config model.
 - [cli.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/cli.py): CLI parser and linear stage dispatch after bootstrap completes.
+- [runtime_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/runtime_execution.py): runtime capability detection, requested-versus-resolved execution context, and bootstrap/runtime metadata helpers.
 - [competition.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/competition.py): in-memory competition preparation, fold assignment materialization, and prepared-context construction.
 - [config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/config.py): nested config validation, metric normalization, candidate-id derivation, and resolved model lookup.
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
@@ -175,6 +185,9 @@ Required top-level keys:
 
 `experiment.tracking`:
 - `tracking_uri` only
+
+`experiment.runtime`:
+- `compute_target`: `auto`, `cpu`, or `gpu`
 
 Model candidate contract:
 - `candidate_type: model`

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -1,13 +1,29 @@
 import sys
 
 
-def _apply_runtime_bootstrap() -> None:
-    # Future RAPIDS import hooks must run here before any app module imports.
-    return
+def _should_skip_runtime_bootstrap(argv: list[str] | None) -> bool:
+    if argv is None:
+        return False
+    return any(argument in {"-h", "--help"} for argument in argv)
+
+
+def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
+    if _should_skip_runtime_bootstrap(argv):
+        return
+
+    from tabular_shenanigans.bootstrap_config import load_bootstrap_runtime_config
+    from tabular_shenanigans.runtime_execution import (
+        export_runtime_execution_context,
+        resolve_runtime_execution,
+    )
+
+    runtime_config = load_bootstrap_runtime_config()
+    runtime_context = resolve_runtime_execution(runtime_config.compute_target)
+    export_runtime_execution_context(runtime_context)
 
 
 def main(argv: list[str] | None = None) -> None:
-    _apply_runtime_bootstrap()
+    _apply_runtime_bootstrap(argv)
 
     from tabular_shenanigans.cli import main as cli_main
 

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class BootstrapRuntimeConfig:
+    compute_target: str = "auto"
+
+
+def _validate_compute_target(value: object) -> str:
+    if value is None:
+        return "auto"
+    if not isinstance(value, str):
+        raise ValueError("experiment.runtime.compute_target must be a string when provided.")
+
+    normalized_value = value.strip().lower()
+    if normalized_value in {"auto", "cpu", "gpu"}:
+        return normalized_value
+
+    raise ValueError(
+        "experiment.runtime.compute_target must be one of ['auto', 'cpu', 'gpu']."
+    )
+
+
+def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> BootstrapRuntimeConfig:
+    config_path = Path(path)
+
+    try:
+        raw_data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"Config file not found: {config_path}. "
+            "Create repository-root config.yaml from config.binary.example.yaml "
+            "or config.regression.example.yaml."
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in config file: {exc}") from exc
+
+    if raw_data is None:
+        return BootstrapRuntimeConfig()
+    if not isinstance(raw_data, dict):
+        raise ValueError("Config must be a top-level mapping.")
+
+    experiment = raw_data.get("experiment")
+    if experiment is None:
+        return BootstrapRuntimeConfig()
+    if not isinstance(experiment, dict):
+        raise ValueError("experiment must be a mapping when provided.")
+
+    runtime = experiment.get("runtime")
+    if runtime is None:
+        return BootstrapRuntimeConfig()
+    if not isinstance(runtime, dict):
+        raise ValueError("experiment.runtime must be a mapping when provided.")
+
+    return BootstrapRuntimeConfig(
+        compute_target=_validate_compute_target(runtime.get("compute_target")),
+    )

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -206,10 +206,17 @@ class ExperimentTrackingConfig(BaseModel):
     tracking_uri: str = Field(min_length=1)
 
 
+class ExperimentRuntimeConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    compute_target: Literal["auto", "cpu", "gpu"] = "auto"
+
+
 class ExperimentConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     candidate: ExperimentCandidateConfig
+    runtime: ExperimentRuntimeConfig = Field(default_factory=ExperimentRuntimeConfig)
     submit: ExperimentSubmitConfig = Field(default_factory=ExperimentSubmitConfig)
     tracking: ExperimentTrackingConfig = Field(default_factory=ExperimentTrackingConfig)
 
@@ -299,6 +306,12 @@ class AppConfig(BaseModel):
         )
 
     @property
+    def runtime_execution_context(self):
+        from tabular_shenanigans.runtime_execution import get_runtime_execution_context
+
+        return get_runtime_execution_context(self.experiment.runtime.compute_target)
+
+    @property
     def resolved_candidate_id(self) -> str:
         competition = self.competition
         candidate = self.experiment.candidate
@@ -323,6 +336,10 @@ class AppConfig(BaseModel):
                     "model_registry_key": self.resolved_model_registry_key,
                     "model_params": candidate.model_params,
                     "optimization": optimization_payload,
+                },
+                "runtime": {
+                    "compute_target": self.experiment.runtime.compute_target,
+                    "resolved_compute_target": self.runtime_execution_context.resolved_compute_target,
                 },
             }
             return build_model_candidate_id(

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -160,6 +160,7 @@ def ensure_candidate_run_absent(config: AppConfig, candidate_id: str) -> None:
 
 
 def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: str) -> dict[str, object]:
+    runtime_execution_context = config.runtime_execution_context
     tags: dict[str, object] = {
         "run_kind": RUN_KIND_CANDIDATE,
         "tracking_schema_version": TRACKING_SCHEMA_VERSION,
@@ -168,6 +169,8 @@ def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: s
         "candidate_type": candidate_type,
         "task_type": config.competition.task_type,
         "primary_metric": config.competition.primary_metric,
+        "runtime_requested_compute_target": runtime_execution_context.requested_compute_target,
+        "runtime_resolved_compute_target": runtime_execution_context.resolved_compute_target,
         **_git_metadata(),
     }
     return tags
@@ -204,11 +207,17 @@ def terminate_run(
 def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dict[str, object]:
     competition = config.competition
     candidate = config.experiment.candidate
+    runtime_execution_context = config.runtime_execution_context
     params: dict[str, object] = {
         "cv__n_splits": competition.cv.n_splits,
         "cv__shuffle": competition.cv.shuffle,
         "cv__random_state": competition.cv.random_state,
+        "runtime__requested_compute_target": runtime_execution_context.requested_compute_target,
+        "runtime__resolved_compute_target": runtime_execution_context.resolved_compute_target,
+        "runtime__gpu_available": runtime_execution_context.gpu_available,
     }
+    if runtime_execution_context.fallback_reason is not None:
+        params["runtime__fallback_reason"] = runtime_execution_context.fallback_reason
     if config.is_model_candidate:
         params.update(
             {

--- a/src/tabular_shenanigans/runtime_execution.py
+++ b/src/tabular_shenanigans/runtime_execution.py
@@ -1,0 +1,244 @@
+import os
+import platform
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+REQUESTED_COMPUTE_TARGET_ENV = "TABULAR_SHENANIGANS_REQUESTED_COMPUTE_TARGET"
+RESOLVED_COMPUTE_TARGET_ENV = "TABULAR_SHENANIGANS_RESOLVED_COMPUTE_TARGET"
+GPU_AVAILABLE_ENV = "TABULAR_SHENANIGANS_GPU_AVAILABLE"
+FALLBACK_REASON_ENV = "TABULAR_SHENANIGANS_RUNTIME_FALLBACK_REASON"
+PLATFORM_SYSTEM_ENV = "TABULAR_SHENANIGANS_RUNTIME_PLATFORM_SYSTEM"
+VISIBLE_NVIDIA_DEVICES_ENV = "TABULAR_SHENANIGANS_VISIBLE_NVIDIA_DEVICES"
+CUDA_VISIBLE_DEVICES_ENV = "CUDA_VISIBLE_DEVICES"
+
+
+@dataclass(frozen=True)
+class RuntimeCapabilitySnapshot:
+    platform_system: str
+    gpu_available: bool
+    visible_nvidia_devices: tuple[str, ...]
+    cuda_visible_devices: str | None
+    unavailable_reason: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "platform_system": self.platform_system,
+            "gpu_available": self.gpu_available,
+            "visible_nvidia_devices": list(self.visible_nvidia_devices),
+            "cuda_visible_devices": self.cuda_visible_devices,
+            "unavailable_reason": self.unavailable_reason,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeExecutionContext:
+    requested_compute_target: str
+    resolved_compute_target: str
+    capabilities: RuntimeCapabilitySnapshot
+    fallback_reason: str | None
+
+    @property
+    def gpu_available(self) -> bool:
+        return self.capabilities.gpu_available
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "requested_compute_target": self.requested_compute_target,
+            "resolved_compute_target": self.resolved_compute_target,
+            "gpu_available": self.gpu_available,
+            "fallback_reason": self.fallback_reason,
+            "capabilities": self.capabilities.to_dict(),
+        }
+
+
+def _validate_compute_target(value: str) -> str:
+    normalized_value = value.strip().lower()
+    if normalized_value in {"auto", "cpu", "gpu"}:
+        return normalized_value
+    raise ValueError(
+        f"Unsupported compute target '{value}'. Expected one of ['auto', 'cpu', 'gpu']."
+    )
+
+
+def _cuda_visible_devices_disables_gpu(cuda_visible_devices: str | None) -> bool:
+    if cuda_visible_devices is None:
+        return False
+    normalized_value = cuda_visible_devices.strip().lower()
+    return normalized_value in {"", "-1", "none", "void"}
+
+
+def _discover_visible_nvidia_devices() -> tuple[str, ...]:
+    device_patterns = (
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+        "/dev/nvidia-uvm-tools",
+    )
+    device_paths = [pattern for pattern in device_patterns if Path(pattern).exists()]
+    device_paths.extend(str(path) for path in sorted(Path("/dev").glob("nvidia[0-9]*")))
+    return tuple(dict.fromkeys(device_paths))
+
+
+@lru_cache(maxsize=1)
+def detect_runtime_capabilities() -> RuntimeCapabilitySnapshot:
+    platform_system = platform.system()
+    cuda_visible_devices = os.getenv(CUDA_VISIBLE_DEVICES_ENV)
+    visible_nvidia_devices = _discover_visible_nvidia_devices()
+
+    if platform_system != "Linux":
+        return RuntimeCapabilitySnapshot(
+            platform_system=platform_system,
+            gpu_available=False,
+            visible_nvidia_devices=visible_nvidia_devices,
+            cuda_visible_devices=cuda_visible_devices,
+            unavailable_reason=f"platform '{platform_system}' does not expose NVIDIA CUDA devices",
+        )
+
+    if _cuda_visible_devices_disables_gpu(cuda_visible_devices):
+        return RuntimeCapabilitySnapshot(
+            platform_system=platform_system,
+            gpu_available=False,
+            visible_nvidia_devices=visible_nvidia_devices,
+            cuda_visible_devices=cuda_visible_devices,
+            unavailable_reason=f"{CUDA_VISIBLE_DEVICES_ENV} disables GPU visibility",
+        )
+
+    if not visible_nvidia_devices:
+        return RuntimeCapabilitySnapshot(
+            platform_system=platform_system,
+            gpu_available=False,
+            visible_nvidia_devices=visible_nvidia_devices,
+            cuda_visible_devices=cuda_visible_devices,
+            unavailable_reason="no visible NVIDIA device files were detected under /dev",
+        )
+
+    return RuntimeCapabilitySnapshot(
+        platform_system=platform_system,
+        gpu_available=True,
+        visible_nvidia_devices=visible_nvidia_devices,
+        cuda_visible_devices=cuda_visible_devices,
+        unavailable_reason=None,
+    )
+
+
+def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecutionContext:
+    normalized_target = _validate_compute_target(requested_compute_target)
+    capabilities = detect_runtime_capabilities()
+
+    if normalized_target == "cpu":
+        return RuntimeExecutionContext(
+            requested_compute_target=normalized_target,
+            resolved_compute_target="cpu",
+            capabilities=capabilities,
+            fallback_reason=None,
+        )
+
+    if normalized_target == "gpu":
+        if capabilities.gpu_available:
+            return RuntimeExecutionContext(
+                requested_compute_target=normalized_target,
+                resolved_compute_target="gpu",
+                capabilities=capabilities,
+                fallback_reason=None,
+            )
+        raise RuntimeError(
+            "Configured experiment.runtime.compute_target='gpu' but GPU execution is unavailable. "
+            f"Detection summary: {describe_runtime_capabilities(capabilities)}"
+        )
+
+    if capabilities.gpu_available:
+        return RuntimeExecutionContext(
+            requested_compute_target=normalized_target,
+            resolved_compute_target="gpu",
+            capabilities=capabilities,
+            fallback_reason=None,
+        )
+
+    return RuntimeExecutionContext(
+        requested_compute_target=normalized_target,
+        resolved_compute_target="cpu",
+        capabilities=capabilities,
+        fallback_reason=capabilities.unavailable_reason,
+    )
+
+
+def export_runtime_execution_context(context: RuntimeExecutionContext) -> None:
+    os.environ[REQUESTED_COMPUTE_TARGET_ENV] = context.requested_compute_target
+    os.environ[RESOLVED_COMPUTE_TARGET_ENV] = context.resolved_compute_target
+    os.environ[GPU_AVAILABLE_ENV] = "true" if context.gpu_available else "false"
+    os.environ[PLATFORM_SYSTEM_ENV] = context.capabilities.platform_system
+    os.environ[VISIBLE_NVIDIA_DEVICES_ENV] = ",".join(context.capabilities.visible_nvidia_devices)
+    if context.fallback_reason is None:
+        os.environ.pop(FALLBACK_REASON_ENV, None)
+    else:
+        os.environ[FALLBACK_REASON_ENV] = context.fallback_reason
+
+
+def _parse_exported_runtime_execution_context() -> RuntimeExecutionContext | None:
+    requested_compute_target = os.getenv(REQUESTED_COMPUTE_TARGET_ENV)
+    resolved_compute_target = os.getenv(RESOLVED_COMPUTE_TARGET_ENV)
+    gpu_available = os.getenv(GPU_AVAILABLE_ENV)
+    platform_system = os.getenv(PLATFORM_SYSTEM_ENV)
+
+    if (
+        requested_compute_target is None
+        or resolved_compute_target is None
+        or gpu_available is None
+        or platform_system is None
+    ):
+        return None
+
+    visible_nvidia_devices_raw = os.getenv(VISIBLE_NVIDIA_DEVICES_ENV, "")
+    visible_nvidia_devices = tuple(
+        device_path for device_path in visible_nvidia_devices_raw.split(",") if device_path
+    )
+    fallback_reason = os.getenv(FALLBACK_REASON_ENV)
+    capabilities = RuntimeCapabilitySnapshot(
+        platform_system=platform_system,
+        gpu_available=gpu_available == "true",
+        visible_nvidia_devices=visible_nvidia_devices,
+        cuda_visible_devices=os.getenv(CUDA_VISIBLE_DEVICES_ENV),
+        unavailable_reason=fallback_reason,
+    )
+    return RuntimeExecutionContext(
+        requested_compute_target=requested_compute_target,
+        resolved_compute_target=resolved_compute_target,
+        capabilities=capabilities,
+        fallback_reason=fallback_reason,
+    )
+
+
+def get_runtime_execution_context(requested_compute_target: str = "auto") -> RuntimeExecutionContext:
+    exported_context = _parse_exported_runtime_execution_context()
+    if exported_context is not None:
+        return exported_context
+    return resolve_runtime_execution(requested_compute_target)
+
+
+def describe_runtime_capabilities(capabilities: RuntimeCapabilitySnapshot) -> str:
+    visible_devices = ",".join(capabilities.visible_nvidia_devices) or "none"
+    cuda_visible_devices = capabilities.cuda_visible_devices or "unset"
+    summary = (
+        f"platform={capabilities.platform_system}, "
+        f"gpu_available={capabilities.gpu_available}, "
+        f"visible_nvidia_devices={visible_devices}, "
+        f"{CUDA_VISIBLE_DEVICES_ENV}={cuda_visible_devices}"
+    )
+    if capabilities.unavailable_reason is not None:
+        summary = f"{summary}, unavailable_reason={capabilities.unavailable_reason}"
+    return summary
+
+
+def format_runtime_execution_context(context: RuntimeExecutionContext) -> str:
+    summary = (
+        f"requested_compute_target={context.requested_compute_target}, "
+        f"resolved_compute_target={context.resolved_compute_target}, "
+        f"gpu_available={context.gpu_available}, "
+        f"platform={context.capabilities.platform_system}"
+    )
+    visible_devices = ",".join(context.capabilities.visible_nvidia_devices)
+    if visible_devices:
+        summary = f"{summary}, visible_nvidia_devices={visible_devices}"
+    if context.fallback_reason is not None:
+        summary = f"{summary}, fallback_reason={context.fallback_reason}"
+    return summary

--- a/src/tabular_shenanigans/runtime_logging.py
+++ b/src/tabular_shenanigans/runtime_logging.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator, TextIO
 
+from tabular_shenanigans.runtime_execution import (
+    format_runtime_execution_context,
+    get_runtime_execution_context,
+)
+
 RUNTIME_LOG_ARTIFACT_DIRNAME = "logs"
 RUNTIME_LOG_FILENAME = "runtime.log"
 
@@ -125,6 +130,7 @@ def emit_runtime_log_header(
     candidate_id: str,
     mlflow_run_id: str,
 ) -> None:
+    runtime_execution_context = get_runtime_execution_context()
     print(
         "Runtime log started: "
         f"stage={stage_name}, competition_slug={competition_slug}, "
@@ -134,3 +140,4 @@ def emit_runtime_log_header(
         "Runtime environment: "
         f"pid={os.getpid()}, cwd={Path.cwd()}, python={sys.executable}, argv={sys.argv}"
     )
+    print(f"Runtime execution: {format_runtime_execution_context(runtime_execution_context)}")

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -110,6 +110,7 @@ def _build_candidate_manifest(
 ) -> dict[str, object]:
     competition = config.competition
     candidate = config.experiment.candidate
+    runtime_execution_context = config.runtime_execution_context
     manifest = {
         "artifact_type": "candidate",
         "candidate_id": config.resolved_candidate_id,
@@ -146,6 +147,7 @@ def _build_candidate_manifest(
         "test_rows": int(training_context.x_test_features.shape[0]),
         "test_cols": int(training_context.x_test_features.shape[1]),
         "tuning_provenance": tuning_provenance,
+        "runtime_execution": runtime_execution_context.to_dict(),
     }
     manifest.update(
         build_binary_accuracy_artifact_metadata(


### PR DESCRIPTION
## Summary
- add bootstrap-time runtime config loading for `experiment.runtime.compute_target`
- resolve and export the requested vs resolved execution mode before the CLI imports the training stack
- log runtime execution metadata into candidate ids, manifests, runtime logs, MLflow tags/params, and docs

Closes #155

## Manual verification
- `.venv/bin/python -m py_compile main.py src/tabular_shenanigans/bootstrap.py src/tabular_shenanigans/bootstrap_config.py src/tabular_shenanigans/runtime_execution.py src/tabular_shenanigans/config.py src/tabular_shenanigans/runtime_logging.py src/tabular_shenanigans/mlflow_store.py src/tabular_shenanigans/train.py src/tabular_shenanigans/cli.py`
- `.venv/bin/python - <<'PY'` import `main` and confirm `pandas` / `sklearn` are absent from `sys.modules`
- `.venv/bin/python main.py train --help`
- `.venv/bin/python - <<'PY'` resolve `auto` on this machine and confirm CPU fallback on Darwin
- `.venv/bin/python - <<'PY'` load a temporary config with `experiment.runtime.compute_target: gpu` and confirm it raises the expected runtime error when GPU execution is unavailable
