### PR TITLE
Implement gpu-native frequency preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,17 @@ Required top-level sections:
   - advanced/transitional override; leave this at `auto` for normal use
   - `auto`: when GPU execution is selected, route onto the current patch-based GPU path
   - `patch`: require the current RAPIDS hook-based GPU path
-  - `native`: require the future explicit GPU-native path; this currently fails fast because no `gpu_native` tuples are registered yet
+  - `native`: require the explicit GPU-native path
+  - the current `gpu_native` support matrix is intentionally narrow:
+    - `model_family: xgboost`
+    - `categorical_preprocessor: frequency`
+    - `numeric_preprocessor: median` or `standardize`
+  - unsupported `gpu_native` tuples fail fast with repo-owned errors
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
   - when GPU execution is active for `xgboost`, the runtime keeps fold-local preprocessing semantics but converts dense fold outputs to `cupy` / `cudf` before XGBoost fit and predict
+  - when runtime resolves to `gpu_native` for the supported XGBoost slice, `frequency` preprocessing is performed by the repo-owned `cudf` path rather than patched pandas/sklearn behavior
   - the XGBoost GPU-native input path currently supports dense preprocessing outputs such as `categorical_preprocessor: ordinal` and `categorical_preprocessor: frequency`
   - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
   - the GPU logistic regression path currently supports `categorical_preprocessor: frequency` only

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -204,8 +204,12 @@ Required top-level keys:
   - advanced/transitional override; leave this at `auto` for normal use
   - `auto`: when GPU execution is selected, route onto the current `gpu_patch` path
   - `patch`: require the current RAPIDS hook-based `gpu_patch` path
-  - `native`: require the future explicit `gpu_native` path
-  - today `gpu_backend: native` fails fast because no native tuples are registered yet
+  - `native`: require the explicit `gpu_native` path
+  - current supported `gpu_native` tuple:
+    - `model_family: xgboost`
+    - `categorical_preprocessor: frequency`
+    - `numeric_preprocessor: median` or `standardize`
+  - unsupported `gpu_native` tuples fail fast with repo-owned errors
 
 GPU dependency contract:
 - base project dependencies pin `numpy` and `pandas` into the RAPIDS-compatible range used by both CPU and GPU installs
@@ -258,6 +262,7 @@ Booster GPU routing contract:
 
 XGBoost GPU-native input contract:
 - when runtime execution resolves to GPU for `xgboost`, fold-local preprocessing still happens per fold so CV remains leakage-safe
+- when runtime execution resolves to `gpu_native` for the supported `frequency` slice, the repo uses an explicit `cudf` preprocessing path instead of CPU-side transformed folds plus conversion
 - after preprocessing, dense fold outputs are promoted to GPU-native inputs before `fit` and `predict`
   - pandas DataFrame outputs, such as the `frequency` categorical path, are promoted to `cudf.DataFrame`
   - dense ndarray outputs, such as the `ordinal` categorical path, are promoted to `cupy.ndarray`

