### PR TITLE
Add explicit GPU backend contract and runtime metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Required top-level sections:
   - `auto`: prefer GPU only when the runtime exposes visible NVIDIA devices and RAPIDS hooks are available, otherwise fall back to CPU
   - `cpu`: force CPU execution
   - `gpu`: require GPU execution and fail fast when no GPU runtime or RAPIDS hook path is available
+- optional `gpu_backend`: `auto`, `patch`, or `native`
+  - advanced/transitional override; leave this at `auto` for normal use
+  - `auto`: when GPU execution is selected, route onto the current patch-based GPU path
+  - `patch`: require the current RAPIDS hook-based GPU path
+  - `native`: require the future explicit GPU-native path; this currently fails fast because no `gpu_native` tuples are registered yet
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
@@ -220,12 +225,14 @@ Current candidate-run metrics include:
 
 Current candidate-run tags include:
 - `run_kind=candidate`
-- `tracking_schema_version=2`
+- `tracking_schema_version=3`
 - `competition_slug`
 - `candidate_id`
 - `candidate_type`
 - `task_type`
 - `primary_metric`
+- `runtime_requested_gpu_backend`
+- `runtime_resolved_gpu_backend`
 - `config_fingerprint`
 - git metadata when available
 

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -34,6 +34,8 @@ experiment:
 
   runtime:
     compute_target: auto
+    # Advanced/transitional override. Leave on auto for normal use.
+    # gpu_backend: auto
 
   candidate:
     candidate_type: model

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -30,6 +30,8 @@ experiment:
 
   runtime:
     compute_target: auto
+    # Advanced/transitional override. Leave on auto for normal use.
+    # gpu_backend: auto
 
   candidate:
     candidate_type: model

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -4,7 +4,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 
 ## System Flow
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` from repository-root `config.yaml`, resolve the requested execution mode for the current machine, install RAPIDS hooks before the CLI imports the training stack when GPU execution is selected, and route GPU-capable booster families onto their GPU parameter paths.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware intent separately from backend choice for the current machine, install RAPIDS hooks only when the resolved backend is `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -42,7 +42,7 @@ Each candidate run is named with `candidate_id`.
 ### Tags
 Current candidate-run tags:
 - `run_kind=candidate`
-- `tracking_schema_version=2`
+- `tracking_schema_version=3`
 - `competition_slug`
 - `candidate_id`
 - `candidate_type`
@@ -50,6 +50,8 @@ Current candidate-run tags:
 - `primary_metric`
 - `runtime_requested_compute_target`
 - `runtime_resolved_compute_target`
+- `runtime_requested_gpu_backend`
+- `runtime_resolved_gpu_backend`
 - `runtime_acceleration_backend`
 - `config_fingerprint`
 - `git_commit` when available
@@ -62,6 +64,8 @@ Current candidate-run params:
 - `cv__random_state`
 - `runtime__requested_compute_target`
 - `runtime__resolved_compute_target`
+- `runtime__requested_gpu_backend`
+- `runtime__resolved_gpu_backend`
 - `runtime__gpu_available`
 - `runtime__acceleration_backend`
 - `runtime__rapids_hooks_installed`
@@ -132,7 +136,7 @@ Submission artifacts on the same candidate run:
 
 Stage notes:
 - `main.py` keeps the existing user-facing command but now delegates into a bootstrap module before the runtime imports `pandas`- or `sklearn`-dependent modules.
-- bootstrap resolves `experiment.runtime.compute_target` for the current machine and installs RAPIDS hooks before the CLI imports the training stack when GPU execution is selected.
+- bootstrap resolves `experiment.runtime.compute_target` and optional `experiment.runtime.gpu_backend` for the current machine and installs RAPIDS hooks only when the resolved backend is `gpu_patch`.
 - the GPU runtime contract assumes the environment was synced with `uv sync --extra boosters --extra gpu`; plain `uv run python main.py ...` is safe after that because the lockfile now pins the RAPIDS-compatible shared dependency range
 - `prepare` no longer persists canonical competition metadata. It only prepares the context in memory and writes EDA reports.
 - `train` is the only stage that creates candidate runs.
@@ -196,6 +200,12 @@ Required top-level keys:
   - `auto`: use GPU only when the machine exposes NVIDIA devices and RAPIDS hooks are available
   - `cpu`: stay on CPU
   - `gpu`: require the GPU + RAPIDS path and fail fast otherwise
