### PR TITLE
Register CatBoost gpu_native routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Required top-level sections:
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
+    - `model_family: catboost`
+    - `categorical_preprocessor: native`
+    - `numeric_preprocessor: median`, `standardize`, or `kbins`
   - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
   - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
   - `extra_trees` and `hist_gradient_boosting` are currently intentional CPU-fallback families under `compute_target: auto` even on GPU hosts; this repo does not ship custom GPU implementations for them
@@ -160,6 +163,7 @@ Required top-level sections:
   - the `gpu_patch` logistic regression path currently supports `categorical_preprocessor: frequency` only
   - the `gpu_patch` logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution
   - the `gpu_native` logistic regression path currently supports `categorical_preprocessor: frequency` with `numeric_preprocessor: standardize` only
+  - the `gpu_native` CatBoost path currently supports `categorical_preprocessor: native` only and uses CatBoost's own GPU mode rather than the RAPIDS patch layer
 
 `experiment.candidate` keys:
 - shared:

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -215,6 +215,9 @@ Required top-level keys:
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
+    - `model_family: catboost`
+    - `categorical_preprocessor: native`
+    - `numeric_preprocessor: median`, `standardize`, or `kbins`
   - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
   - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
   - `extra_trees` and `hist_gradient_boosting` are currently intentional CPU-fallback families on GPU hosts because no maintained official GPU implementation is registered for them in this runtime
@@ -266,6 +269,7 @@ Booster GPU routing contract:
 - when runtime execution resolves to GPU, `xgboost` adds `device="cuda"`
 - when runtime execution resolves to GPU, `lightgbm` adds `device_type="cuda"`
 - when runtime execution resolves to GPU, `catboost` adds `task_type="GPU"`
+- when runtime execution resolves to `gpu_native` for `catboost`, the repo keeps CatBoost on the existing native categorical frame path and does not route it through the RAPIDS patch layer or the repo-owned `cudf` frequency preprocessor
 - when runtime execution resolves to GPU, `logistic_regression` continues to use the sklearn estimator surface but runs through the RAPIDS `cuml.accel` hook path
 - user `model_params` still override repo defaults
 

--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -84,6 +84,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
         categorical_preprocessors=("frequency",),
         gpu_paths=(NATIVE_GPU_BACKEND, PATCH_GPU_BACKEND),
     )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
+        model_family="catboost",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("native",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
     return registry
 
 

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -105,7 +105,7 @@ class PreparedTrainingContext:
     preprocessing_scheme_id: str
     matrix_output_kind: str
     uses_xgboost_gpu_native_inputs: bool
-    uses_gpu_native_preprocessing: bool
+    uses_repo_gpu_native_preprocessing: bool
 
 
 def _validate_gpu_native_matrix_output(
@@ -122,6 +122,13 @@ def _validate_gpu_native_matrix_output(
         "cannot be promoted to a supported GPU-native XGBoost input because cupyx CSR is not supported yet. "
         "Use categorical_preprocessor='ordinal' or 'frequency', or force CPU execution."
     )
+
+
+def _uses_repo_gpu_native_preprocessing(
+    resolved_gpu_backend: str,
+    categorical_preprocessor: str,
+) -> bool:
+    return resolved_gpu_backend == "gpu_native" and categorical_preprocessor == "frequency"
 
 
 def build_prepared_training_context(
@@ -187,7 +194,10 @@ def build_prepared_training_context(
         categorical_preprocessor_id=candidate.categorical_preprocessor,
     )
     resolved_gpu_backend = config.runtime_execution_context.resolved_gpu_backend
-    uses_gpu_native_preprocessing = resolved_gpu_backend == "gpu_native"
+    uses_repo_gpu_native_preprocessing = _uses_repo_gpu_native_preprocessing(
+        resolved_gpu_backend=resolved_gpu_backend,
+        categorical_preprocessor=candidate.categorical_preprocessor,
+    )
     uses_xgboost_gpu_native_inputs = (
         config.resolved_model_registry_key == "xgboost"
         and config.runtime_execution_context.resolved_compute_target == "gpu"
@@ -215,7 +225,7 @@ def build_prepared_training_context(
         preprocessing_scheme_id=candidate.preprocessing_scheme_id,
         matrix_output_kind=matrix_output_kind,
         uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
-        uses_gpu_native_preprocessing=uses_gpu_native_preprocessing,
+        uses_repo_gpu_native_preprocessing=uses_repo_gpu_native_preprocessing,
     )
 
 
@@ -353,7 +363,7 @@ def _run_cv_evaluation(
     preprocessing_scheme_id = training_context.preprocessing_scheme_id
     matrix_output_kind = training_context.matrix_output_kind
     uses_xgboost_gpu_native_inputs = training_context.uses_xgboost_gpu_native_inputs
-    uses_gpu_native_preprocessing = training_context.uses_gpu_native_preprocessing
+    uses_repo_gpu_native_preprocessing = training_context.uses_repo_gpu_native_preprocessing
 
     oof_predictions = (
         np.zeros(training_context.x_train_features.shape[0], dtype=float)
@@ -377,7 +387,7 @@ def _run_cv_evaluation(
         y_fold_valid = training_context.y_train.iloc[valid_idx]
 
         preprocess_started = time.perf_counter()
-        if uses_gpu_native_preprocessing:
+        if uses_repo_gpu_native_preprocessing:
             preprocessor = build_gpu_native_preprocessor_from_schema(
                 feature_schema=training_context.feature_schema,
                 numeric_preprocessor_id=training_context.numeric_preprocessor,


### PR DESCRIPTION
## Summary
- register CatBoost native-categorical tuples as first-class `gpu_native` routing entries
- keep CatBoost on the existing native-frame preprocessing path instead of forcing repo-owned GPU preprocessing for every `gpu_native` run
- document the current CatBoost `gpu_native` support matrix and its independence from the RAPIDS patch layer

Closes #179

## Verification
- simulated a GPU-capable runtime and verified CatBoost native tuples resolve to `gpu_native` for both task types
- verified explicit `gpu_backend: patch` fails for the registered CatBoost native tuple
- verified CatBoost native categorical fit kwargs still map categorical columns to `cat_features` indices correctly
