### PR TITLE
Tighten native XGBoost closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,8 @@ Required top-level sections:
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
-  - when GPU execution is active for `xgboost`, the runtime keeps fold-local preprocessing semantics but converts dense fold outputs to `cupy` / `cudf` before XGBoost fit and predict
-  - when runtime resolves to `gpu_native` for the supported XGBoost slice, `frequency` preprocessing is performed by the repo-owned `cudf` path rather than patched pandas/sklearn behavior
-  - the XGBoost GPU-native input path currently supports dense preprocessing outputs such as `categorical_preprocessor: ordinal` and `categorical_preprocessor: frequency`
+  - when runtime resolves to `gpu_native` for the supported XGBoost slice, fold-local preprocessing remains per-CV-split, `frequency` preprocessing is performed by the repo-owned `cudf` path, and the first supported dense outputs stay GPU-resident through fit and predict
+  - the current native XGBoost support matrix is intentionally narrow and aligned with the documented `gpu_native` tuples above
   - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
   - the `gpu_patch` logistic regression path currently supports `categorical_preprocessor: frequency` only
   - the `gpu_patch` logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -266,10 +266,12 @@ Booster GPU routing contract:
 
 XGBoost GPU-native input contract:
 - when runtime execution resolves to GPU for `xgboost`, fold-local preprocessing still happens per fold so CV remains leakage-safe
-- when runtime execution resolves to `gpu_native` for the supported `frequency` slice, the repo uses an explicit `cudf` preprocessing path instead of CPU-side transformed folds plus conversion
-- after preprocessing, dense fold outputs are promoted to GPU-native inputs before `fit` and `predict`
-  - pandas DataFrame outputs, such as the `frequency` categorical path, are promoted to `cudf.DataFrame`
-  - dense ndarray outputs, such as the `ordinal` categorical path, are promoted to `cupy.ndarray`
+- when runtime execution resolves to `gpu_native` for the supported XGBoost tuple, the repo uses the explicit native preprocessing path instead of CPU-side transformed folds plus conversion
+- the current native XGBoost support matrix remains intentionally narrow:
+  - `categorical_preprocessor: frequency`
+  - `numeric_preprocessor: median` or `standardize`
+- after preprocessing, supported dense fold outputs stay on GPU through `fit` and `predict`
+  - the current supported slice produces `cudf.DataFrame` fold outputs
 - prediction outputs are coerced back to NumPy before scoring and artifact assembly
 - sparse CSR preprocessing output is rejected before training for the XGBoost GPU-native path
   - this currently covers `categorical_preprocessor: onehot` and related sparse `kbins` compositions

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -26,6 +26,12 @@ from tabular_shenanigans.preprocess import (
     prepare_feature_frames,
     resolve_feature_schema,
 )
+
+
+def _module_startswith(values: object, prefix: str) -> bool:
+    return type(values).__module__.startswith(prefix)
+
+
 @dataclass(frozen=True)
 class CvSummary:
     metric_name: str
@@ -308,7 +314,7 @@ def build_prepared_training_context(
 
 
 def _coerce_processed_matrix(values: object, matrix_output_kind: str) -> object:
-    if type(values).__module__.startswith("cudf.") or type(values).__module__.startswith("cupy."):
+    if _module_startswith(values, "cudf") or _module_startswith(values, "cupy"):
         return values
     if matrix_output_kind == "native_frame":
         if not isinstance(values, pd.DataFrame):
@@ -341,7 +347,7 @@ def _coerce_xgboost_gpu_input(values: object, matrix_output_kind: str) -> object
             "XGBoost GPU execution currently does not support sparse CSR preprocessing output in this runtime."
         )
 
-    if type(values).__module__.startswith("cudf.") or type(values).__module__.startswith("cupy."):
+    if _module_startswith(values, "cudf") or _module_startswith(values, "cupy"):
         return values
 
     if isinstance(values, pd.DataFrame):
@@ -357,7 +363,7 @@ def _coerce_prediction_values(values: object) -> np.ndarray:
     if isinstance(values, np.ndarray):
         return values
 
-    if type(values).__module__.startswith("cupy."):
+    if _module_startswith(values, "cupy"):
         import cupy as cp
 
         return cp.asnumpy(values)
@@ -383,7 +389,7 @@ def _select_binary_positive_class_scores(
             return probability_values
         return probability_values[:, positive_class_index]
 
-    if type(probability_values).__module__.startswith("cupy."):
+    if _module_startswith(probability_values, "cupy"):
         return probability_values[:, positive_class_index]
 
     if hasattr(probability_values, "ndim") and getattr(probability_values, "ndim") == 1:
@@ -397,9 +403,9 @@ def _describe_matrix_residency(values: object) -> dict[str, object]:
     module_name = value_type.__module__
     type_name = value_type.__name__
 
-    if module_name.startswith("cudf."):
+    if module_name.startswith("cudf"):
         residency = "gpu_cudf"
-    elif module_name.startswith("cupy."):
+    elif module_name.startswith("cupy"):
         residency = "gpu_cupy"
     elif sparse.issparse(values):
         residency = "cpu_scipy_sparse"


### PR DESCRIPTION
Closes #170

## Summary
- tighten the documented native XGBoost contract to match the current supported matrix
- fix GPU object detection in the runtime profiling helpers so `cupy` residency is reported explicitly
- close out #170 as delivered by the earlier native-path and benchmark work

## Verification
- ran a local smoke check for the updated residency helper
- confirmed fake `cupy`-module objects now report `gpu_cupy` instead of `unknown`
- audited the current native XGBoost path against the issue text and benchmark findings from #183

## Notes
- the substantive implementation work for the native XGBoost path was already in place before this PR
- this PR is the cleanup/closeout step that aligns telemetry and docs with the audited reality