### PR TITLE
Add registry-driven GPU routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,15 @@ Required top-level sections:
 
 `experiment.runtime` keys:
 - `compute_target`: `auto`, `cpu`, or `gpu`
-  - `auto`: prefer GPU only when the runtime exposes visible NVIDIA devices and RAPIDS hooks are available, otherwise fall back to CPU
+  - `auto`: choose the best registered implementation for the current tuple on the current machine: `gpu_native` first, then `gpu_patch`, otherwise CPU fallback
   - `cpu`: force CPU execution
-  - `gpu`: require GPU execution and fail fast when no GPU runtime or RAPIDS hook path is available
+  - `gpu`: require GPU execution and fail fast when no supported GPU implementation exists for the current tuple on the current machine
 - optional `gpu_backend`: `auto`, `patch`, or `native`
   - advanced/transitional override; leave this at `auto` for normal use
-  - `auto`: when GPU execution is selected, route onto the current patch-based GPU path
-  - `patch`: require the current RAPIDS hook-based GPU path
-  - `native`: require the explicit GPU-native path
+  - `auto`: let the registry choose between `gpu_native` and `gpu_patch`
+  - `patch`: require the registered RAPIDS hook-based GPU path for the current tuple
+  - `native`: require the registered explicit GPU-native path for the current tuple
+  - tuple routing is registry-driven rather than spread across model-specific branches
   - the current `gpu_native` support matrix is intentionally narrow:
     - `model_family: logistic_regression`
     - `categorical_preprocessor: frequency`
