### PR TITLE
Add GPU-native XGBoost input conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Required top-level sections:
   - `gpu`: require GPU execution and fail fast when no GPU runtime or RAPIDS hook path is available
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
+  - when GPU execution is active for `xgboost`, the runtime keeps fold-local preprocessing semantics but converts dense fold outputs to `cupy` / `cudf` before XGBoost fit and predict
+  - the XGBoost GPU-native input path currently supports dense preprocessing outputs such as `categorical_preprocessor: ordinal` and `categorical_preprocessor: frequency`
+  - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
 
 `experiment.candidate` keys:
 - shared:
@@ -158,6 +161,7 @@ Required top-level sections:
     - sparse CSR output: `ridge`, `elasticnet`, `logistic_regression`, `random_forest`, `extra_trees`, `lightgbm`, `catboost`, `xgboost`
     - dense array output: `hist_gradient_boosting`
     - `numeric_preprocessor: kbins` follows the same sparse-versus-dense decision when combined with `onehot`
+    - when `model_family: xgboost` and runtime resolves to GPU, the sparse CSR branch is rejected before training because XGBoost does not support `cupyx` CSR inputs yet in this runtime
 - blend candidate:
   - `base_candidate_ids`: at least two existing compatible candidate IDs from the same competition experiment
   - optional `weights`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -245,6 +245,16 @@ Booster GPU routing contract:
 - when runtime execution resolves to GPU, `catboost` adds `task_type="GPU"`
 - user `model_params` still override repo defaults
 
+XGBoost GPU-native input contract:
+- when runtime execution resolves to GPU for `xgboost`, fold-local preprocessing still happens per fold so CV remains leakage-safe
+- after preprocessing, dense fold outputs are promoted to GPU-native inputs before `fit` and `predict`
+  - pandas DataFrame outputs, such as the `frequency` categorical path, are promoted to `cudf.DataFrame`
+  - dense ndarray outputs, such as the `ordinal` categorical path, are promoted to `cupy.ndarray`
+- prediction outputs are coerced back to NumPy before scoring and artifact assembly
+- sparse CSR preprocessing output is rejected before training for the XGBoost GPU-native path
+  - this currently covers `categorical_preprocessor: onehot` and related sparse `kbins` compositions
+  - rationale: XGBoost does not support `cupyx` CSR inputs in this runtime
+
 ## Candidate Manifest Contract
 Model candidate manifests currently record:
 - identity: `candidate_id`, `candidate_type`, `competition_slug`, `task_type`, `primary_metric`

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -21,8 +21,6 @@ from tabular_shenanigans.preprocess import (
     prepare_feature_frames,
     resolve_feature_schema,
 )
-
-
 @dataclass(frozen=True)
 class CvSummary:
     metric_name: str
@@ -95,6 +93,23 @@ class PreparedTrainingContext:
     categorical_preprocessor: str
     preprocessing_scheme_id: str
     matrix_output_kind: str
