### PR TITLE
Add explicit cuML logistic regression backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Required top-level sections:
   - `patch`: require the current RAPIDS hook-based GPU path
   - `native`: require the explicit GPU-native path
   - the current `gpu_native` support matrix is intentionally narrow:
+    - `model_family: logistic_regression`
+    - `categorical_preprocessor: frequency`
+    - `numeric_preprocessor: standardize`
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
@@ -150,8 +153,9 @@ Required top-level sections:
   - when runtime resolves to `gpu_native` for the supported XGBoost slice, `frequency` preprocessing is performed by the repo-owned `cudf` path rather than patched pandas/sklearn behavior
   - the XGBoost GPU-native input path currently supports dense preprocessing outputs such as `categorical_preprocessor: ordinal` and `categorical_preprocessor: frequency`
   - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
-  - the GPU logistic regression path currently supports `categorical_preprocessor: frequency` only
-  - the GPU logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution
+  - the `gpu_patch` logistic regression path currently supports `categorical_preprocessor: frequency` only
+  - the `gpu_patch` logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution
+  - the `gpu_native` logistic regression path currently supports `categorical_preprocessor: frequency` with `numeric_preprocessor: standardize` only
 
 `experiment.candidate` keys:
 - shared:

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -206,6 +206,9 @@ Required top-level keys:
   - `patch`: require the current RAPIDS hook-based `gpu_patch` path
   - `native`: require the explicit `gpu_native` path
   - current supported `gpu_native` tuple:
+    - `model_family: logistic_regression`
+    - `categorical_preprocessor: frequency`
+    - `numeric_preprocessor: standardize`
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
@@ -272,12 +275,17 @@ XGBoost GPU-native input contract:
   - rationale: XGBoost does not support `cupyx` CSR inputs in this runtime
 
 GPU logistic regression contract:
-- when runtime execution resolves to GPU for `logistic_regression`, the builder wraps the sklearn estimator in the existing binary-label encoding adapter before fit
+- when runtime execution resolves to `gpu_patch` for `logistic_regression`, the builder wraps the sklearn estimator in the existing binary-label encoding adapter before fit
 - this keeps original competition labels in `model.classes_` while ensuring cuML sees numeric binary targets during fit