+- optional `gpu_backend`: `auto`, `patch`, or `native`
+  - advanced/transitional override; leave this at `auto` for normal use
+  - `auto`: when GPU execution is selected, route onto the current `gpu_patch` path
+  - `patch`: require the current RAPIDS hook-based `gpu_patch` path
+  - `native`: require the future explicit `gpu_native` path
+  - today `gpu_backend: native` fails fast because no native tuples are registered yet
 
 GPU dependency contract:
 - base project dependencies pin `numpy` and `pandas` into the RAPIDS-compatible range used by both CPU and GPU installs

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -19,7 +19,10 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
     )
 
     runtime_config = load_bootstrap_runtime_config()
-    runtime_context = resolve_runtime_execution(runtime_config.compute_target)
+    runtime_context = resolve_runtime_execution(
+        runtime_config.compute_target,
+        runtime_config.gpu_backend,
+    )
     runtime_context = activate_runtime_acceleration(runtime_context)
     export_runtime_execution_context(runtime_context)
 

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -7,6 +7,7 @@ import yaml
 @dataclass(frozen=True)
 class BootstrapRuntimeConfig:
     compute_target: str = "auto"
+    gpu_backend: str = "auto"
 
 
 def _validate_compute_target(value: object) -> str:
@@ -21,6 +22,21 @@ def _validate_compute_target(value: object) -> str:
 
     raise ValueError(
         "experiment.runtime.compute_target must be one of ['auto', 'cpu', 'gpu']."
+    )
+
+
+def _validate_gpu_backend(value: object) -> str:
+    if value is None:
+        return "auto"
+    if not isinstance(value, str):
+        raise ValueError("experiment.runtime.gpu_backend must be a string when provided.")
+
+    normalized_value = value.strip().lower()
+    if normalized_value in {"auto", "patch", "native"}:
+        return normalized_value
+
+    raise ValueError(
+        "experiment.runtime.gpu_backend must be one of ['auto', 'patch', 'native']."
     )
 
 
@@ -57,4 +73,5 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
 
     return BootstrapRuntimeConfig(
         compute_target=_validate_compute_target(runtime.get("compute_target")),
+        gpu_backend=_validate_gpu_backend(runtime.get("gpu_backend")),
     )

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -210,6 +210,7 @@ class ExperimentRuntimeConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     compute_target: Literal["auto", "cpu", "gpu"] = "auto"
+    gpu_backend: Literal["auto", "patch", "native"] = "auto"
 
 
 class ExperimentConfig(BaseModel):
@@ -309,7 +310,10 @@ class AppConfig(BaseModel):
     def runtime_execution_context(self):
         from tabular_shenanigans.runtime_execution import get_runtime_execution_context
 
-        return get_runtime_execution_context(self.experiment.runtime.compute_target)
+        return get_runtime_execution_context(
+            self.experiment.runtime.compute_target,
+            self.experiment.runtime.gpu_backend,
+        )
 
     @property
     def resolved_candidate_id(self) -> str:
@@ -339,7 +343,9 @@ class AppConfig(BaseModel):
                 },
                 "runtime": {
                     "compute_target": self.experiment.runtime.compute_target,
+                    "gpu_backend": self.experiment.runtime.gpu_backend,
                     "resolved_compute_target": self.runtime_execution_context.resolved_compute_target,
+                    "resolved_gpu_backend": self.runtime_execution_context.resolved_gpu_backend,
                     "acceleration_backend": self.runtime_execution_context.acceleration_backend,
                 },
             }

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -15,7 +15,7 @@ from tabular_shenanigans.candidate_artifacts import (
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.submission_history import CandidateSubmissionHistory
 
-TRACKING_SCHEMA_VERSION = "2"
+TRACKING_SCHEMA_VERSION = "3"
 RUN_KIND_CANDIDATE = "candidate"
 SUBMISSION_HISTORY_ARTIFACT_PATH = "submissions/history.json"
 
@@ -171,6 +171,8 @@ def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: s
         "primary_metric": config.competition.primary_metric,
         "runtime_requested_compute_target": runtime_execution_context.requested_compute_target,
         "runtime_resolved_compute_target": runtime_execution_context.resolved_compute_target,
+        "runtime_requested_gpu_backend": runtime_execution_context.requested_gpu_backend,
+        "runtime_resolved_gpu_backend": runtime_execution_context.resolved_gpu_backend,
         "runtime_acceleration_backend": runtime_execution_context.acceleration_backend,
         **_git_metadata(),
     }