+    uses_xgboost_gpu_native_inputs: bool
+
+
+def _validate_gpu_native_matrix_output(
+    uses_xgboost_gpu_native_inputs: bool,
+    matrix_output_kind: str,
+) -> None:
+    if not uses_xgboost_gpu_native_inputs:
+        return
+    if matrix_output_kind != "sparse_csr":
+        return
+    raise ValueError(
+        "XGBoost GPU execution currently requires dense fold-local preprocessing output in this runtime. "
+        "The sparse CSR path produced by categorical_preprocessor='onehot' and related kbins compositions "
+        "cannot be promoted to a supported GPU-native XGBoost input because cupyx CSR is not supported yet. "
+        "Use categorical_preprocessor='ordinal' or 'frequency', or force CPU execution."
+    )
 
 
 def build_prepared_training_context(
@@ -159,6 +174,14 @@ def build_prepared_training_context(
         model_id=config.resolved_model_registry_key,
         categorical_preprocessor_id=candidate.categorical_preprocessor,
     )
+    uses_xgboost_gpu_native_inputs = (
+        config.resolved_model_registry_key == "xgboost"
+        and config.runtime_execution_context.resolved_compute_target == "gpu"
+    )
+    _validate_gpu_native_matrix_output(
+        uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
+        matrix_output_kind=matrix_output_kind,
+    )
     return PreparedTrainingContext(
         id_column=id_column,
         label_column=label_column,
@@ -177,6 +200,7 @@ def build_prepared_training_context(
         categorical_preprocessor=candidate.categorical_preprocessor,
         preprocessing_scheme_id=candidate.preprocessing_scheme_id,
         matrix_output_kind=matrix_output_kind,
+        uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
     )
 
 
@@ -187,6 +211,58 @@ def _coerce_processed_matrix(values: object, matrix_output_kind: str) -> object:
         return values
     if matrix_output_kind == "sparse_csr":
         return sparse.csr_matrix(values)
+    return np.asarray(values)
+
+
+def _coerce_xgboost_gpu_input(values: object, matrix_output_kind: str) -> object:
+    try:
+        import cudf
+    except ImportError as exc:
+        raise RuntimeError(
+            "XGBoost GPU-native inputs require the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    try:
+        import cupy as cp
+    except ImportError as exc:
+        raise RuntimeError(
+            "XGBoost GPU-native inputs require the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    if matrix_output_kind == "sparse_csr":
+        raise ValueError(
+            "XGBoost GPU execution currently does not support sparse CSR preprocessing output in this runtime."
+        )
+
+    if type(values).__module__.startswith("cudf.") or type(values).__module__.startswith("cupy."):
+        return values
+
+    if isinstance(values, pd.DataFrame):
+        return cudf.from_pandas(values)
+
+    if hasattr(values, "to_pandas"):
+        return cudf.from_pandas(values.to_pandas())
+
+    return cp.asarray(values)
+
+
+def _coerce_prediction_values(values: object) -> np.ndarray:
+    if isinstance(values, np.ndarray):
+        return values
+
+    if type(values).__module__.startswith("cupy."):
+        import cupy as cp
+
+        return cp.asnumpy(values)
+
+    if hasattr(values, "to_pandas"):
+        return np.asarray(values.to_pandas())
+
+    if hasattr(values, "to_numpy"):
+        return np.asarray(values.to_numpy())
+
     return np.asarray(values)
 
 
@@ -208,6 +284,7 @@ def _run_cv_evaluation(
     estimator_name = model_definition.model_name
     preprocessing_scheme_id = training_context.preprocessing_scheme_id
     matrix_output_kind = training_context.matrix_output_kind
+    uses_xgboost_gpu_native_inputs = training_context.uses_xgboost_gpu_native_inputs
 
     oof_predictions = (
         np.zeros(training_context.x_train_features.shape[0], dtype=float)
@@ -243,6 +320,13 @@ def _run_cv_evaluation(
         if x_test_processed is not None:
             x_test_processed = _coerce_processed_matrix(x_test_processed, matrix_output_kind)
 
+        if uses_xgboost_gpu_native_inputs:
+            # Convert fold-local preprocessing outputs to GPU-native inputs before XGBoost fit/predict.
+            x_fold_train_processed = _coerce_xgboost_gpu_input(x_fold_train_processed, matrix_output_kind)
+            x_fold_valid_processed = _coerce_xgboost_gpu_input(x_fold_valid_processed, matrix_output_kind)
+            if x_test_processed is not None:
+                x_test_processed = _coerce_xgboost_gpu_input(x_test_processed, matrix_output_kind)
+
         _, model, _ = build_model(
             task_type,
             resolved_model_registry_key,
@@ -271,6 +355,10 @@ def _run_cv_evaluation(
             fold_test_predictions = None
             if x_test_processed is not None:
                 fold_test_predictions = model.predict(x_test_processed)
+
+        fold_valid_predictions = _coerce_prediction_values(fold_valid_predictions)
+        if fold_test_predictions is not None:
+            fold_test_predictions = _coerce_prediction_values(fold_test_predictions)
 
         fold_score = score_predictions(
             task_type=task_type,


### PR DESCRIPTION
Closes #163

Summary
- convert dense fold-local preprocessing outputs to GPU-native cudf and cupy inputs before XGBoost fit and predict
- reject sparse CSR preprocessing output for the XGBoost GPU-native path with a clear early error
- document the supported dense XGBoost GPU preprocessing combinations and current sparse limitation

Manual verification
- uv run python -m py_compile src/tabular_shenanigans/model_evaluation.py
- uv run python main.py train --help
- A100 host baseline before patch: frequency XGBoost GPU evaluation script emitted the prior mismatched-device warning and took 43.016s
- A100 host after patch: the same frequency evaluation script completed without the mismatched-device warning and took 40.369s
- A100 host after patch: ordinal XGBoost GPU evaluation completed successfully
- A100 host after patch: onehot XGBoost GPU path failed early with the expected sparse CSR error
- A100 host after patch: full train smoke run completed and logged to MLflow as run d885686bc9114bb7bc3a6f71ba92cee6
- MLflow verification for run d885686bc9114bb7bc3a6f71ba92cee6: runtime_requested_compute_target=gpu, runtime_resolved_compute_target=gpu, runtime_acceleration_backend=rapids, runtime__rapids_hooks_installed=True, model__device=cuda
- MLflow fit comparison: prior smoke run 54e10b4f0e414d108be8e29a5d378066 had fit_wall_seconds=58.180015009999806; new smoke run d885686bc9114bb7bc3a6f71ba92cee6 had fit_wall_seconds=55.5987607940001

Notes
- this keeps fold-local preprocessing semantics intact; it does not move the sklearn preprocessing stack itself onto GPU
- the XGBoost GPU-native path currently supports dense outputs such as frequency and ordinal and rejects sparse CSR output produced by onehot and related sparse kbins compositions