### PR TITLE
Install RAPIDS hooks during GPU bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ cp config.regression.example.yaml config.yaml
 `config.yaml` is the only runtime config source. It is intentionally ignored by Git.
 
 `main.py` is a thin wrapper around a bootstrap module. The bootstrap runs before the
-runtime imports application modules that depend on `pandas` or `sklearn`, so future
-accelerator hooks can patch imports safely without changing the user-facing command.
+runtime imports application modules that depend on `pandas` or `sklearn`, so GPU
+setups can install RAPIDS acceleration hooks before the training stack loads.
 
 ## Stage Commands
 `uv run python main.py` runs the default pipeline: `fetch -> prepare -> train -> submit`.
@@ -123,9 +123,9 @@ Required top-level sections:
 
 `experiment.runtime` keys:
 - `compute_target`: `auto`, `cpu`, or `gpu`
-  - `auto`: prefer GPU when the runtime exposes visible NVIDIA devices, otherwise fall back to CPU
+  - `auto`: prefer GPU only when the runtime exposes visible NVIDIA devices and RAPIDS hooks are available, otherwise fall back to CPU
   - `cpu`: force CPU execution
-  - `gpu`: require GPU execution and fail fast when no GPU runtime is available
+  - `gpu`: require GPU execution and fail fast when no GPU runtime or RAPIDS hook path is available
 
 `experiment.candidate` keys:
 - shared:
@@ -238,6 +238,7 @@ Suggested checks:
 ## Current Limits
 - Kaggle authentication is expected to be preconfigured.
 - Competition downloads still live under `data/<competition_slug>/`.