@@ -215,6 +217,8 @@ def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dic
         "cv__random_state": competition.cv.random_state,
         "runtime__requested_compute_target": runtime_execution_context.requested_compute_target,
         "runtime__resolved_compute_target": runtime_execution_context.resolved_compute_target,
+        "runtime__requested_gpu_backend": runtime_execution_context.requested_gpu_backend,
+        "runtime__resolved_gpu_backend": runtime_execution_context.resolved_gpu_backend,
         "runtime__gpu_available": runtime_execution_context.gpu_available,
         "runtime__acceleration_backend": runtime_execution_context.acceleration_backend,
         "runtime__rapids_hooks_installed": runtime_execution_context.rapids_hooks_installed,

--- a/src/tabular_shenanigans/runtime_execution.py
+++ b/src/tabular_shenanigans/runtime_execution.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 REQUESTED_COMPUTE_TARGET_ENV = "TABULAR_SHENANIGANS_REQUESTED_COMPUTE_TARGET"
 RESOLVED_COMPUTE_TARGET_ENV = "TABULAR_SHENANIGANS_RESOLVED_COMPUTE_TARGET"
+REQUESTED_GPU_BACKEND_ENV = "TABULAR_SHENANIGANS_REQUESTED_GPU_BACKEND"
+RESOLVED_GPU_BACKEND_ENV = "TABULAR_SHENANIGANS_RESOLVED_GPU_BACKEND"
 GPU_AVAILABLE_ENV = "TABULAR_SHENANIGANS_GPU_AVAILABLE"
 FALLBACK_REASON_ENV = "TABULAR_SHENANIGANS_RUNTIME_FALLBACK_REASON"
 PLATFORM_SYSTEM_ENV = "TABULAR_SHENANIGANS_RUNTIME_PLATFORM_SYSTEM"
@@ -15,9 +17,9 @@ VISIBLE_NVIDIA_DEVICES_ENV = "TABULAR_SHENANIGANS_VISIBLE_NVIDIA_DEVICES"
 ACCELERATION_BACKEND_ENV = "TABULAR_SHENANIGANS_ACCELERATION_BACKEND"
 RAPIDS_HOOKS_INSTALLED_ENV = "TABULAR_SHENANIGANS_RAPIDS_HOOKS_INSTALLED"
 CUDA_VISIBLE_DEVICES_ENV = "CUDA_VISIBLE_DEVICES"
-CPU_ACCELERATION_BACKEND = "cpu"
-PENDING_ACCELERATION_BACKEND = "pending"
-RAPIDS_ACCELERATION_BACKEND = "rapids"
+CPU_GPU_BACKEND = "cpu"
+PATCH_GPU_BACKEND = "gpu_patch"
+NATIVE_GPU_BACKEND = "gpu_native"
 
 
 @dataclass(frozen=True)
@@ -42,19 +44,26 @@ class RuntimeCapabilitySnapshot:
 class RuntimeExecutionContext:
     requested_compute_target: str
     resolved_compute_target: str
+    requested_gpu_backend: str
+    resolved_gpu_backend: str
     capabilities: RuntimeCapabilitySnapshot
     fallback_reason: str | None
-    acceleration_backend: str
     rapids_hooks_installed: bool
 
     @property
     def gpu_available(self) -> bool:
         return self.capabilities.gpu_available
 
+    @property
+    def acceleration_backend(self) -> str:
+        return self.resolved_gpu_backend
+
     def to_dict(self) -> dict[str, object]:
         return {
             "requested_compute_target": self.requested_compute_target,
             "resolved_compute_target": self.resolved_compute_target,
+            "requested_gpu_backend": self.requested_gpu_backend,
+            "resolved_gpu_backend": self.resolved_gpu_backend,
             "gpu_available": self.gpu_available,
             "fallback_reason": self.fallback_reason,
             "acceleration_backend": self.acceleration_backend,
@@ -75,6 +84,15 @@ def _validate_compute_target(value: str) -> str:
         return normalized_value
     raise ValueError(
         f"Unsupported compute target '{value}'. Expected one of ['auto', 'cpu', 'gpu']."
+    )
+
+
+def _validate_gpu_backend(value: str) -> str:
+    normalized_value = value.strip().lower()
+    if normalized_value in {"auto", "patch", "native"}:
+        return normalized_value
+    raise ValueError(
+        f"Unsupported gpu backend '{value}'. Expected one of ['auto', 'patch', 'native']."
     )
 
 
@@ -138,17 +156,22 @@ def detect_runtime_capabilities() -> RuntimeCapabilitySnapshot:
     )
 
 