@@ -147,7 +148,8 @@ Required top-level sections:
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
-  - unsupported `gpu_native` tuples fail fast with repo-owned errors
+  - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
+  - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -4,7 +4,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 
 ## System Flow
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware intent separately from backend choice for the current machine, install RAPIDS hooks only when the resolved backend is `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, install RAPIDS hooks only when the registry resolves the current tuple to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -146,6 +146,7 @@ Stage notes:
 - [main.py](/Users/hs/dev/TabularShenanigans/main.py): thin repository-root wrapper that inserts `src/` on `sys.path` and forwards into the bootstrap entrypoint.
 - [bootstrap.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap.py): pre-runtime bootstrap hook point that resolves execution mode and installs RAPIDS hooks before runtime modules import `pandas` or `sklearn`.
 - [bootstrap_config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/bootstrap_config.py): lightweight YAML reader for the bootstrap-only runtime settings loaded before the full config model.
+- [execution_routing.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/execution_routing.py): repo-owned tuple support registry and routing resolver for `cpu`, `gpu_patch`, and `gpu_native`.
 - [cli.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/cli.py): CLI parser and linear stage dispatch after bootstrap completes.
 - [runtime_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/runtime_execution.py): runtime capability detection, RAPIDS hook activation, requested-versus-resolved execution context, and bootstrap/runtime metadata helpers.
 - [competition.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/competition.py): in-memory competition preparation, fold assignment materialization, and prepared-context construction.
@@ -198,14 +199,15 @@ Required top-level keys:
 
 `experiment.runtime`:
 - `compute_target`: `auto`, `cpu`, or `gpu`
-  - `auto`: use GPU only when the machine exposes NVIDIA devices and RAPIDS hooks are available
+  - `auto`: choose the best registered implementation for the current tuple on the current machine: `gpu_native`, then `gpu_patch`, otherwise CPU fallback
   - `cpu`: stay on CPU
-  - `gpu`: require the GPU + RAPIDS path and fail fast otherwise
+  - `gpu`: require a registered GPU implementation for the current tuple and fail fast otherwise
 - optional `gpu_backend`: `auto`, `patch`, or `native`
   - advanced/transitional override; leave this at `auto` for normal use
-  - `auto`: when GPU execution is selected, route onto the current `gpu_patch` path
-  - `patch`: require the current RAPIDS hook-based `gpu_patch` path
-  - `native`: require the explicit `gpu_native` path
+  - `auto`: let the registry choose between `gpu_native` and `gpu_patch`
+  - `patch`: require the registered RAPIDS hook-based `gpu_patch` path for the current tuple
+  - `native`: require the registered explicit `gpu_native` path for the current tuple
+  - tuple routing is registry-driven and is resolved during bootstrap for model candidates before `pandas` / `sklearn` imports happen
   - current supported `gpu_native` tuple:
     - `model_family: logistic_regression`
     - `categorical_preprocessor: frequency`
@@ -213,7 +215,8 @@ Required top-level keys:
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
-  - unsupported `gpu_native` tuples fail fast with repo-owned errors
+  - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
+  - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
 
 GPU dependency contract:
 - base project dependencies pin `numpy` and `pandas` into the RAPIDS-compatible range used by both CPU and GPU installs

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -12,17 +12,36 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
         return
 
     from tabular_shenanigans.bootstrap_config import load_bootstrap_runtime_config
+    from tabular_shenanigans.execution_routing import resolve_model_candidate_runtime_execution
     from tabular_shenanigans.runtime_execution import (
         activate_runtime_acceleration,
+        detect_runtime_capabilities,
         export_runtime_execution_context,
         resolve_runtime_execution,
     )
 
     runtime_config = load_bootstrap_runtime_config()
-    runtime_context = resolve_runtime_execution(
-        runtime_config.compute_target,
-        runtime_config.gpu_backend,
-    )
+    if (
+        runtime_config.candidate_type == "model"
+        and runtime_config.task_type is not None
+        and runtime_config.model_family is not None
+        and runtime_config.numeric_preprocessor is not None
+        and runtime_config.categorical_preprocessor is not None
+    ):
+        runtime_context = resolve_model_candidate_runtime_execution(
+            requested_compute_target=runtime_config.compute_target,
+            requested_gpu_backend=runtime_config.gpu_backend,
+            capabilities=detect_runtime_capabilities(),
+            task_type=runtime_config.task_type,
+            model_family=runtime_config.model_family,
+            numeric_preprocessor=runtime_config.numeric_preprocessor,
+            categorical_preprocessor=runtime_config.categorical_preprocessor,
+        )
+    else:
+        runtime_context = resolve_runtime_execution(
+            runtime_config.compute_target,
+            runtime_config.gpu_backend,
+        )
     runtime_context = activate_runtime_acceleration(runtime_context)
     export_runtime_execution_context(runtime_context)
 

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -8,6 +8,11 @@ import yaml
 class BootstrapRuntimeConfig:
     compute_target: str = "auto"
     gpu_backend: str = "auto"
+    task_type: str | None = None
+    candidate_type: str | None = None
+    model_family: str | None = None
+    numeric_preprocessor: str | None = None
+    categorical_preprocessor: str | None = None
 
 
 def _validate_compute_target(value: object) -> str:
@@ -66,12 +71,21 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
         raise ValueError("experiment must be a mapping when provided.")
 
     runtime = experiment.get("runtime")
-    if runtime is None:
-        return BootstrapRuntimeConfig()
-    if not isinstance(runtime, dict):
+    if runtime is not None and not isinstance(runtime, dict):
         raise ValueError("experiment.runtime must be a mapping when provided.")
+    candidate = experiment.get("candidate")
+    if candidate is not None and not isinstance(candidate, dict):
+        raise ValueError("experiment.candidate must be a mapping when provided.")
+    competition = raw_data.get("competition")
+    if competition is not None and not isinstance(competition, dict):
+        raise ValueError("competition must be a mapping when provided.")
 
     return BootstrapRuntimeConfig(
-        compute_target=_validate_compute_target(runtime.get("compute_target")),
-        gpu_backend=_validate_gpu_backend(runtime.get("gpu_backend")),
+        compute_target=_validate_compute_target(None if runtime is None else runtime.get("compute_target")),
+        gpu_backend=_validate_gpu_backend(None if runtime is None else runtime.get("gpu_backend")),
+        task_type=None if competition is None else competition.get("task_type"),
+        candidate_type=None if candidate is None else candidate.get("candidate_type"),
+        model_family=None if candidate is None else candidate.get("model_family"),
+        numeric_preprocessor=None if candidate is None else candidate.get("numeric_preprocessor"),
+        categorical_preprocessor=None if candidate is None else candidate.get("categorical_preprocessor"),
     )

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -308,11 +308,32 @@ class AppConfig(BaseModel):
 
     @property
     def runtime_execution_context(self):
-        from tabular_shenanigans.runtime_execution import get_runtime_execution_context
+        from tabular_shenanigans.execution_routing import resolve_model_candidate_runtime_execution
+        from tabular_shenanigans.runtime_execution import (
+            get_exported_runtime_execution_context,
+            get_runtime_execution_context,
+        )
 
-        return get_runtime_execution_context(
+        exported_runtime_execution_context = get_exported_runtime_execution_context()
+        if exported_runtime_execution_context is not None:
+            return exported_runtime_execution_context
+
+        runtime_execution_context = get_runtime_execution_context(
             self.experiment.runtime.compute_target,
             self.experiment.runtime.gpu_backend,
+        )
+        if not self.is_model_candidate:
+            return runtime_execution_context
+
+        candidate = self.experiment.candidate
+        return resolve_model_candidate_runtime_execution(
+            requested_compute_target=self.experiment.runtime.compute_target,
+            requested_gpu_backend=self.experiment.runtime.gpu_backend,
+            capabilities=runtime_execution_context.capabilities,
+            task_type=self.competition.task_type,
+            model_family=candidate.model_family,
+            numeric_preprocessor=candidate.numeric_preprocessor,
+            categorical_preprocessor=candidate.categorical_preprocessor,
         )
 
     @property

--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -1,0 +1,210 @@
+from dataclasses import dataclass
+
+from tabular_shenanigans.runtime_execution import (
+    CPU_GPU_BACKEND,
+    NATIVE_GPU_BACKEND,
+    PATCH_GPU_BACKEND,
+    RuntimeCapabilitySnapshot,
+    RuntimeExecutionContext,
+)
+
+
+GPU_EXECUTION_PATHS = (NATIVE_GPU_BACKEND, PATCH_GPU_BACKEND)
+
+
+@dataclass(frozen=True)
+class ModelExecutionRoutingKey:
+    task_type: str
+    model_family: str
+    numeric_preprocessor: str
+    categorical_preprocessor: str
+
+    def to_tuple(self) -> tuple[str, str, str, str]:
+        return (
+            self.task_type,
+            self.model_family,
+            self.numeric_preprocessor,
+            self.categorical_preprocessor,
+        )
+
+
+def _register_model_paths(
+    registry: dict[tuple[str, str, str, str], tuple[str, ...]],
+    *,
+    task_types: tuple[str, ...],
+    model_family: str,
+    numeric_preprocessors: tuple[str, ...],
+    categorical_preprocessors: tuple[str, ...],
+    gpu_paths: tuple[str, ...],
+) -> None:
+    for task_type in task_types:
+        for numeric_preprocessor in numeric_preprocessors:
+            for categorical_preprocessor in categorical_preprocessors:
+                key = ModelExecutionRoutingKey(
+                    task_type=task_type,
+                    model_family=model_family,
+                    numeric_preprocessor=numeric_preprocessor,
+                    categorical_preprocessor=categorical_preprocessor,
+                )
+                registry[key.to_tuple()] = gpu_paths
+
+
+def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, ...]]:
+    registry: dict[tuple[str, str, str, str], tuple[str, ...]] = {}
+    _register_model_paths(
+        registry,
+        task_types=("binary",),
+        model_family="logistic_regression",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("frequency",),
+        gpu_paths=(PATCH_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary",),
+        model_family="logistic_regression",
+        numeric_preprocessors=("standardize",),
+        categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND, PATCH_GPU_BACKEND),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
+        model_family="xgboost",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("ordinal", "frequency"),
+        gpu_paths=(PATCH_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
+        model_family="xgboost",
+        numeric_preprocessors=("median", "standardize"),
+        categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND, PATCH_GPU_BACKEND),
+    )
+    return registry
+
+
+GPU_SUPPORT_REGISTRY = _build_gpu_support_registry()
+
+
+def format_model_execution_routing_key(key: ModelExecutionRoutingKey) -> str:
+    return (
+        f"(task_type={key.task_type}, model_family={key.model_family}, "
+        f"numeric_preprocessor={key.numeric_preprocessor}, "
+        f"categorical_preprocessor={key.categorical_preprocessor})"
+    )
+
+
+def get_registered_gpu_execution_paths(key: ModelExecutionRoutingKey) -> tuple[str, ...]:
+    return GPU_SUPPORT_REGISTRY.get(key.to_tuple(), ())
+
+
+def resolve_model_candidate_runtime_execution(
+    *,
+    requested_compute_target: str,
+    requested_gpu_backend: str,
+    capabilities: RuntimeCapabilitySnapshot,
+    task_type: str,
+    model_family: str,
+    numeric_preprocessor: str,
+    categorical_preprocessor: str,
+) -> RuntimeExecutionContext:
+    routing_key = ModelExecutionRoutingKey(
+        task_type=task_type,
+        model_family=model_family,
+        numeric_preprocessor=numeric_preprocessor,
+        categorical_preprocessor=categorical_preprocessor,
+    )
+    supported_gpu_paths = get_registered_gpu_execution_paths(routing_key)
+
+    if requested_compute_target == "cpu":
+        return RuntimeExecutionContext(
+            requested_compute_target=requested_compute_target,
+            resolved_compute_target="cpu",
+            requested_gpu_backend=requested_gpu_backend,
+            resolved_gpu_backend=CPU_GPU_BACKEND,
+            capabilities=capabilities,
+            fallback_reason=None,
+            rapids_hooks_installed=False,
+        )
+
+    if not capabilities.gpu_available:
+        if requested_compute_target == "gpu" or requested_gpu_backend != "auto":
+            raise RuntimeError(
+                "Configured GPU execution is unavailable for "
+                f"{format_model_execution_routing_key(routing_key)}. "
+                f"Reason: {capabilities.unavailable_reason}"
+            )
+        return RuntimeExecutionContext(
+            requested_compute_target=requested_compute_target,
+            resolved_compute_target="cpu",
+            requested_gpu_backend=requested_gpu_backend,
+            resolved_gpu_backend=CPU_GPU_BACKEND,
+            capabilities=capabilities,
+            fallback_reason=capabilities.unavailable_reason,
+            rapids_hooks_installed=False,
+        )
+
+    if requested_gpu_backend == "native":
+        if NATIVE_GPU_BACKEND not in supported_gpu_paths:
+            raise RuntimeError(
+                "Configured gpu_backend='native' is unsupported for "
+                f"{format_model_execution_routing_key(routing_key)}."
+            )
+        return RuntimeExecutionContext(
+            requested_compute_target=requested_compute_target,
+            resolved_compute_target="gpu",
+            requested_gpu_backend=requested_gpu_backend,
+            resolved_gpu_backend=NATIVE_GPU_BACKEND,
+            capabilities=capabilities,
+            fallback_reason=None,
+            rapids_hooks_installed=False,
+        )
+
+    if requested_gpu_backend == "patch":
+        if PATCH_GPU_BACKEND not in supported_gpu_paths:
+            raise RuntimeError(
+                "Configured gpu_backend='patch' is unsupported for "
+                f"{format_model_execution_routing_key(routing_key)}."
+            )
+        return RuntimeExecutionContext(
+            requested_compute_target=requested_compute_target,
+            resolved_compute_target="gpu",
+            requested_gpu_backend=requested_gpu_backend,
+            resolved_gpu_backend=PATCH_GPU_BACKEND,
+            capabilities=capabilities,
+            fallback_reason=None,
+            rapids_hooks_installed=False,
+        )
+
+    if supported_gpu_paths:
+        return RuntimeExecutionContext(
+            requested_compute_target=requested_compute_target,
+            resolved_compute_target="gpu",
+            requested_gpu_backend=requested_gpu_backend,
+            resolved_gpu_backend=supported_gpu_paths[0],
+            capabilities=capabilities,
+            fallback_reason=None,
+            rapids_hooks_installed=False,
+        )
+
+    if requested_compute_target == "gpu":
+        raise RuntimeError(
+            "Configured experiment.runtime.compute_target='gpu' but no supported GPU implementation is "
+            f"registered for {format_model_execution_routing_key(routing_key)}."
+        )
+
+    return RuntimeExecutionContext(
+        requested_compute_target=requested_compute_target,
+        resolved_compute_target="cpu",
+        requested_gpu_backend=requested_gpu_backend,
+        resolved_gpu_backend=CPU_GPU_BACKEND,
+        capabilities=capabilities,
+        fallback_reason=(
+            "No supported GPU implementation is registered for "
+            f"{format_model_execution_routing_key(routing_key)}"
+        ),
+        rapids_hooks_installed=False,
+    )

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -12,7 +12,6 @@ from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, sco
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.feature_recipes import apply_feature_recipe
 from tabular_shenanigans.gpu_preprocess import (
-    SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS,
     build_gpu_native_preprocessor_from_schema,
 )
 from tabular_shenanigans.models import (
@@ -125,77 +124,6 @@ def _validate_gpu_native_matrix_output(
     )
 
 
-def _validate_gpu_logistic_matrix_output(
-    uses_gpu_logistic_regression: bool,
-    categorical_preprocessor_id: str,
-    matrix_output_kind: str,
-) -> None:
-    if not uses_gpu_logistic_regression:
-        return
-    if categorical_preprocessor_id == "frequency":
-        return
-    if matrix_output_kind == "sparse_csr":
-        raise ValueError(
-            "Logistic regression GPU execution currently supports categorical_preprocessor='frequency' only in "
-            "this runtime. The sparse CSR path produced by categorical_preprocessor='onehot' and related kbins "
-            "compositions is not supported under the RAPIDS-hooked sklearn preprocessing stack yet. "
-            "Use categorical_preprocessor='frequency' or force CPU execution."
-        )
-    raise ValueError(
-        "Logistic regression GPU execution currently supports categorical_preprocessor='frequency' only in "
-        "this runtime. The RAPIDS-hooked sklearn preprocessing stack is not stable yet for "
-        f"categorical_preprocessor='{categorical_preprocessor_id}'. "
-        "Use categorical_preprocessor='frequency' or force CPU execution."
-    )
-
-
-def _validate_gpu_native_preprocessing_support(
-    resolved_gpu_backend: str,
-    model_registry_key: str,
-    numeric_preprocessor_id: str,
-    categorical_preprocessor_id: str,
-) -> None:
-    if resolved_gpu_backend != "gpu_native":
-        return
-    if model_registry_key not in {"logistic_regression", "xgboost"}:
-        raise ValueError(
-            "gpu_native currently supports model_family in ['logistic_regression', 'xgboost'] only "
-            "in this runtime. Use gpu_backend='auto' or 'patch' for other model families until the "
-            "follow-on native model issues land."
-        )
-    if categorical_preprocessor_id != "frequency":
-        raise ValueError(
-            "gpu_native currently supports categorical_preprocessor='frequency' only in this runtime. "
-            f"Got '{categorical_preprocessor_id}'."
-        )
-    if numeric_preprocessor_id not in SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS:
-        raise ValueError(
-            "gpu_native currently supports numeric_preprocessor in "
-            f"{sorted(SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS)} only. "
-            f"Got '{numeric_preprocessor_id}'."
-        )
-
-
-def _validate_gpu_native_logistic_support(
-    resolved_gpu_backend: str,
-    model_registry_key: str,
-    numeric_preprocessor_id: str,
-    categorical_preprocessor_id: str,
-) -> None:
-    if resolved_gpu_backend != "gpu_native" or model_registry_key != "logistic_regression":
-        return
-    if categorical_preprocessor_id != "frequency":
-        raise ValueError(
-            "gpu_native logistic regression currently supports categorical_preprocessor='frequency' only "
-            f"in this runtime. Got '{categorical_preprocessor_id}'."
-        )
-    if numeric_preprocessor_id != "standardize":
-        raise ValueError(
-            "gpu_native logistic regression currently supports numeric_preprocessor='standardize' only "
-            f"in this runtime. Got '{numeric_preprocessor_id}'."
-        )
-
-
 def build_prepared_training_context(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
@@ -264,30 +192,8 @@ def build_prepared_training_context(
         config.resolved_model_registry_key == "xgboost"
         and config.runtime_execution_context.resolved_compute_target == "gpu"
     )
-    uses_gpu_logistic_regression = (
-        config.resolved_model_registry_key == "logistic_regression"
-        and config.runtime_execution_context.resolved_compute_target == "gpu"
-        and resolved_gpu_backend == "gpu_patch"
-    )
-    _validate_gpu_native_preprocessing_support(
-        resolved_gpu_backend=resolved_gpu_backend,
-        model_registry_key=config.resolved_model_registry_key,
-        numeric_preprocessor_id=candidate.numeric_preprocessor,
-        categorical_preprocessor_id=candidate.categorical_preprocessor,
-    )
-    _validate_gpu_native_logistic_support(
-        resolved_gpu_backend=resolved_gpu_backend,
-        model_registry_key=config.resolved_model_registry_key,
-        numeric_preprocessor_id=candidate.numeric_preprocessor,
-        categorical_preprocessor_id=candidate.categorical_preprocessor,
-    )
     _validate_gpu_native_matrix_output(
         uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
-        matrix_output_kind=matrix_output_kind,
-    )
-    _validate_gpu_logistic_matrix_output(
-        uses_gpu_logistic_regression=uses_gpu_logistic_regression,
-        categorical_preprocessor_id=candidate.categorical_preprocessor,
         matrix_output_kind=matrix_output_kind,
     )
     return PreparedTrainingContext(

--- a/src/tabular_shenanigans/runtime_execution.py
+++ b/src/tabular_shenanigans/runtime_execution.py
@@ -252,7 +252,7 @@ def activate_runtime_acceleration(context: RuntimeExecutionContext) -> RuntimeEx
     try:
         rapids_installers = _load_rapids_hook_installers()
     except RuntimeError as exc:
-        if context.requested_compute_target == "gpu":
+        if context.requested_compute_target == "gpu" or context.requested_gpu_backend == "patch":
             raise RuntimeError(
                 "Configured GPU patch execution is unavailable. "
                 f"Reason: {exc}. Detection summary: {describe_runtime_capabilities(context.capabilities)}"
@@ -340,11 +340,15 @@ def _parse_exported_runtime_execution_context() -> RuntimeExecutionContext | Non
     )
 
 
+def get_exported_runtime_execution_context() -> RuntimeExecutionContext | None:
+    return _parse_exported_runtime_execution_context()
+
+
 def get_runtime_execution_context(
     requested_compute_target: str = "auto",
     requested_gpu_backend: str = "auto",
 ) -> RuntimeExecutionContext:
-    exported_context = _parse_exported_runtime_execution_context()
+    exported_context = get_exported_runtime_execution_context()
     if exported_context is not None:
         return exported_context
     return resolve_runtime_execution(requested_compute_target, requested_gpu_backend)


### PR DESCRIPTION
Closes #175

## Summary
- add a repo-owned tuple support registry and routing resolver for `cpu`, `gpu_patch`, and `gpu_native`
- resolve model-candidate runtime routing during bootstrap so `auto` can choose native, patch, or CPU fallback before `pandas` / `sklearn` imports
- make `compute_target: auto` intentionally fall back to CPU for unsupported tuples on GPU hosts
- remove the old hard-coded native/patch tuple checks from the training layer and document the registry-driven contract

## Verification
- ran focused routing smoke checks with fake runtime capabilities
- verified `auto` resolves a native tuple to `gpu_native`, a patch-only tuple to `gpu_patch`, and an unsupported tuple to CPU with a direct fallback reason
- verified an exported bootstrap-style fallback context is preserved by `AppConfig.runtime_execution_context`
- ran import-level smoke checks for the changed routing and training modules

## Notes
- explicit unsupported `gpu_backend: patch` / `gpu_backend: native` requests now fail fast
- under `compute_target: auto`, unsupported tuples on a GPU host now intentionally fall back to CPU instead of assuming the patch path