-- `categorical_preprocessor: frequency` is currently the only supported GPU logistic categorical path
+- the `gpu_patch` path currently supports `categorical_preprocessor: frequency` only
 - unsupported preprocessing combinations are rejected before training for the GPU logistic path
   - this currently covers `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions
   - rationale: the RAPIDS-hooked sklearn preprocessing stack is not stable yet for these branches in the current runtime
+- when runtime execution resolves to `gpu_native` for `logistic_regression`, the repo builds an explicit `cuml.LogisticRegression` estimator instead of relying on sklearn interception
+- the `gpu_native` logistic path currently supports:
+  - `categorical_preprocessor: frequency`
+  - `numeric_preprocessor: standardize`
+- `gpu_native` logistic currently rejects `model_params.class_weight`; use `gpu_backend: patch` or CPU execution when class weighting is required
 
 ## Candidate Manifest Contract
 Model candidate manifests currently record:

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -149,11 +149,11 @@ def _validate_gpu_native_preprocessing_support(
 ) -> None:
     if resolved_gpu_backend != "gpu_native":
         return
-    if model_registry_key != "xgboost":
+    if model_registry_key not in {"logistic_regression", "xgboost"}:
         raise ValueError(
-            "gpu_native currently supports model_family='xgboost' only in this runtime. "
-            "Use gpu_backend='auto' or 'patch' for other model families until the follow-on "
-            "native model issues land."
+            "gpu_native currently supports model_family in ['logistic_regression', 'xgboost'] only "
+            "in this runtime. Use gpu_backend='auto' or 'patch' for other model families until the "
+            "follow-on native model issues land."
         )
     if categorical_preprocessor_id != "frequency":
         raise ValueError(
@@ -165,6 +165,26 @@ def _validate_gpu_native_preprocessing_support(
             "gpu_native currently supports numeric_preprocessor in "
             f"{sorted(SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS)} only. "
             f"Got '{numeric_preprocessor_id}'."
+        )
+
+
+def _validate_gpu_native_logistic_support(
+    resolved_gpu_backend: str,
+    model_registry_key: str,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+) -> None:
+    if resolved_gpu_backend != "gpu_native" or model_registry_key != "logistic_regression":
+        return
+    if categorical_preprocessor_id != "frequency":
+        raise ValueError(
+            "gpu_native logistic regression currently supports categorical_preprocessor='frequency' only "
+            f"in this runtime. Got '{categorical_preprocessor_id}'."
+        )
+    if numeric_preprocessor_id != "standardize":
+        raise ValueError(
+            "gpu_native logistic regression currently supports numeric_preprocessor='standardize' only "
+            f"in this runtime. Got '{numeric_preprocessor_id}'."
         )
 
 
@@ -242,6 +262,12 @@ def build_prepared_training_context(
         and resolved_gpu_backend == "gpu_patch"
     )
     _validate_gpu_native_preprocessing_support(
+        resolved_gpu_backend=resolved_gpu_backend,
+        model_registry_key=config.resolved_model_registry_key,
+        numeric_preprocessor_id=candidate.numeric_preprocessor,
+        categorical_preprocessor_id=candidate.categorical_preprocessor,
+    )
+    _validate_gpu_native_logistic_support(
         resolved_gpu_backend=resolved_gpu_backend,
         model_registry_key=config.resolved_model_registry_key,
         numeric_preprocessor_id=candidate.numeric_preprocessor,

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -142,11 +142,55 @@ def _build_logreg(
 ) -> tuple[object, dict[str, object]]:
     del random_state
     _validate_logreg_parameter_overrides(parameter_overrides)
+    runtime_execution_context = get_runtime_execution_context()
+    if runtime_execution_context.resolved_gpu_backend == "gpu_native":
+        params = _build_gpu_native_logreg_params(parameter_overrides)
+        try:
+            from cuml.linear_model import LogisticRegression as CuMlLogisticRegression
+        except ImportError as exc:
+            raise ImportError(
+                "gpu_native logistic regression requires the optional GPU dependencies. "
+                "Install them with `uv sync --extra boosters --extra gpu`."
+            ) from exc
+
+        estimator = CuMlLogisticRegression(**params)
+        return BinaryLabelEncodingClassifier(estimator), params
+
     params = _merge_model_params({"solver": "saga", "max_iter": 1000}, parameter_overrides)
     estimator = LogisticRegression(**params)
-    if get_runtime_execution_context().resolved_compute_target == "gpu":
+    if runtime_execution_context.resolved_gpu_backend == "gpu_patch":
         return BinaryLabelEncodingClassifier(estimator), params
     return estimator, params
+
+
+def _build_gpu_native_logreg_params(
+    parameter_overrides: dict[str, object] | None,
+) -> dict[str, object]:
+    resolved_overrides = dict(parameter_overrides or {})
+    class_weight = resolved_overrides.get("class_weight")
+    if class_weight not in (None,):
+        raise ValueError(
+            "gpu_native logistic regression currently does not support model_params.class_weight. "
+            "Use null, force gpu_backend='patch', or force CPU execution."
+        )
+    resolved_overrides.pop("class_weight", None)
+
+    l1_ratio = float(resolved_overrides.pop("l1_ratio", 0.0))
+    if l1_ratio == 0.0:
+        penalty = "l2"
+    elif l1_ratio == 1.0:
+        penalty = "l1"
+    else:
+        penalty = "elasticnet"
+
+    default_params: dict[str, object] = {
+        "penalty": penalty,
+        "max_iter": 1000,
+    }
+    if penalty == "elasticnet":
+        default_params["l1_ratio"] = l1_ratio
+    params = _merge_model_params(default_params, resolved_overrides)
+    return params
 
 
 def _build_random_forest_classifier(
@@ -375,6 +419,14 @@ def _build_hist_gradient_boosting_tuning_space(trial: object) -> dict[str, objec
 
 
 def _build_logreg_tuning_space(trial: object) -> dict[str, object]:
+    runtime_execution_context = get_runtime_execution_context()
+    if runtime_execution_context.resolved_gpu_backend == "gpu_native":
+        return {
+            "C": trial.suggest_float("C", 1e-4, 1e3, log=True),
+            "l1_ratio": trial.suggest_float("l1_ratio", 0.0, 1.0, step=0.05),
+            "max_iter": 1000,
+            "tol": trial.suggest_float("tol", 1e-4, 1e-2, log=True),
+        }
     return {
         "C": trial.suggest_float("C", 1e-4, 1e3, log=True),
         "class_weight": trial.suggest_categorical("class_weight", [None, "balanced"]),


### PR DESCRIPTION
Closes #171

## Summary
- add an explicit cuML logistic regression builder for gpu_native
- gate gpu_native logistic regression to the supported frequency + standardize tuple
- document the current native logistic contract

## Verification
- ran a fake cuML builder smoke test by injecting a stub cuml.linear_model.LogisticRegression and verifying the native builder wrapped it in BinaryLabelEncodingClassifier with the expected params
- simulated a Linux GPU host and verified build_prepared_training_context accepts the supported gpu_native logistic tuple
- simulated an unsupported gpu_native logistic tuple and verified it fails early with the intended repo-owned error
- imported the changed modules successfully

## Limitations
- no real end-to-end cuML run was possible in this environment because this machine does not have the Linux NVIDIA GPU runtime or optional GPU dependencies installed