-def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecutionContext:
+def resolve_runtime_execution(
+    requested_compute_target: str,
+    requested_gpu_backend: str = "auto",
+) -> RuntimeExecutionContext:
     normalized_target = _validate_compute_target(requested_compute_target)
+    normalized_backend = _validate_gpu_backend(requested_gpu_backend)
     capabilities = detect_runtime_capabilities()
 
     if normalized_target == "cpu":
         return RuntimeExecutionContext(
             requested_compute_target=normalized_target,
             resolved_compute_target="cpu",
+            requested_gpu_backend=normalized_backend,
+            resolved_gpu_backend=CPU_GPU_BACKEND,
             capabilities=capabilities,
             fallback_reason=None,
-            acceleration_backend=CPU_ACCELERATION_BACKEND,
             rapids_hooks_installed=False,
         )
 
@@ -157,9 +180,12 @@ def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecution
             return RuntimeExecutionContext(
                 requested_compute_target=normalized_target,
                 resolved_compute_target="gpu",
+                requested_gpu_backend=normalized_backend,
+                resolved_gpu_backend=(
+                    NATIVE_GPU_BACKEND if normalized_backend == "native" else PATCH_GPU_BACKEND
+                ),
                 capabilities=capabilities,
                 fallback_reason=None,
-                acceleration_backend=PENDING_ACCELERATION_BACKEND,
                 rapids_hooks_installed=False,
             )
         raise RuntimeError(
@@ -171,18 +197,22 @@ def resolve_runtime_execution(requested_compute_target: str) -> RuntimeExecution
         return RuntimeExecutionContext(
             requested_compute_target=normalized_target,
             resolved_compute_target="gpu",
+            requested_gpu_backend=normalized_backend,
+            resolved_gpu_backend=(
+                NATIVE_GPU_BACKEND if normalized_backend == "native" else PATCH_GPU_BACKEND
+            ),
             capabilities=capabilities,
             fallback_reason=None,
-            acceleration_backend=PENDING_ACCELERATION_BACKEND,
             rapids_hooks_installed=False,
         )
 
     return RuntimeExecutionContext(
         requested_compute_target=normalized_target,
         resolved_compute_target="cpu",
+        requested_gpu_backend=normalized_backend,
+        resolved_gpu_backend=CPU_GPU_BACKEND,
         capabilities=capabilities,
         fallback_reason=capabilities.unavailable_reason,
-        acceleration_backend=CPU_ACCELERATION_BACKEND,
         rapids_hooks_installed=False,
     )
 
@@ -213,22 +243,29 @@ def _load_rapids_hook_installers() -> RapidsHookInstallers:
 
 
 def activate_runtime_acceleration(context: RuntimeExecutionContext) -> RuntimeExecutionContext:
-    if context.resolved_compute_target != "gpu":
+    if context.resolved_gpu_backend == CPU_GPU_BACKEND:
         return context
+
+    if context.resolved_gpu_backend == NATIVE_GPU_BACKEND:
+        raise RuntimeError(
+            "Configured experiment.runtime.gpu_backend='native' but no explicit gpu_native "
+            "paths are registered in this runtime yet. Use gpu_backend='auto' or 'patch' "
+            "until the follow-on native issues land."
+        )
 
     try:
         rapids_installers = _load_rapids_hook_installers()
     except RuntimeError as exc:
         if context.requested_compute_target == "gpu":
             raise RuntimeError(
-                "Configured experiment.runtime.compute_target='gpu' but RAPIDS hooks are unavailable. "
+                "Configured GPU patch execution is unavailable. "
                 f"Reason: {exc}. Detection summary: {describe_runtime_capabilities(context.capabilities)}"
             ) from exc
         return replace(
             context,
             resolved_compute_target="cpu",
+            resolved_gpu_backend=CPU_GPU_BACKEND,
             fallback_reason=f"RAPIDS hooks unavailable: {exc}",
-            acceleration_backend=CPU_ACCELERATION_BACKEND,
             rapids_hooks_installed=False,
         )
 
@@ -244,7 +281,6 @@ def activate_runtime_acceleration(context: RuntimeExecutionContext) -> RuntimeEx
 
     return replace(
         context,
-        acceleration_backend=RAPIDS_ACCELERATION_BACKEND,
         rapids_hooks_installed=True,
     )
 
@@ -252,6 +288,8 @@ def activate_runtime_acceleration(context: RuntimeExecutionContext) -> RuntimeEx
 def export_runtime_execution_context(context: RuntimeExecutionContext) -> None:
     os.environ[REQUESTED_COMPUTE_TARGET_ENV] = context.requested_compute_target
     os.environ[RESOLVED_COMPUTE_TARGET_ENV] = context.resolved_compute_target
+    os.environ[REQUESTED_GPU_BACKEND_ENV] = context.requested_gpu_backend
+    os.environ[RESOLVED_GPU_BACKEND_ENV] = context.resolved_gpu_backend
     os.environ[GPU_AVAILABLE_ENV] = "true" if context.gpu_available else "false"
     os.environ[PLATFORM_SYSTEM_ENV] = context.capabilities.platform_system
     os.environ[VISIBLE_NVIDIA_DEVICES_ENV] = ",".join(context.capabilities.visible_nvidia_devices)
@@ -266,17 +304,19 @@ def export_runtime_execution_context(context: RuntimeExecutionContext) -> None:
 def _parse_exported_runtime_execution_context() -> RuntimeExecutionContext | None:
     requested_compute_target = os.getenv(REQUESTED_COMPUTE_TARGET_ENV)
     resolved_compute_target = os.getenv(RESOLVED_COMPUTE_TARGET_ENV)
+    requested_gpu_backend = os.getenv(REQUESTED_GPU_BACKEND_ENV)
+    resolved_gpu_backend = os.getenv(RESOLVED_GPU_BACKEND_ENV)
     gpu_available = os.getenv(GPU_AVAILABLE_ENV)
     platform_system = os.getenv(PLATFORM_SYSTEM_ENV)
-    acceleration_backend = os.getenv(ACCELERATION_BACKEND_ENV)
     rapids_hooks_installed = os.getenv(RAPIDS_HOOKS_INSTALLED_ENV)
 
     if (
         requested_compute_target is None
         or resolved_compute_target is None
+        or requested_gpu_backend is None
+        or resolved_gpu_backend is None
         or gpu_available is None
         or platform_system is None
-        or acceleration_backend is None
         or rapids_hooks_installed is None
     ):
         return None
@@ -296,18 +336,22 @@ def _parse_exported_runtime_execution_context() -> RuntimeExecutionContext | Non
     return RuntimeExecutionContext(
         requested_compute_target=requested_compute_target,
         resolved_compute_target=resolved_compute_target,
+        requested_gpu_backend=requested_gpu_backend,
+        resolved_gpu_backend=resolved_gpu_backend,
         capabilities=capabilities,
         fallback_reason=fallback_reason,
-        acceleration_backend=acceleration_backend,
         rapids_hooks_installed=rapids_hooks_installed == "true",
     )
 
 
-def get_runtime_execution_context(requested_compute_target: str = "auto") -> RuntimeExecutionContext:
+def get_runtime_execution_context(
+    requested_compute_target: str = "auto",
+    requested_gpu_backend: str = "auto",
+) -> RuntimeExecutionContext:
     exported_context = _parse_exported_runtime_execution_context()
     if exported_context is not None:
         return exported_context
-    return resolve_runtime_execution(requested_compute_target)
+    return resolve_runtime_execution(requested_compute_target, requested_gpu_backend)
 
 
 def describe_runtime_capabilities(capabilities: RuntimeCapabilitySnapshot) -> str:
@@ -328,6 +372,8 @@ def format_runtime_execution_context(context: RuntimeExecutionContext) -> str:
     summary = (
         f"requested_compute_target={context.requested_compute_target}, "
         f"resolved_compute_target={context.resolved_compute_target}, "
+        f"requested_gpu_backend={context.requested_gpu_backend}, "
+        f"resolved_gpu_backend={context.resolved_gpu_backend}, "
         f"gpu_available={context.gpu_available}, "
         f"acceleration_backend={context.acceleration_backend}, "
         f"rapids_hooks_installed={context.rapids_hooks_installed}, "


### PR DESCRIPTION
## Summary
- add an explicit `gpu_backend` runtime contract alongside `compute_target`
- distinguish requested/resolved GPU backend in runtime context, metadata, and candidate fingerprints
- keep current default GPU behavior on the patch-based path while making `gpu_backend: native` fail fast until native tuples exist

Closes #169

## Verification
- imported the changed modules successfully with the project interpreter
- verified CPU resolution on the current host
- verified that a simulated Linux GPU host resolves `gpu_backend: native` to `gpu_native` and then fails with the intended repo-owned error
- verified config validation and candidate-id derivation include the backend contract
- attempted `uv run python -m py_compile ...`, but `uv` itself panicked in this environment during that invocation; import-level smoke checks passed