### PR TITLE
Clarify CPU fallback contract for CPU-only models

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Required top-level sections:
     - `numeric_preprocessor: median` or `standardize`
   - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
   - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
+  - `extra_trees` and `hist_gradient_boosting` are currently intentional CPU-fallback families under `compute_target: auto` even on GPU hosts; this repo does not ship custom GPU implementations for them
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -217,6 +217,8 @@ Required top-level keys:
     - `numeric_preprocessor: median` or `standardize`
   - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
   - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
+  - `extra_trees` and `hist_gradient_boosting` are currently intentional CPU-fallback families on GPU hosts because no maintained official GPU implementation is registered for them in this runtime
+  - `#181` does not authorize custom GPU implementations for those algorithms; a future GPU path would need to come from a maintained upstream library and then be added to the registry
 
 GPU dependency contract:
 - base project dependencies pin `numpy` and `pandas` into the RAPIDS-compatible range used by both CPU and GPU installs

--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -10,6 +10,7 @@ from tabular_shenanigans.runtime_execution import (
 
 
 GPU_EXECUTION_PATHS = (NATIVE_GPU_BACKEND, PATCH_GPU_BACKEND)
+CPU_ONLY_MODEL_FAMILIES = ("extra_trees", "hist_gradient_boosting")
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,10 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
 GPU_SUPPORT_REGISTRY = _build_gpu_support_registry()
 
 
+def is_cpu_only_model_family(model_family: str) -> bool:
+    return model_family in CPU_ONLY_MODEL_FAMILIES
+
+
 def format_model_execution_routing_key(key: ModelExecutionRoutingKey) -> str:
     return (
         f"(task_type={key.task_type}, model_family={key.model_family}, "
@@ -99,6 +104,19 @@ def format_model_execution_routing_key(key: ModelExecutionRoutingKey) -> str:
 
 def get_registered_gpu_execution_paths(key: ModelExecutionRoutingKey) -> tuple[str, ...]:
     return GPU_SUPPORT_REGISTRY.get(key.to_tuple(), ())
+
+
+def describe_missing_gpu_implementation(key: ModelExecutionRoutingKey) -> str:
+    if is_cpu_only_model_family(key.model_family):
+        return (
+            f"{key.model_family} is intentionally CPU-only in this runtime because no maintained "
+            "official GPU implementation is registered for "
+            f"{format_model_execution_routing_key(key)}"
+        )
+    return (
+        "No supported GPU implementation is registered for "
+        f"{format_model_execution_routing_key(key)}"
+    )
 
 
 def resolve_model_candidate_runtime_execution(
@@ -193,7 +211,8 @@ def resolve_model_candidate_runtime_execution(
     if requested_compute_target == "gpu":
         raise RuntimeError(
             "Configured experiment.runtime.compute_target='gpu' but no supported GPU implementation is "
-            f"registered for {format_model_execution_routing_key(routing_key)}."
+            f"registered for {format_model_execution_routing_key(routing_key)}. "
+            f"Reason: {describe_missing_gpu_implementation(routing_key)}"
         )
 
     return RuntimeExecutionContext(
@@ -202,9 +221,6 @@ def resolve_model_candidate_runtime_execution(
         requested_gpu_backend=requested_gpu_backend,
         resolved_gpu_backend=CPU_GPU_BACKEND,
         capabilities=capabilities,
-        fallback_reason=(
-            "No supported GPU implementation is registered for "
-            f"{format_model_execution_routing_key(routing_key)}"
-        ),
+        fallback_reason=describe_missing_gpu_implementation(routing_key),
         rapids_hooks_installed=False,
     )


### PR DESCRIPTION
## Summary
- make the routing fallback reason explicit for CPU-only model families on GPU hosts
- document `extra_trees` and `hist_gradient_boosting` as intentional CPU-fallback families under `compute_target: auto`
- keep explicit GPU requests failing fast for unsupported backends

Closes #181

## Verification
- simulated a GPU-capable runtime and verified for both `extra_trees` and `hist_gradient_boosting` that:
  - `compute_target: auto` resolves to CPU with an explicit intentional CPU-only fallback reason
  - `compute_target: gpu` fails fast
  - `gpu_backend: patch` fails fast
  - `gpu_backend: native` fails fast