+- RAPIDS acceleration is a Linux GPU runtime concern. Native macOS runs stay on CPU.
 - EDA reports still live under `reports/<competition_slug>/`.
 - Local temp directories are used during a running command, but candidate state is not kept there after the command finishes.
 - Candidate lookup is keyed by derived `candidate_id` inside the competition MLflow experiment. Reusing the same candidate spec without deleting the existing run is a hard error.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -4,7 +4,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 
 ## System Flow
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` from repository-root `config.yaml` and resolve the requested execution mode to CPU or GPU for the current machine.
+2. Read `experiment.runtime.compute_target` from repository-root `config.yaml`, resolve the requested execution mode for the current machine, and install RAPIDS hooks before the CLI imports the training stack when GPU execution is selected.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -50,6 +50,7 @@ Current candidate-run tags:
 - `primary_metric`
 - `runtime_requested_compute_target`
 - `runtime_resolved_compute_target`
+- `runtime_acceleration_backend`
 - `config_fingerprint`
 - `git_commit` when available
 - `git_branch` when available
@@ -62,6 +63,8 @@ Current candidate-run params:
 - `runtime__requested_compute_target`
 - `runtime__resolved_compute_target`
 - `runtime__gpu_available`
+- `runtime__acceleration_backend`
+- `runtime__rapids_hooks_installed`
 - `runtime__fallback_reason` when CPU fallback happened under `compute_target=auto`
 - model candidates:
   - `feature_recipe_id`
@@ -129,17 +132,17 @@ Submission artifacts on the same candidate run:
 
 Stage notes:
 - `main.py` keeps the existing user-facing command but now delegates into a bootstrap module before the runtime imports `pandas`- or `sklearn`-dependent modules.
-- bootstrap resolves `experiment.runtime.compute_target` for the current machine before the CLI imports the training stack.
+- bootstrap resolves `experiment.runtime.compute_target` for the current machine and installs RAPIDS hooks before the CLI imports the training stack when GPU execution is selected.
 - `prepare` no longer persists canonical competition metadata. It only prepares the context in memory and writes EDA reports.
 - `train` is the only stage that creates candidate runs.
 - `submit` and `refresh-submissions` mutate existing candidate runs by appending submission history and score metrics.
 
 ## Module Responsibilities
 - [main.py](/Users/hs/dev/TabularShenanigans/main.py): thin repository-root wrapper that inserts `src/` on `sys.path` and forwards into the bootstrap entrypoint.
-- [bootstrap.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap.py): pre-runtime bootstrap hook point that resolves execution mode before runtime modules import `pandas` or `sklearn`.
+- [bootstrap.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap.py): pre-runtime bootstrap hook point that resolves execution mode and installs RAPIDS hooks before runtime modules import `pandas` or `sklearn`.
 - [bootstrap_config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap_config.py): lightweight YAML reader for the bootstrap-only runtime settings loaded before the full config model.
 - [cli.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/cli.py): CLI parser and linear stage dispatch after bootstrap completes.
-- [runtime_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/runtime_execution.py): runtime capability detection, requested-versus-resolved execution context, and bootstrap/runtime metadata helpers.
+- [runtime_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/runtime_execution.py): runtime capability detection, RAPIDS hook activation, requested-versus-resolved execution context, and bootstrap/runtime metadata helpers.
 - [competition.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/competition.py): in-memory competition preparation, fold assignment materialization, and prepared-context construction.
 - [config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/config.py): nested config validation, metric normalization, candidate-id derivation, and resolved model lookup.
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
@@ -180,6 +183,7 @@ Required top-level keys:
 
 `experiment` keys:
 - required `tracking`
+- optional `runtime`
 - required `candidate`
 - optional `submit`
 
@@ -188,6 +192,9 @@ Required top-level keys:
 
 `experiment.runtime`:
 - `compute_target`: `auto`, `cpu`, or `gpu`
+  - `auto`: use GPU only when the machine exposes NVIDIA devices and RAPIDS hooks are available
+  - `cpu`: stay on CPU
+  - `gpu`: require the GPU + RAPIDS path and fail fast otherwise
 
 Model candidate contract:
 - `candidate_type: model`
@@ -227,6 +234,7 @@ Sparse onehot runtime contract:
 Model candidate manifests currently record:
 - identity: `candidate_id`, `candidate_type`, `competition_slug`, `task_type`, `primary_metric`
 - provenance: `config_fingerprint`, `config_snapshot`, `mlflow_run_id`
+- runtime execution: requested/ resolved compute target, acceleration backend, RAPIDS hook status, and hardware capability snapshot
 - model info: `model_family`, `model_registry_key`, `estimator_name`
 - feature/preprocessing info: `feature_recipe_id`, `feature_columns`, `numeric_preprocessor`, `categorical_preprocessor`, `preprocessing_scheme_id`
 - CV summary: `cv_summary`
@@ -257,6 +265,11 @@ Validation rules:
 - regression values must be numeric, non-missing, and finite
 - binary `roc_auc`/`log_loss` values must be numeric probabilities in `[0, 1]`
 - binary `accuracy` values must stay within the observed label pair
+
+## Runtime Constraints
+- RAPIDS acceleration is only expected on Linux GPU runtimes.
+- `auto` can fall back to CPU for either missing GPU hardware or unavailable RAPIDS hook modules.
+- once RAPIDS hook installation starts, rollback is not guaranteed; install failures are treated as hard errors.
 
 Real Kaggle submissions:
 - generate one `submission_event_id`

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -13,12 +13,14 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
 
     from tabular_shenanigans.bootstrap_config import load_bootstrap_runtime_config
     from tabular_shenanigans.runtime_execution import (
+        activate_runtime_acceleration,
         export_runtime_execution_context,
         resolve_runtime_execution,
     )
 
     runtime_config = load_bootstrap_runtime_config()
     runtime_context = resolve_runtime_execution(runtime_config.compute_target)
+    runtime_context = activate_runtime_acceleration(runtime_context)
     export_runtime_execution_context(runtime_context)
 
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -340,6 +340,7 @@ class AppConfig(BaseModel):
                 "runtime": {
                     "compute_target": self.experiment.runtime.compute_target,
                     "resolved_compute_target": self.runtime_execution_context.resolved_compute_target,
+                    "acceleration_backend": self.runtime_execution_context.acceleration_backend,
                 },
             }
             return build_model_candidate_id(

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -171,6 +171,7 @@ def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: s
         "primary_metric": config.competition.primary_metric,
         "runtime_requested_compute_target": runtime_execution_context.requested_compute_target,
         "runtime_resolved_compute_target": runtime_execution_context.resolved_compute_target,
+        "runtime_acceleration_backend": runtime_execution_context.acceleration_backend,
         **_git_metadata(),
     }
     return tags
@@ -215,6 +216,8 @@ def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dic
         "runtime__requested_compute_target": runtime_execution_context.requested_compute_target,
         "runtime__resolved_compute_target": runtime_execution_context.resolved_compute_target,
         "runtime__gpu_available": runtime_execution_context.gpu_available,
+        "runtime__acceleration_backend": runtime_execution_context.acceleration_backend,
+        "runtime__rapids_hooks_installed": runtime_execution_context.rapids_hooks_installed,
     }
     if runtime_execution_context.fallback_reason is not None:
         params["runtime__fallback_reason"] = runtime_execution_context.fallback_reason

--- a/src/tabular_shenanigans/runtime_execution.py
+++ b/src/tabular_shenanigans/runtime_execution.py
@@ -1,6 +1,8 @@
+import importlib
 import os
 import platform
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path
 
@@ -10,7 +12,12 @@ GPU_AVAILABLE_ENV = "TABULAR_SHENANIGANS_GPU_AVAILABLE"
 FALLBACK_REASON_ENV = "TABULAR_SHENANIGANS_RUNTIME_FALLBACK_REASON"
 PLATFORM_SYSTEM_ENV = "TABULAR_SHENANIGANS_RUNTIME_PLATFORM_SYSTEM"
 VISIBLE_NVIDIA_DEVICES_ENV = "TABULAR_SHENANIGANS_VISIBLE_NVIDIA_DEVICES"
+ACCELERATION_BACKEND_ENV = "TABULAR_SHENANIGANS_ACCELERATION_BACKEND"
+RAPIDS_HOOKS_INSTALLED_ENV = "TABULAR_SHENANIGANS_RAPIDS_HOOKS_INSTALLED"
 CUDA_VISIBLE_DEVICES_ENV = "CUDA_VISIBLE_DEVICES"
+CPU_ACCELERATION_BACKEND = "cpu"
+PENDING_ACCELERATION_BACKEND = "pending"
+RAPIDS_ACCELERATION_BACKEND = "rapids"
 
 
 @dataclass(frozen=True)
@@ -37,6 +44,8 @@ class RuntimeExecutionContext:
     resolved_compute_target: str
     capabilities: RuntimeCapabilitySnapshot
     fallback_reason: str | None
+    acceleration_backend: str
+    rapids_hooks_installed: bool
 
     @property
     def gpu_available(self) -> bool:
@@ -48,8 +57,16 @@ class RuntimeExecutionContext:
             "resolved_compute_target": self.resolved_compute_target,
             "gpu_available": self.gpu_available,
             "fallback_reason": self.fallback_reason,
+            "acceleration_backend": self.acceleration_backend,
+            "rapids_hooks_installed": self.rapids_hooks_installed,
             "capabilities": self.capabilities.to_dict(),
         }
+
+
+@dataclass(frozen=True)
+class RapidsHookInstallers:
+    cudf_pandas_install: Callable[[], object]
+    cuml_accel_install: Callable[[], object]
 
 
 def _validate_compute_target(value: str) -> str:
@@ -131,6 +148,8 @@ def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecution
             resolved_compute_target="cpu",
             capabilities=capabilities,
             fallback_reason=None,
+            acceleration_backend=CPU_ACCELERATION_BACKEND,
+            rapids_hooks_installed=False,
         )
 
     if normalized_target == "gpu":
@@ -140,6 +159,8 @@ def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecution
                 resolved_compute_target="gpu",
                 capabilities=capabilities,
                 fallback_reason=None,
+                acceleration_backend=PENDING_ACCELERATION_BACKEND,
+                rapids_hooks_installed=False,
             )
         raise RuntimeError(
             "Configured experiment.runtime.compute_target='gpu' but GPU execution is unavailable. "
@@ -152,6 +173,8 @@ def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecution
             resolved_compute_target="gpu",
             capabilities=capabilities,
             fallback_reason=None,
+            acceleration_backend=PENDING_ACCELERATION_BACKEND,
+            rapids_hooks_installed=False,
         )
 
     return RuntimeExecutionContext(
@@ -159,6 +182,70 @@ def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecution
         resolved_compute_target="cpu",
         capabilities=capabilities,
         fallback_reason=capabilities.unavailable_reason,
+        acceleration_backend=CPU_ACCELERATION_BACKEND,
+        rapids_hooks_installed=False,
+    )
+
+
+def _load_rapids_hook_installers() -> RapidsHookInstallers:
+    try:
+        cudf_pandas = importlib.import_module("cudf.pandas")
+    except ImportError as exc:
+        raise RuntimeError("cudf.pandas is not importable in this environment") from exc
+
+    try:
+        cuml_accel = importlib.import_module("cuml.accel")
+    except ImportError as exc:
+        raise RuntimeError("cuml.accel is not importable in this environment") from exc
+
+    cudf_pandas_install = getattr(cudf_pandas, "install", None)
+    if not callable(cudf_pandas_install):
+        raise RuntimeError("cudf.pandas.install() is unavailable in this environment")
+
+    cuml_accel_install = getattr(cuml_accel, "install", None)
+    if not callable(cuml_accel_install):
+        raise RuntimeError("cuml.accel.install() is unavailable in this environment")
+
+    return RapidsHookInstallers(
+        cudf_pandas_install=cudf_pandas_install,
+        cuml_accel_install=cuml_accel_install,
+    )
+
+
+def activate_runtime_acceleration(context: RuntimeExecutionContext) -> RuntimeExecutionContext:
+    if context.resolved_compute_target != "gpu":
+        return context
+
+    try:
+        rapids_installers = _load_rapids_hook_installers()
+    except RuntimeError as exc:
+        if context.requested_compute_target == "gpu":
+            raise RuntimeError(
+                "Configured experiment.runtime.compute_target='gpu' but RAPIDS hooks are unavailable. "
+                f"Reason: {exc}. Detection summary: {describe_runtime_capabilities(context.capabilities)}"
+            ) from exc
+        return replace(
+            context,
+            resolved_compute_target="cpu",
+            fallback_reason=f"RAPIDS hooks unavailable: {exc}",
+            acceleration_backend=CPU_ACCELERATION_BACKEND,
+            rapids_hooks_installed=False,
+        )
+
+    # Once either install call runs, rollback is not guaranteed. Treat install failures as hard errors.
+    try:
+        rapids_installers.cudf_pandas_install()
+        rapids_installers.cuml_accel_install()
+    except Exception as exc:
+        raise RuntimeError(
+            "RAPIDS hook installation failed after preflight succeeded. "
+            f"Reason: {exc}. Detection summary: {describe_runtime_capabilities(context.capabilities)}"
+        ) from exc
+
+    return replace(
+        context,
+        acceleration_backend=RAPIDS_ACCELERATION_BACKEND,
+        rapids_hooks_installed=True,
     )
 
 
@@ -168,6 +255,8 @@ def export_runtime_execution_context(context: RuntimeExecutionContext) -> None:
     os.environ[GPU_AVAILABLE_ENV] = "true" if context.gpu_available else "false"
     os.environ[PLATFORM_SYSTEM_ENV] = context.capabilities.platform_system
     os.environ[VISIBLE_NVIDIA_DEVICES_ENV] = ",".join(context.capabilities.visible_nvidia_devices)
+    os.environ[ACCELERATION_BACKEND_ENV] = context.acceleration_backend
+    os.environ[RAPIDS_HOOKS_INSTALLED_ENV] = "true" if context.rapids_hooks_installed else "false"
     if context.fallback_reason is None:
         os.environ.pop(FALLBACK_REASON_ENV, None)
     else:
@@ -179,12 +268,16 @@ def _parse_exported_runtime_execution_context() -> RuntimeExecutionContext | Non
     resolved_compute_target = os.getenv(RESOLVED_COMPUTE_TARGET_ENV)
     gpu_available = os.getenv(GPU_AVAILABLE_ENV)
     platform_system = os.getenv(PLATFORM_SYSTEM_ENV)
+    acceleration_backend = os.getenv(ACCELERATION_BACKEND_ENV)
+    rapids_hooks_installed = os.getenv(RAPIDS_HOOKS_INSTALLED_ENV)
 
     if (
         requested_compute_target is None
         or resolved_compute_target is None
         or gpu_available is None
         or platform_system is None
+        or acceleration_backend is None
+        or rapids_hooks_installed is None
     ):
         return None
 
@@ -205,6 +298,8 @@ def _parse_exported_runtime_execution_context() -> RuntimeExecutionContext | Non
         resolved_compute_target=resolved_compute_target,
         capabilities=capabilities,
         fallback_reason=fallback_reason,
+        acceleration_backend=acceleration_backend,
+        rapids_hooks_installed=rapids_hooks_installed == "true",
     )
 
 
@@ -234,6 +329,8 @@ def format_runtime_execution_context(context: RuntimeExecutionContext) -> str:
         f"requested_compute_target={context.requested_compute_target}, "
         f"resolved_compute_target={context.resolved_compute_target}, "
         f"gpu_available={context.gpu_available}, "
+        f"acceleration_backend={context.acceleration_backend}, "
+        f"rapids_hooks_installed={context.rapids_hooks_installed}, "
         f"platform={context.capabilities.platform_system}"
     )
     visible_devices = ",".join(context.capabilities.visible_nvidia_devices)


### PR DESCRIPTION
## Summary
- install RAPIDS bootstrap hooks before the CLI imports runtime modules when GPU execution is selected
- record acceleration backend and RAPIDS hook status in runtime metadata and MLflow logging
- document the new GPU bootstrap contract and current Linux-only RAPIDS constraint

Closes #157

## Manual verification
- `.venv/bin/python -m py_compile main.py src/tabular_shenanigans/bootstrap.py src/tabular_shenanigans/bootstrap_config.py src/tabular_shenanigans/runtime_execution.py src/tabular_shenanigans/config.py src/tabular_shenanigans/mlflow_store.py src/tabular_shenanigans/runtime_logging.py src/tabular_shenanigans/train.py src/tabular_shenanigans/cli.py`
- `.venv/bin/python - <<'PY'` import `main` and confirm `pandas` / `sklearn` are absent from `sys.modules`
- `.venv/bin/python main.py train --help`
- `.venv/bin/python - <<'PY'` resolve and activate `auto` on this Darwin machine and confirm CPU fallback with `acceleration_backend=cpu`
- `.venv/bin/python - <<'PY'` simulate a Linux GPU host with missing RAPIDS modules and confirm `auto` falls back to CPU while explicit `gpu` fails clearly
