### PR TITLE
Support GPU logistic regression runtime path

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,13 @@ Required top-level sections:
   - `cpu`: force CPU execution
   - `gpu`: require GPU execution and fail fast when no GPU runtime or RAPIDS hook path is available
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
+  - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
   - when GPU execution is active for `xgboost`, the runtime keeps fold-local preprocessing semantics but converts dense fold outputs to `cupy` / `cudf` before XGBoost fit and predict
   - the XGBoost GPU-native input path currently supports dense preprocessing outputs such as `categorical_preprocessor: ordinal` and `categorical_preprocessor: frequency`
   - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
+  - the GPU logistic regression path currently supports `categorical_preprocessor: frequency` only
+  - the GPU logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution
 
 `experiment.candidate` keys:
 - shared:
@@ -162,6 +165,7 @@ Required top-level sections:
     - dense array output: `hist_gradient_boosting`
     - `numeric_preprocessor: kbins` follows the same sparse-versus-dense decision when combined with `onehot`
     - when `model_family: xgboost` and runtime resolves to GPU, the sparse CSR branch is rejected before training because XGBoost does not support `cupyx` CSR inputs yet in this runtime
+    - when `model_family: logistic_regression` and runtime resolves to GPU, only `categorical_preprocessor: frequency` is currently supported; the `onehot` sparse branch and the current `ordinal` branch are both rejected before training because the RAPIDS-hooked sklearn preprocessing path is not stable there yet in this runtime
 - blend candidate:
   - `base_candidate_ids`: at least two existing compatible candidate IDs from the same competition experiment
   - optional `weights`

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -243,6 +243,7 @@ Booster GPU routing contract:
 - when runtime execution resolves to GPU, `xgboost` adds `device="cuda"`
 - when runtime execution resolves to GPU, `lightgbm` adds `device_type="cuda"`
 - when runtime execution resolves to GPU, `catboost` adds `task_type="GPU"`
+- when runtime execution resolves to GPU, `logistic_regression` continues to use the sklearn estimator surface but runs through the RAPIDS `cuml.accel` hook path
 - user `model_params` still override repo defaults
 
 XGBoost GPU-native input contract:
@@ -254,6 +255,14 @@ XGBoost GPU-native input contract:
 - sparse CSR preprocessing output is rejected before training for the XGBoost GPU-native path
   - this currently covers `categorical_preprocessor: onehot` and related sparse `kbins` compositions
   - rationale: XGBoost does not support `cupyx` CSR inputs in this runtime
