### PR TITLE
Route booster models through GPU params

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Required top-level sections:
   - `auto`: prefer GPU only when the runtime exposes visible NVIDIA devices and RAPIDS hooks are available, otherwise fall back to CPU
   - `cpu`: force CPU execution
   - `gpu`: require GPU execution and fail fast when no GPU runtime or RAPIDS hook path is available
+  - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
 
 `experiment.candidate` keys:
 - shared:
@@ -239,6 +240,7 @@ Suggested checks:
 - Kaggle authentication is expected to be preconfigured.
 - Competition downloads still live under `data/<competition_slug>/`.
 - RAPIDS acceleration is a Linux GPU runtime concern. Native macOS runs stay on CPU.
+- LightGBM GPU routing still depends on a CUDA-enabled LightGBM runtime build in the target image or host environment.
 - EDA reports still live under `reports/<competition_slug>/`.
 - Local temp directories are used during a running command, but candidate state is not kept there after the command finishes.
 - Candidate lookup is keyed by derived `candidate_id` inside the competition MLflow experiment. Reusing the same candidate spec without deleting the existing run is a hard error.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -4,7 +4,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 
 ## System Flow
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` from repository-root `config.yaml`, resolve the requested execution mode for the current machine, and install RAPIDS hooks before the CLI imports the training stack when GPU execution is selected.
+2. Read `experiment.runtime.compute_target` from repository-root `config.yaml`, resolve the requested execution mode for the current machine, install RAPIDS hooks before the CLI imports the training stack when GPU execution is selected, and route GPU-capable booster families onto their GPU parameter paths.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -230,6 +230,12 @@ Sparse onehot runtime contract:
 - dense array output remains in place for `hist_gradient_boosting`
 - `numeric_preprocessor: kbins` follows the same sparse-versus-dense output contract when composed with `onehot`
 
+Booster GPU routing contract:
+- when runtime execution resolves to GPU, `xgboost` adds `device="cuda"`
+- when runtime execution resolves to GPU, `lightgbm` adds `device_type="cuda"`
+- when runtime execution resolves to GPU, `catboost` adds `task_type="GPU"`
+- user `model_params` still override repo defaults
+
 ## Candidate Manifest Contract
 Model candidate manifests currently record:
 - identity: `candidate_id`, `candidate_type`, `competition_slug`, `task_type`, `primary_metric`
@@ -270,6 +276,7 @@ Validation rules:
 - RAPIDS acceleration is only expected on Linux GPU runtimes.
 - `auto` can fall back to CPU for either missing GPU hardware or unavailable RAPIDS hook modules.
 - once RAPIDS hook installation starts, rollback is not guaranteed; install failures are treated as hard errors.
+- LightGBM GPU routing still requires a CUDA-enabled LightGBM runtime build in the target environment.
 
 Real Kaggle submissions:
 - generate one `submission_event_id`

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -15,6 +15,8 @@ from sklearn.ensemble import (
 )
 from sklearn.linear_model import ElasticNet, LogisticRegression, Ridge
 
+from tabular_shenanigans.runtime_execution import get_runtime_execution_context
+
 ModelBuilder = Callable[[int, dict[str, object] | None], tuple[object, dict[str, object]]]
 FitKwargsBuilder = Callable[[object, list[str], list[str]], dict[str, object]]
 TuningSpaceBuilder = Callable[[object], dict[str, object]]
@@ -71,6 +73,20 @@ def _merge_model_params(
     if parameter_overrides:
         merged_params.update(parameter_overrides)
     return merged_params
+
+
+def _resolve_booster_runtime_defaults(model_id: str) -> dict[str, object]:
+    runtime_execution_context = get_runtime_execution_context()
+    if runtime_execution_context.resolved_compute_target != "gpu":
+        return {}
+
+    if model_id == "xgboost":
+        return {"device": "cuda"}
+    if model_id == "lightgbm":
+        return {"device_type": "cuda"}
+    if model_id == "catboost":
+        return {"task_type": "GPU"}
+    return {}
 
 
 def _build_ridge(random_state: int, parameter_overrides: dict[str, object] | None = None) -> tuple[Ridge, dict[str, object]]:
@@ -174,18 +190,17 @@ def _build_lightgbm_regressor(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = _merge_model_params(
-        {
-            "colsample_bytree": 0.8,
-            "learning_rate": 0.05,
-            "n_estimators": 500,
-            "n_jobs": -1,
-            "random_state": random_state,
-            "subsample": 0.8,
-            "verbosity": -1,
-        },
-        parameter_overrides,
-    )
+    params = {
+        "colsample_bytree": 0.8,
+        "learning_rate": 0.05,
+        "n_estimators": 500,
+        "n_jobs": -1,
+        "random_state": random_state,
+        "subsample": 0.8,
+        "verbosity": -1,
+        **_resolve_booster_runtime_defaults("lightgbm"),
+    }
+    params = _merge_model_params(params, parameter_overrides)
     return LGBMRegressor(**params), params
 
 
@@ -201,18 +216,17 @@ def _build_lightgbm_classifier(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = _merge_model_params(
-        {
-            "colsample_bytree": 0.8,
-            "learning_rate": 0.05,
-            "n_estimators": 500,
-            "n_jobs": -1,
-            "random_state": random_state,
-            "subsample": 0.8,
-            "verbosity": -1,
-        },
-        parameter_overrides,
-    )
+    params = {
+        "colsample_bytree": 0.8,
+        "learning_rate": 0.05,
+        "n_estimators": 500,
+        "n_jobs": -1,
+        "random_state": random_state,
+        "subsample": 0.8,
+        "verbosity": -1,
+        **_resolve_booster_runtime_defaults("lightgbm"),
+    }
+    params = _merge_model_params(params, parameter_overrides)
     return LGBMClassifier(**params), params
 
 
@@ -228,19 +242,18 @@ def _build_catboost_regressor(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = _merge_model_params(
-        {
-            "allow_writing_files": False,
-            "depth": 6,
-            "iterations": 500,
-            "learning_rate": 0.05,
-            "loss_function": "RMSE",
-            "random_seed": random_state,
-            "thread_count": -1,
-            "verbose": False,
-        },
-        parameter_overrides,
-    )
+    params = {
+        "allow_writing_files": False,
+        "depth": 6,
+        "iterations": 500,
+        "learning_rate": 0.05,
+        "loss_function": "RMSE",
+        "random_seed": random_state,
+        "thread_count": -1,
+        "verbose": False,
+        **_resolve_booster_runtime_defaults("catboost"),
+    }
+    params = _merge_model_params(params, parameter_overrides)
     return CatBoostRegressor(**params), params
 
 
@@ -256,19 +269,18 @@ def _build_catboost_classifier(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = _merge_model_params(
-        {
-            "allow_writing_files": False,
-            "depth": 6,
-            "iterations": 500,
-            "learning_rate": 0.05,
-            "loss_function": "Logloss",
-            "random_seed": random_state,
-            "thread_count": -1,
-            "verbose": False,
-        },
-        parameter_overrides,
-    )
+    params = {
+        "allow_writing_files": False,
+        "depth": 6,
+        "iterations": 500,
+        "learning_rate": 0.05,
+        "loss_function": "Logloss",
+        "random_seed": random_state,
+        "thread_count": -1,
+        "verbose": False,
+        **_resolve_booster_runtime_defaults("catboost"),
+    }
+    params = _merge_model_params(params, parameter_overrides)
     return CatBoostClassifier(**params), params
 
 
@@ -284,21 +296,20 @@ def _build_xgboost_regressor(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = _merge_model_params(
-        {
-            "colsample_bytree": 0.8,
-            "eval_metric": "rmse",
-            "learning_rate": 0.05,
-            "max_depth": 6,
-            "n_estimators": 500,
-            "n_jobs": -1,
-            "objective": "reg:squarederror",
-            "random_state": random_state,
-            "subsample": 0.8,
-            "tree_method": "hist",
-        },
-        parameter_overrides,
-    )
+    params = {
+        "colsample_bytree": 0.8,
+        "eval_metric": "rmse",
+        "learning_rate": 0.05,
+        "max_depth": 6,
+        "n_estimators": 500,
+        "n_jobs": -1,
+        "objective": "reg:squarederror",
+        "random_state": random_state,
+        "subsample": 0.8,
+        "tree_method": "hist",
+        **_resolve_booster_runtime_defaults("xgboost"),
+    }
+    params = _merge_model_params(params, parameter_overrides)
     return XGBRegressor(**params), params
 
 
@@ -314,21 +325,20 @@ def _build_xgboost_classifier(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
-    params = _merge_model_params(
-        {
-            "colsample_bytree": 0.8,
-            "eval_metric": "logloss",
-            "learning_rate": 0.05,
-            "max_depth": 6,
-            "n_estimators": 500,
-            "n_jobs": -1,
-            "objective": "binary:logistic",
-            "random_state": random_state,
-            "subsample": 0.8,
-            "tree_method": "hist",
-        },
-        parameter_overrides,
-    )
+    params = {
+        "colsample_bytree": 0.8,
+        "eval_metric": "logloss",
+        "learning_rate": 0.05,
+        "max_depth": 6,
+        "n_estimators": 500,
+        "n_jobs": -1,
+        "objective": "binary:logistic",
+        "random_state": random_state,
+        "subsample": 0.8,
+        "tree_method": "hist",
+        **_resolve_booster_runtime_defaults("xgboost"),
+    }
+    params = _merge_model_params(params, parameter_overrides)
     return BinaryLabelEncodingClassifier(XGBClassifier(**params)), params
 
 


### PR DESCRIPTION
## Summary
- route XGBoost, LightGBM, and CatBoost through the resolved runtime execution context
- switch those booster families onto their GPU-specific estimator params when runtime execution resolves to GPU
- document the routing behavior and the remaining LightGBM CUDA build constraint

Closes #159

## Manual verification
- `.venv/bin/python -m py_compile src/tabular_shenanigans/models.py`
- `MPLCONFIGDIR=/tmp .venv/bin/python - <<'PY'` import the real booster libraries and confirm CPU `auto` builds return CPU params for `xgboost`, `lightgbm`, and `catboost`
- `MPLCONFIGDIR=/tmp .venv/bin/python - <<'PY'` monkeypatch `get_runtime_execution_context()` to a simulated GPU context and confirm the returned params add `device="cuda"`, `device_type="cuda"`, and `task_type="GPU"`
- `MPLCONFIGDIR=/tmp .venv/bin/python - <<'PY'` monkeypatch an explicit CPU runtime context and confirm all three boosters stay on CPU params
- `MPLCONFIGDIR=/tmp .venv/bin/python - <<'PY'` confirm user overrides still win for `device`, `device_type`, and `task_type`