--- a/src/tabular_shenanigans/gpu_preprocess.py
+++ b/src/tabular_shenanigans/gpu_preprocess.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+
+import pandas as pd
+
+from tabular_shenanigans.preprocess import ResolvedFeatureSchema
+
+SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS = frozenset({"median", "standardize"})
+SUPPORTED_GPU_NATIVE_CATEGORICAL_PREPROCESSOR_IDS = frozenset({"frequency"})
+
+
+def _import_cudf():
+    try:
+        import cudf
+    except ImportError as exc:
+        raise RuntimeError(
+            "gpu_native preprocessing requires the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+    return cudf
+
+
+@dataclass(frozen=True)
+class _ResolvedNumericStatistics:
+    medians: dict[str, float]
+    means: dict[str, float]
+    scales: dict[str, float]
+
+
+class GpuNativeFrequencyPreprocessor:
+    CATEGORICAL_MISSING_VALUE = "__missing__"
+
+    def __init__(
+        self,
+        feature_columns: list[str],
+        numeric_columns: list[str],
+        categorical_columns: list[str],
+        numeric_preprocessor_id: str,
+    ) -> None:
+        self.feature_columns = feature_columns
+        self.numeric_columns = numeric_columns
+        self.categorical_columns = categorical_columns
+        self.numeric_preprocessor_id = numeric_preprocessor_id
+        self.numeric_statistics = _ResolvedNumericStatistics(medians={}, means={}, scales={})
+        self.category_frequencies: dict[str, dict[str, float]] = {}
+
+    def _normalize_numeric_frame(self, frame: pd.DataFrame):
+        cudf = _import_cudf()
+        if not self.numeric_columns:
+            return cudf.DataFrame(index=frame.index)
+        return cudf.from_pandas(frame.loc[:, self.numeric_columns]).astype("float64")
+
+    def _normalize_categorical_frame(self, frame: pd.DataFrame):
+        cudf = _import_cudf()
+        if not self.categorical_columns:
+            return cudf.DataFrame(index=frame.index)
+        categorical_frame = cudf.from_pandas(frame.loc[:, self.categorical_columns])
+        return categorical_frame.fillna(self.CATEGORICAL_MISSING_VALUE).astype("str")
+
+    def fit(self, frame: pd.DataFrame) -> "GpuNativeFrequencyPreprocessor":
+        numeric_frame = self._normalize_numeric_frame(frame)
+        medians: dict[str, float] = {}
+        means: dict[str, float] = {}
+        scales: dict[str, float] = {}
+
+        for column in self.numeric_columns:
+            column_values = numeric_frame[column]
+            median_value = column_values.dropna().median()
+            if pd.isna(median_value):
+                raise ValueError(
+                    "gpu_native preprocessing does not support all-null numeric columns yet. "
+                    f"Column: {column}"
+                )
+            median_float = float(median_value)
+            medians[column] = median_float
+
+            if self.numeric_preprocessor_id == "standardize":
+                imputed_values = column_values.fillna(median_float)
+                mean_float = float(imputed_values.mean())
+                scale_float = float(imputed_values.std(ddof=0))
+                if pd.isna(scale_float) or scale_float == 0.0:
+                    scale_float = 1.0
+                means[column] = mean_float
+                scales[column] = scale_float
+
+        categorical_frame = self._normalize_categorical_frame(frame)
+        for column in self.categorical_columns:
+            value_frequencies = categorical_frame[column].value_counts(normalize=True, dropna=False)
+            self.category_frequencies[column] = {
+                str(category_value): float(frequency)
+                for category_value, frequency in value_frequencies.to_pandas().items()
+            }
+
+        self.numeric_statistics = _ResolvedNumericStatistics(
+            medians=medians,
+            means=means,
+            scales=scales,
+        )
+        return self
+
+    def _transform_numeric_frame(self, frame: pd.DataFrame):
+        cudf = _import_cudf()
+        if not self.numeric_columns:
+            return cudf.DataFrame(index=frame.index)
+
+        numeric_frame = self._normalize_numeric_frame(frame)
+        transformed_columns: dict[str, object] = {}
+        for column in self.numeric_columns:
+            transformed_values = numeric_frame[column].fillna(self.numeric_statistics.medians[column])
+            if self.numeric_preprocessor_id == "standardize":
+                transformed_values = (
+                    transformed_values - self.numeric_statistics.means[column]
+                ) / self.numeric_statistics.scales[column]
+            transformed_columns[column] = transformed_values.astype("float64")
+        return cudf.DataFrame(transformed_columns, index=numeric_frame.index)
+
+    def _transform_categorical_frame(self, frame: pd.DataFrame):
+        cudf = _import_cudf()
+        if not self.categorical_columns:
+            return cudf.DataFrame(index=frame.index)
+
+        categorical_frame = self._normalize_categorical_frame(frame)
+        transformed_columns: dict[str, object] = {}
+        for column in self.categorical_columns:
+            transformed_columns[column] = (
+                categorical_frame[column]
+                .map(self.category_frequencies[column])
+                .fillna(0.0)
+                .astype("float64")
+            )
+        return cudf.DataFrame(transformed_columns, index=categorical_frame.index)
+
+    def transform(self, frame: pd.DataFrame):
+        cudf = _import_cudf()
+        transformed_frames = [
+            self._transform_numeric_frame(frame),
+            self._transform_categorical_frame(frame),
+        ]
+        populated_frames = [transformed_frame for transformed_frame in transformed_frames if len(transformed_frame.columns) > 0]
+        if not populated_frames:
+            return cudf.DataFrame(index=frame.index)
+        return cudf.concat(populated_frames, axis=1)
+
+    def fit_transform(self, frame: pd.DataFrame):
+        return self.fit(frame).transform(frame)
+
+
+def build_gpu_native_preprocessor_from_schema(
+    feature_schema: ResolvedFeatureSchema,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+) -> GpuNativeFrequencyPreprocessor:
+    if not feature_schema.numeric_columns and not feature_schema.categorical_columns:
+        raise ValueError("No modeled features remain after excluding id_column and applying drop_columns.")
+
+    if categorical_preprocessor_id not in SUPPORTED_GPU_NATIVE_CATEGORICAL_PREPROCESSOR_IDS:
+        raise ValueError(
+            "gpu_native preprocessing currently supports categorical_preprocessor='frequency' only. "
+            f"Got '{categorical_preprocessor_id}'."
+        )
+
+    if numeric_preprocessor_id not in SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS:
+        raise ValueError(
+            "gpu_native preprocessing currently supports numeric_preprocessor in "
+            f"{sorted(SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS)} only. "
+            f"Got '{numeric_preprocessor_id}'."
+        )
+
+    return GpuNativeFrequencyPreprocessor(
+        feature_columns=feature_schema.feature_columns,
+        numeric_columns=feature_schema.numeric_columns,
+        categorical_columns=feature_schema.categorical_columns,
+        numeric_preprocessor_id=numeric_preprocessor_id,
+    )

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -10,6 +10,10 @@ from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.feature_recipes import apply_feature_recipe
+from tabular_shenanigans.gpu_preprocess import (
+    SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS,
+    build_gpu_native_preprocessor_from_schema,
+)
 from tabular_shenanigans.models import (
     build_model,
     build_model_fit_kwargs,
@@ -94,6 +98,7 @@ class PreparedTrainingContext:
     preprocessing_scheme_id: str
     matrix_output_kind: str
     uses_xgboost_gpu_native_inputs: bool
+    uses_gpu_native_preprocessing: bool
 
 
 def _validate_gpu_native_matrix_output(
@@ -134,6 +139,33 @@ def _validate_gpu_logistic_matrix_output(
         f"categorical_preprocessor='{categorical_preprocessor_id}'. "
         "Use categorical_preprocessor='frequency' or force CPU execution."
     )
+
+
+def _validate_gpu_native_preprocessing_support(
+    resolved_gpu_backend: str,
+    model_registry_key: str,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+) -> None:
+    if resolved_gpu_backend != "gpu_native":
+        return
+    if model_registry_key != "xgboost":
+        raise ValueError(
+            "gpu_native currently supports model_family='xgboost' only in this runtime. "
+            "Use gpu_backend='auto' or 'patch' for other model families until the follow-on "
+            "native model issues land."
+        )
+    if categorical_preprocessor_id != "frequency":
+        raise ValueError(
+            "gpu_native currently supports categorical_preprocessor='frequency' only in this runtime. "
+            f"Got '{categorical_preprocessor_id}'."
+        )
+    if numeric_preprocessor_id not in SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS:
+        raise ValueError(
+            "gpu_native currently supports numeric_preprocessor in "
+            f"{sorted(SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS)} only. "
+            f"Got '{numeric_preprocessor_id}'."
+        )
 
 
 def build_prepared_training_context(
@@ -198,6 +230,8 @@ def build_prepared_training_context(
         model_id=config.resolved_model_registry_key,
         categorical_preprocessor_id=candidate.categorical_preprocessor,
     )
+    resolved_gpu_backend = config.runtime_execution_context.resolved_gpu_backend
+    uses_gpu_native_preprocessing = resolved_gpu_backend == "gpu_native"
     uses_xgboost_gpu_native_inputs = (
         config.resolved_model_registry_key == "xgboost"
         and config.runtime_execution_context.resolved_compute_target == "gpu"
@@ -205,6 +239,13 @@ def build_prepared_training_context(
     uses_gpu_logistic_regression = (
         config.resolved_model_registry_key == "logistic_regression"
         and config.runtime_execution_context.resolved_compute_target == "gpu"
+        and resolved_gpu_backend == "gpu_patch"
+    )
+    _validate_gpu_native_preprocessing_support(
+        resolved_gpu_backend=resolved_gpu_backend,
+        model_registry_key=config.resolved_model_registry_key,
+        numeric_preprocessor_id=candidate.numeric_preprocessor,
+        categorical_preprocessor_id=candidate.categorical_preprocessor,
     )
     _validate_gpu_native_matrix_output(
         uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
@@ -234,10 +275,13 @@ def build_prepared_training_context(
         preprocessing_scheme_id=candidate.preprocessing_scheme_id,
         matrix_output_kind=matrix_output_kind,
         uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
+        uses_gpu_native_preprocessing=uses_gpu_native_preprocessing,
     )
 
 
 def _coerce_processed_matrix(values: object, matrix_output_kind: str) -> object:
+    if type(values).__module__.startswith("cudf.") or type(values).__module__.startswith("cupy."):
+        return values
     if matrix_output_kind == "native_frame":
         if not isinstance(values, pd.DataFrame):
             raise ValueError("Native categorical preprocessing must produce a pandas DataFrame.")
@@ -318,6 +362,7 @@ def _run_cv_evaluation(
     preprocessing_scheme_id = training_context.preprocessing_scheme_id
     matrix_output_kind = training_context.matrix_output_kind
     uses_xgboost_gpu_native_inputs = training_context.uses_xgboost_gpu_native_inputs
+    uses_gpu_native_preprocessing = training_context.uses_gpu_native_preprocessing
 
     oof_predictions = (
         np.zeros(training_context.x_train_features.shape[0], dtype=float)
@@ -336,12 +381,19 @@ def _run_cv_evaluation(
         y_fold_train = training_context.y_train.iloc[train_idx]
         y_fold_valid = training_context.y_train.iloc[valid_idx]
 
-        preprocessor = build_preprocessor_from_schema(
-            feature_schema=training_context.feature_schema,
-            numeric_preprocessor_id=training_context.numeric_preprocessor,
-            categorical_preprocessor_id=training_context.categorical_preprocessor,
-            matrix_output_kind=matrix_output_kind,
-        )
+        if uses_gpu_native_preprocessing:
+            preprocessor = build_gpu_native_preprocessor_from_schema(
+                feature_schema=training_context.feature_schema,
+                numeric_preprocessor_id=training_context.numeric_preprocessor,
+                categorical_preprocessor_id=training_context.categorical_preprocessor,
+            )
+        else:
+            preprocessor = build_preprocessor_from_schema(
+                feature_schema=training_context.feature_schema,
+                numeric_preprocessor_id=training_context.numeric_preprocessor,
+                categorical_preprocessor_id=training_context.categorical_preprocessor,
+                matrix_output_kind=matrix_output_kind,
+            )
         x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
         x_fold_valid_processed = preprocessor.transform(x_fold_valid)
         x_test_processed = None

--- a/src/tabular_shenanigans/runtime_execution.py
+++ b/src/tabular_shenanigans/runtime_execution.py
@@ -247,11 +247,7 @@ def activate_runtime_acceleration(context: RuntimeExecutionContext) -> RuntimeEx
         return context
 
     if context.resolved_gpu_backend == NATIVE_GPU_BACKEND:
-        raise RuntimeError(
-            "Configured experiment.runtime.gpu_backend='native' but no explicit gpu_native "
-            "paths are registered in this runtime yet. Use gpu_backend='auto' or 'patch' "
-            "until the follow-on native issues land."
-        )
+        return context
 
     try:
         rapids_installers = _load_rapids_hook_installers()


### PR DESCRIPTION
## Summary
- add the first repo-owned `gpu_native` preprocessing slice with explicit `cudf` frequency preprocessing
- register the first supported `gpu_native` tuple as `xgboost + frequency + (median|standardize)`
- allow `gpu_backend: native` to proceed without RAPIDS patch hooks and fail unsupported tuples in the training layer with direct errors

Closes #172

## Verification
- imported the changed modules successfully with the project interpreter
- simulated a Linux GPU host and verified that `compute_target=gpu` plus `gpu_backend=native` now resolves to `gpu_native` without installing RAPIDS hooks
- simulated the supported tuple and verified `build_prepared_training_context()` accepts it and marks `uses_gpu_native_preprocessing=True`
- simulated an unsupported native tuple and verified it fails early with a repo-owned error
- full end-to-end `cudf` execution was not run in this environment because the optional GPU dependencies and Linux NVIDIA runtime are not available here