+
+GPU logistic regression contract:
+- when runtime execution resolves to GPU for `logistic_regression`, the builder wraps the sklearn estimator in the existing binary-label encoding adapter before fit
+- this keeps original competition labels in `model.classes_` while ensuring cuML sees numeric binary targets during fit
+- `categorical_preprocessor: frequency` is currently the only supported GPU logistic categorical path
+- unsupported preprocessing combinations are rejected before training for the GPU logistic path
+  - this currently covers `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions
+  - rationale: the RAPIDS-hooked sklearn preprocessing stack is not stable yet for these branches in the current runtime
 
 ## Candidate Manifest Contract
 Model candidate manifests currently record:

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -112,6 +112,30 @@ def _validate_gpu_native_matrix_output(
     )
 
 
+def _validate_gpu_logistic_matrix_output(
+    uses_gpu_logistic_regression: bool,
+    categorical_preprocessor_id: str,
+    matrix_output_kind: str,
+) -> None:
+    if not uses_gpu_logistic_regression:
+        return
+    if categorical_preprocessor_id == "frequency":
+        return
+    if matrix_output_kind == "sparse_csr":
+        raise ValueError(
+            "Logistic regression GPU execution currently supports categorical_preprocessor='frequency' only in "
+            "this runtime. The sparse CSR path produced by categorical_preprocessor='onehot' and related kbins "
+            "compositions is not supported under the RAPIDS-hooked sklearn preprocessing stack yet. "
+            "Use categorical_preprocessor='frequency' or force CPU execution."
+        )
+    raise ValueError(
+        "Logistic regression GPU execution currently supports categorical_preprocessor='frequency' only in "
+        "this runtime. The RAPIDS-hooked sklearn preprocessing stack is not stable yet for "
+        f"categorical_preprocessor='{categorical_preprocessor_id}'. "
+        "Use categorical_preprocessor='frequency' or force CPU execution."
+    )
+
+
 def build_prepared_training_context(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
@@ -178,8 +202,17 @@ def build_prepared_training_context(
         config.resolved_model_registry_key == "xgboost"
         and config.runtime_execution_context.resolved_compute_target == "gpu"
     )
+    uses_gpu_logistic_regression = (
+        config.resolved_model_registry_key == "logistic_regression"
+        and config.runtime_execution_context.resolved_compute_target == "gpu"
+    )
     _validate_gpu_native_matrix_output(
         uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
+        matrix_output_kind=matrix_output_kind,
+    )
+    _validate_gpu_logistic_matrix_output(
+        uses_gpu_logistic_regression=uses_gpu_logistic_regression,
+        categorical_preprocessor_id=candidate.categorical_preprocessor,
         matrix_output_kind=matrix_output_kind,
     )
     return PreparedTrainingContext(

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -139,11 +139,14 @@ def _build_hist_gradient_boosting_regressor(
 def _build_logreg(
     random_state: int,
     parameter_overrides: dict[str, object] | None = None,
-) -> tuple[LogisticRegression, dict[str, object]]:
+) -> tuple[object, dict[str, object]]:
     del random_state
     _validate_logreg_parameter_overrides(parameter_overrides)
     params = _merge_model_params({"solver": "saga", "max_iter": 1000}, parameter_overrides)
-    return LogisticRegression(**params), params
+    estimator = LogisticRegression(**params)
+    if get_runtime_execution_context().resolved_compute_target == "gpu":
+        return BinaryLabelEncodingClassifier(estimator), params
+    return estimator, params
 
 
 def _build_random_forest_classifier(


### PR DESCRIPTION
Closes #166

## Summary
- wrap GPU logistic regression in the existing binary label encoding adapter so cuML sees numeric targets while repo-level classes stay on the original competition labels
- reject unsupported GPU logistic preprocessing combinations before training instead of failing deep inside the RAPIDS-hooked sklearn stack
- document the current GPU logistic runtime contract in the README and technical guide

## Manual verification
- `PYTHONPYCACHEPREFIX=/tmp/tabularshenanigans-pycache python3 -m py_compile src/tabular_shenanigans/models.py src/tabular_shenanigans/model_evaluation.py`
- `uv run python main.py train --help`
- A100 host `217.18.55.37` with `PYTHONPATH=/tmp/ts-logreg-probe/src` over the synced GPU environment:
  - `categorical_preprocessor=frequency` completed a real fold probe with `cuml.accel profile` showing GPU calls for `LogisticRegression.fit` and `LogisticRegression.predict_proba`
  - the same probe preserved original classes as `['No', 'Yes']`
  - `categorical_preprocessor=ordinal` now fails early with the new repo error
  - `categorical_preprocessor=onehot` now fails early with the new repo error
- A100 host full smoke run:
  - command shape: `PYTHONPATH=/tmp/ts-logreg-probe/src MPLCONFIGDIR=/tmp /home/ubuntu/TabularShenanigans/.venv/bin/python -m tabular_shenanigans.bootstrap train`
  - candidate: `fr2--num_standardize__cat_frequency--logistic_regression--b88ae9c6`
  - MLflow run: `7c6154527ef14597a9f6637756b404be`
  - CV ROC AUC: `0.911409`
  - MLflow tags/params confirmed `runtime_requested_compute_target=gpu`, `runtime_resolved_compute_target=gpu`, `runtime_acceleration_backend=rapids`, and `runtime__rapids_hooks_installed=True`

## Notes
- GPU logistic regression is currently limited to `categorical_preprocessor: frequency`
- `ordinal` and `onehot` remain unsupported on the RAPIDS path and are now rejected before training
