### PR TITLE
Add explicit preprocessing backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Required top-level sections:
   - `patch`: require the registered RAPIDS hook-based GPU path for the current tuple
   - `native`: require the registered explicit GPU-native path for the current tuple
   - tuple routing is registry-driven rather than spread across model-specific branches
+  - preprocessing backend selection is resolved separately from model routing and is recorded in runtime metadata
+  - current preprocessing backend ids are:
+    - `cpu_sklearn`
+    - `cpu_frequency`
+    - `cpu_native_frame`
+    - `gpu_cuml`
+    - `gpu_patch`
+    - `gpu_native_frequency`
   - the current `gpu_native` support matrix is intentionally narrow:
     - `model_family: logistic_regression`
     - `categorical_preprocessor: frequency`
@@ -156,14 +164,19 @@ Required top-level sections:
   - `extra_trees` and `hist_gradient_boosting` are currently intentional CPU-fallback families under `compute_target: auto` even on GPU hosts; this repo does not ship custom GPU implementations for them
   - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
+  - on GPU hosts, preprocessing can resolve to an explicit GPU backend even when the model backend falls back to CPU; GPU outputs are coerced back to CPU before fit in those hybrid cases
+  - `gpu_cuml` is the current maintained explicit preprocessing backend and currently supports dense `categorical_preprocessor: onehot` with numeric `median`, `standardize`, or `kbins`
+  - `gpu_patch` preprocessing currently keeps the existing sklearn/pandas constructors and runs them after RAPIDS hooks are installed when no explicit GPU preprocessing backend is selected
+  - `gpu_native_frequency` is currently the only explicit GPU preprocessing backend
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
   - when runtime resolves to `gpu_native` for the supported XGBoost slice, fold-local preprocessing remains per-CV-split, `frequency` preprocessing is performed by the repo-owned `cudf` path, and the first supported dense outputs stay GPU-resident through fit and predict
   - the current native XGBoost support matrix is intentionally narrow and aligned with the documented `gpu_native` tuples above
+  - explicit cuML preprocessing currently stays on dense output only; sparse onehot paths continue to use `gpu_patch` or CPU fallback
   - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
   - the `gpu_patch` logistic regression path currently supports `categorical_preprocessor: frequency` only
   - the `gpu_patch` logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution
   - the `gpu_native` logistic regression path currently supports `categorical_preprocessor: frequency` with `numeric_preprocessor: standardize` only
-  - the `gpu_native` CatBoost path currently supports `categorical_preprocessor: native` only and uses CatBoost's own GPU mode rather than the RAPIDS patch layer
+  - the `gpu_native` CatBoost path currently supports `categorical_preprocessor: native` only, uses CatBoost's own GPU mode rather than the RAPIDS patch layer, and keeps preprocessing on the existing `cpu_native_frame` path
 
 `experiment.candidate` keys:
 - shared:
@@ -251,6 +264,7 @@ Current candidate-run tags include:
 - `primary_metric`
 - `runtime_requested_gpu_backend`
 - `runtime_resolved_gpu_backend`
+- `runtime_preprocessing_backend`
 - `config_fingerprint`
 - git metadata when available
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -4,7 +4,7 @@ Technical reference for the current repository design. Use GitHub issues and pul
 
 ## System Flow
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, install RAPIDS hooks only when the registry resolves the current tuple to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, resolve preprocessing backend selection separately from model routing, install RAPIDS hooks only when the registry resolves the current tuple to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the candidate contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -53,6 +53,7 @@ Current candidate-run tags:
 - `runtime_requested_gpu_backend`
 - `runtime_resolved_gpu_backend`
 - `runtime_acceleration_backend`
+- `runtime_preprocessing_backend`
 - `config_fingerprint`
 - `git_commit` when available
 - `git_branch` when available
@@ -68,6 +69,7 @@ Current candidate-run params:
 - `runtime__resolved_gpu_backend`
 - `runtime__gpu_available`
 - `runtime__acceleration_backend`
+- `runtime__preprocessing_backend`
 - `runtime__rapids_hooks_installed`
 - `runtime__fallback_reason` when CPU fallback happened under `compute_target=auto`
 - model candidates:
@@ -149,6 +151,8 @@ Stage notes:
 - [execution_routing.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/execution_routing.py): repo-owned tuple support registry and routing resolver for `cpu`, `gpu_patch`, and `gpu_native`.
 - [cli.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/cli.py): CLI parser and linear stage dispatch after bootstrap completes.
 - [runtime_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/runtime_execution.py): runtime capability detection, RAPIDS hook activation, requested-versus-resolved execution context, and bootstrap/runtime metadata helpers.
+- [preprocess_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/preprocess_execution.py): preprocessing backend selection and preprocessor construction for CPU, `gpu_patch`, and the current explicit GPU-native frequency path.
+- [gpu_cuml_preprocess.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/gpu_cuml_preprocess.py): explicit dense GPU preprocessing adapters built on maintained cuML preprocessing constructors.
 - [competition.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/competition.py): in-memory competition preparation, fold assignment materialization, and prepared-context construction.
 - [config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/config.py): nested config validation, metric normalization, candidate-id derivation, and resolved model lookup.
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
@@ -208,6 +212,13 @@ Required top-level keys:
   - `patch`: require the registered RAPIDS hook-based `gpu_patch` path for the current tuple
   - `native`: require the registered explicit `gpu_native` path for the current tuple
   - tuple routing is registry-driven and is resolved during bootstrap for model candidates before `pandas` / `sklearn` imports happen
+  - preprocessing backend selection is resolved separately from model routing and currently emits one of:
+    - `cpu_sklearn`
+    - `cpu_frequency`
+    - `cpu_native_frame`
+    - `gpu_cuml`
+    - `gpu_patch`
+    - `gpu_native_frequency`
   - current supported `gpu_native` tuple:
     - `model_family: logistic_regression`
     - `categorical_preprocessor: frequency`
@@ -269,7 +280,14 @@ Booster GPU routing contract:
 - when runtime execution resolves to GPU, `xgboost` adds `device="cuda"`
 - when runtime execution resolves to GPU, `lightgbm` adds `device_type="cuda"`
 - when runtime execution resolves to GPU, `catboost` adds `task_type="GPU"`
+- on GPU hosts, preprocessing can resolve to an explicit GPU backend even when the model backend still resolves to CPU; in those hybrid cases the runtime converts the preprocessed outputs back to CPU arrays before fit/predict
+- `gpu_cuml` is the current maintained explicit preprocessing backend and currently supports dense `categorical_preprocessor: onehot` with numeric `median`, `standardize`, or `kbins`
+- when runtime execution resolves to `gpu_patch`, preprocessing currently stays on the existing sklearn/pandas constructors and relies on the installed RAPIDS hooks rather than explicit repo-owned GPU preprocessing adapters
 - when runtime execution resolves to `gpu_native` for `catboost`, the repo keeps CatBoost on the existing native categorical frame path and does not route it through the RAPIDS patch layer or the repo-owned `cudf` frequency preprocessor
+- the current explicit GPU preprocessing surface is intentionally narrow:
+  - `gpu_cuml` for dense `onehot` plus numeric `median`, `standardize`, or `kbins`
+  - `gpu_native_frequency` for `categorical_preprocessor: frequency` with numeric `median` or `standardize`
+  - other preprocessing schemes currently stay on CPU-backed constructors unless the runtime is using `gpu_patch`
 - when runtime execution resolves to GPU, `logistic_regression` continues to use the sklearn estimator surface but runs through the RAPIDS `cuml.accel` hook path
 - user `model_params` still override repo defaults
 
@@ -307,6 +325,7 @@ Model candidate manifests currently record:
 - runtime profiling: training-context build time, fold-stage CV timings, artifact staging time, and first-fold matrix residency snapshots when collected
 - model info: `model_family`, `model_registry_key`, `estimator_name`
 - feature/preprocessing info: `feature_recipe_id`, `feature_columns`, `numeric_preprocessor`, `categorical_preprocessor`, `preprocessing_scheme_id`
+- runtime-selected preprocessing backend: `preprocessing_backend`
 - CV summary: `cv_summary`
 - schema/label metadata: `id_column`, `label_column`, `positive_label`, `negative_label`, `observed_label_pair`
 - dataset metadata: `target_summary`, `train_rows`, `train_cols`, `test_rows`, `test_cols`

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -24,6 +24,7 @@ from tabular_shenanigans.preprocess import (
     NUMERIC_PREPROCESSOR_IDS,
     build_preprocessing_scheme_id,
 )
+from tabular_shenanigans.preprocess_execution import resolve_preprocessing_execution_plan
 
 
 class ConfigError(ValueError):
@@ -337,6 +338,26 @@ class AppConfig(BaseModel):
         )
 
     @property
+    def preprocessing_execution_plan(self):
+        from tabular_shenanigans.models import resolve_model_matrix_output_kind
+
+        if not self.is_model_candidate:
+            raise ValueError("preprocessing_execution_plan is only available for model candidates.")
+
+        candidate = self.experiment.candidate
+        matrix_output_kind = resolve_model_matrix_output_kind(
+            task_type=self.competition.task_type,
+            model_id=self.resolved_model_registry_key,
+            categorical_preprocessor_id=candidate.categorical_preprocessor,
+        )
+        return resolve_preprocessing_execution_plan(
+            runtime_execution_context=self.runtime_execution_context,
+            numeric_preprocessor_id=candidate.numeric_preprocessor,
+            categorical_preprocessor_id=candidate.categorical_preprocessor,
+            matrix_output_kind=matrix_output_kind,
+        )
+
+    @property
     def resolved_candidate_id(self) -> str:
         competition = self.competition
         candidate = self.experiment.candidate
@@ -368,6 +389,7 @@ class AppConfig(BaseModel):
                     "resolved_compute_target": self.runtime_execution_context.resolved_compute_target,
                     "resolved_gpu_backend": self.runtime_execution_context.resolved_gpu_backend,
                     "acceleration_backend": self.runtime_execution_context.acceleration_backend,
+                    "preprocessing_backend": self.preprocessing_execution_plan.preprocessing_backend,
                 },
             }
             return build_model_candidate_id(

--- a/src/tabular_shenanigans/gpu_cuml_preprocess.py
+++ b/src/tabular_shenanigans/gpu_cuml_preprocess.py
@@ -1,0 +1,176 @@
+from dataclasses import dataclass
+
+import pandas as pd
+
+from tabular_shenanigans.preprocess import ResolvedFeatureSchema
+
+
+def _import_gpu_preprocessing_modules():
+    try:
+        import cupy as cp
+    except ImportError as exc:
+        raise RuntimeError(
+            "Explicit cuML preprocessing requires the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    try:
+        import cudf
+    except ImportError as exc:
+        raise RuntimeError(
+            "Explicit cuML preprocessing requires the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    try:
+        from cuml.preprocessing import KBinsDiscretizer, OneHotEncoder, SimpleImputer, StandardScaler
+    except ImportError as exc:
+        raise RuntimeError(
+            "Explicit cuML preprocessing requires the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    return cp, cudf, SimpleImputer, StandardScaler, OneHotEncoder, KBinsDiscretizer
+
+def _to_cupy_dense(values: object):
+    cp, _, _, _, _, _ = _import_gpu_preprocessing_modules()
+    if type(values).__module__.startswith("cupy"):
+        return values
+    if hasattr(values, "to_cupy"):
+        return values.to_cupy()
+    if hasattr(values, "values"):
+        return cp.asarray(values.values)
+    return cp.asarray(values)
+
+
+@dataclass(frozen=True)
+class _ResolvedNumericGpuTransformers:
+    imputer: object
+    post_imputer_transformer: object | None
+
+
+class GpuCumlDensePreprocessor:
+    def __init__(
+        self,
+        feature_schema: ResolvedFeatureSchema,
+        numeric_preprocessor_id: str,
+        categorical_preprocessor_id: str,
+    ) -> None:
+        self.feature_schema = feature_schema
+        self.numeric_preprocessor_id = numeric_preprocessor_id
+        self.categorical_preprocessor_id = categorical_preprocessor_id
+        self.numeric_transformers: _ResolvedNumericGpuTransformers | None = None
+        self.categorical_imputer: object | None = None
+        self.categorical_encoder: object | None = None
+
+    def _fit_numeric(self, frame: pd.DataFrame) -> object | None:
+        if not self.feature_schema.numeric_columns:
+            return None
+        _, cudf, SimpleImputer, StandardScaler, _, KBinsDiscretizer = _import_gpu_preprocessing_modules()
+        numeric_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.numeric_columns]).astype("float64")
+        numeric_imputer = SimpleImputer(strategy="median")
+        imputed_numeric = numeric_imputer.fit_transform(numeric_frame)
+
+        post_imputer_transformer = None
+        transformed_numeric = imputed_numeric
+        if self.numeric_preprocessor_id == "standardize":
+            post_imputer_transformer = StandardScaler()
+            transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
+        elif self.numeric_preprocessor_id == "kbins":
+            post_imputer_transformer = KBinsDiscretizer(
+                n_bins=5,
+                encode="onehot-dense",
+                strategy="quantile",
+                quantile_method="averaged_inverted_cdf",
+            )
+            transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
+
+        self.numeric_transformers = _ResolvedNumericGpuTransformers(
+            imputer=numeric_imputer,
+            post_imputer_transformer=post_imputer_transformer,
+        )
+        return _to_cupy_dense(transformed_numeric)
+
+    def _fit_categorical(self, frame: pd.DataFrame) -> object | None:
+        if not self.feature_schema.categorical_columns:
+            return None
+        _, cudf, SimpleImputer, _, OneHotEncoder, _ = _import_gpu_preprocessing_modules()
+        categorical_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.categorical_columns])
+        categorical_imputer = SimpleImputer(strategy="most_frequent")
+        imputed_categorical = categorical_imputer.fit_transform(categorical_frame)
+        categorical_encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+        transformed_categorical = categorical_encoder.fit_transform(imputed_categorical)
+        self.categorical_imputer = categorical_imputer
+        self.categorical_encoder = categorical_encoder
+        return _to_cupy_dense(transformed_categorical)
+
+    def fit(self, frame: pd.DataFrame) -> "GpuCumlDensePreprocessor":
+        self._fit_numeric(frame)
+        self._fit_categorical(frame)
+        return self
+
+    def _transform_numeric(self, frame: pd.DataFrame) -> object | None:
+        if not self.feature_schema.numeric_columns:
+            return None
+        if self.numeric_transformers is None:
+            raise ValueError("Numeric GPU preprocessing must be fit before transform.")
+        _, cudf, _, _, _, _ = _import_gpu_preprocessing_modules()
+        numeric_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.numeric_columns]).astype("float64")
+        transformed_numeric = self.numeric_transformers.imputer.transform(numeric_frame)
+        if self.numeric_transformers.post_imputer_transformer is not None:
+            transformed_numeric = self.numeric_transformers.post_imputer_transformer.transform(transformed_numeric)
+        return _to_cupy_dense(transformed_numeric)
+
+    def _transform_categorical(self, frame: pd.DataFrame) -> object | None:
+        if not self.feature_schema.categorical_columns:
+            return None
+        if self.categorical_imputer is None or self.categorical_encoder is None:
+            raise ValueError("Categorical GPU preprocessing must be fit before transform.")
+        _, cudf, _, _, _, _ = _import_gpu_preprocessing_modules()
+        categorical_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.categorical_columns])
+        transformed_categorical = self.categorical_imputer.transform(categorical_frame)
+        transformed_categorical = self.categorical_encoder.transform(transformed_categorical)
+        return _to_cupy_dense(transformed_categorical)
+
+    def transform(self, frame: pd.DataFrame):
+        cp, _, _, _, _, _ = _import_gpu_preprocessing_modules()
+        transformed_parts = [
+            values
+            for values in (
+                self._transform_numeric(frame),
+                self._transform_categorical(frame),
+            )
+            if values is not None
+        ]
+        if not transformed_parts:
+            return cp.empty((len(frame), 0), dtype=cp.float64)
+        if len(transformed_parts) == 1:
+            return transformed_parts[0]
+        return cp.concatenate(transformed_parts, axis=1)
+
+    def fit_transform(self, frame: pd.DataFrame):
+        self.fit(frame)
+        return self.transform(frame)
+
+
+def build_gpu_cuml_dense_preprocessor_from_schema(
+    feature_schema: ResolvedFeatureSchema,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+) -> GpuCumlDensePreprocessor:
+    if categorical_preprocessor_id != "onehot":
+        raise ValueError(
+            "Explicit cuML dense preprocessing currently supports categorical_preprocessor='onehot' only. "
+            f"Got '{categorical_preprocessor_id}'."
+        )
+    if numeric_preprocessor_id not in {"median", "standardize", "kbins"}:
+        raise ValueError(
+            "Explicit cuML dense preprocessing currently supports numeric_preprocessor in "
+            "['kbins', 'median', 'standardize'] only. "
+            f"Got '{numeric_preprocessor_id}'."
+        )
+    return GpuCumlDensePreprocessor(
+        feature_schema=feature_schema,
+        numeric_preprocessor_id=numeric_preprocessor_id,
+        categorical_preprocessor_id=categorical_preprocessor_id,
+    )

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -176,6 +176,8 @@ def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: s
         "runtime_acceleration_backend": runtime_execution_context.acceleration_backend,
         **_git_metadata(),
     }
+    if config.is_model_candidate:
+        tags["runtime_preprocessing_backend"] = config.preprocessing_execution_plan.preprocessing_backend
     return tags
 
 
@@ -226,6 +228,7 @@ def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dic
     if runtime_execution_context.fallback_reason is not None:
         params["runtime__fallback_reason"] = runtime_execution_context.fallback_reason
     if config.is_model_candidate:
+        params["runtime__preprocessing_backend"] = config.preprocessing_execution_plan.preprocessing_backend
         params.update(
             {
                 "feature_recipe_id": manifest.get("feature_recipe_id"),

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -11,9 +11,6 @@ from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.feature_recipes import apply_feature_recipe
-from tabular_shenanigans.gpu_preprocess import (
-    build_gpu_native_preprocessor_from_schema,
-)
 from tabular_shenanigans.models import (
     build_model,
     build_model_fit_kwargs,
@@ -21,9 +18,12 @@ from tabular_shenanigans.models import (
 )
 from tabular_shenanigans.preprocess import (
     ResolvedFeatureSchema,
-    build_preprocessor_from_schema,
     prepare_feature_frames,
     resolve_feature_schema,
+)
+from tabular_shenanigans.preprocess_execution import (
+    PreprocessingExecutionPlan,
+    build_preprocessor_for_execution_plan,
 )
 
 
@@ -105,7 +105,8 @@ class PreparedTrainingContext:
     preprocessing_scheme_id: str
     matrix_output_kind: str
     uses_xgboost_gpu_native_inputs: bool
-    uses_repo_gpu_native_preprocessing: bool
+    preprocessing_backend: str
+    model_compute_target: str
 
 
 def _validate_gpu_native_matrix_output(
@@ -122,13 +123,6 @@ def _validate_gpu_native_matrix_output(
         "cannot be promoted to a supported GPU-native XGBoost input because cupyx CSR is not supported yet. "
         "Use categorical_preprocessor='ordinal' or 'frequency', or force CPU execution."
     )
-
-
-def _uses_repo_gpu_native_preprocessing(
-    resolved_gpu_backend: str,
-    categorical_preprocessor: str,
-) -> bool:
-    return resolved_gpu_backend == "gpu_native" and categorical_preprocessor == "frequency"
 
 
 def build_prepared_training_context(
@@ -193,11 +187,7 @@ def build_prepared_training_context(
         model_id=config.resolved_model_registry_key,
         categorical_preprocessor_id=candidate.categorical_preprocessor,
     )
-    resolved_gpu_backend = config.runtime_execution_context.resolved_gpu_backend
-    uses_repo_gpu_native_preprocessing = _uses_repo_gpu_native_preprocessing(
-        resolved_gpu_backend=resolved_gpu_backend,
-        categorical_preprocessor=candidate.categorical_preprocessor,
-    )
+    preprocessing_execution_plan = config.preprocessing_execution_plan
     uses_xgboost_gpu_native_inputs = (
         config.resolved_model_registry_key == "xgboost"
         and config.runtime_execution_context.resolved_compute_target == "gpu"
@@ -223,13 +213,26 @@ def build_prepared_training_context(
         numeric_preprocessor=candidate.numeric_preprocessor,
         categorical_preprocessor=candidate.categorical_preprocessor,
         preprocessing_scheme_id=candidate.preprocessing_scheme_id,
-        matrix_output_kind=matrix_output_kind,
+        matrix_output_kind=preprocessing_execution_plan.matrix_output_kind,
         uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
-        uses_repo_gpu_native_preprocessing=uses_repo_gpu_native_preprocessing,
+        preprocessing_backend=preprocessing_execution_plan.preprocessing_backend,
+        model_compute_target=config.runtime_execution_context.resolved_compute_target,
     )
 
 
-def _coerce_processed_matrix(values: object, matrix_output_kind: str) -> object:
+def _coerce_processed_matrix(
+    values: object,
+    matrix_output_kind: str,
+    model_compute_target: str,
+) -> object:
+    if model_compute_target != "gpu":
+        if _module_startswith(values, "cupy"):
+            import cupy as cp
+
+            values = cp.asnumpy(values)
+        elif _module_startswith(values, "cudf"):
+            values = values.to_pandas()
+
     if _module_startswith(values, "cudf") or _module_startswith(values, "cupy"):
         return values
     if matrix_output_kind == "native_frame":
@@ -363,7 +366,8 @@ def _run_cv_evaluation(
     preprocessing_scheme_id = training_context.preprocessing_scheme_id
     matrix_output_kind = training_context.matrix_output_kind
     uses_xgboost_gpu_native_inputs = training_context.uses_xgboost_gpu_native_inputs
-    uses_repo_gpu_native_preprocessing = training_context.uses_repo_gpu_native_preprocessing
+    preprocessing_backend = training_context.preprocessing_backend
+    model_compute_target = training_context.model_compute_target
 
     oof_predictions = (
         np.zeros(training_context.x_train_features.shape[0], dtype=float)
@@ -387,29 +391,37 @@ def _run_cv_evaluation(
         y_fold_valid = training_context.y_train.iloc[valid_idx]
 
         preprocess_started = time.perf_counter()
-        if uses_repo_gpu_native_preprocessing:
-            preprocessor = build_gpu_native_preprocessor_from_schema(
-                feature_schema=training_context.feature_schema,
-                numeric_preprocessor_id=training_context.numeric_preprocessor,
-                categorical_preprocessor_id=training_context.categorical_preprocessor,
-            )
-        else:
-            preprocessor = build_preprocessor_from_schema(
-                feature_schema=training_context.feature_schema,
-                numeric_preprocessor_id=training_context.numeric_preprocessor,
-                categorical_preprocessor_id=training_context.categorical_preprocessor,
+        preprocessor = build_preprocessor_for_execution_plan(
+            feature_schema=training_context.feature_schema,
+            numeric_preprocessor_id=training_context.numeric_preprocessor,
+            categorical_preprocessor_id=training_context.categorical_preprocessor,
+            execution_plan=PreprocessingExecutionPlan(
+                preprocessing_backend=training_context.preprocessing_backend,
                 matrix_output_kind=matrix_output_kind,
-            )
+            ),
+        )
         x_fold_train_processed = preprocessor.fit_transform(x_fold_train)
         x_fold_valid_processed = preprocessor.transform(x_fold_valid)
         x_test_processed = None
         if collect_prediction_artifacts:
             x_test_processed = preprocessor.transform(training_context.x_test_features)
 
-        x_fold_train_processed = _coerce_processed_matrix(x_fold_train_processed, matrix_output_kind)
-        x_fold_valid_processed = _coerce_processed_matrix(x_fold_valid_processed, matrix_output_kind)
+        x_fold_train_processed = _coerce_processed_matrix(
+            x_fold_train_processed,
+            matrix_output_kind,
+            model_compute_target,
+        )
+        x_fold_valid_processed = _coerce_processed_matrix(
+            x_fold_valid_processed,
+            matrix_output_kind,
+            model_compute_target,
+        )
         if x_test_processed is not None:
-            x_test_processed = _coerce_processed_matrix(x_test_processed, matrix_output_kind)
+            x_test_processed = _coerce_processed_matrix(
+                x_test_processed,
+                matrix_output_kind,
+                model_compute_target,
+            )
 
         if uses_xgboost_gpu_native_inputs:
             # Convert fold-local preprocessing outputs to GPU-native inputs before XGBoost fit/predict.
@@ -510,6 +522,7 @@ def _run_cv_evaluation(
     )
     runtime_profile = {
         "fold_count": len(training_context.split_indices),
+        "preprocessing_backend": preprocessing_backend,
         "cv_preprocess_wall_seconds": preprocess_wall_seconds,
         "cv_fit_wall_seconds": fit_wall_seconds,
         "cv_predict_wall_seconds": predict_wall_seconds,

--- a/src/tabular_shenanigans/preprocess_execution.py
+++ b/src/tabular_shenanigans/preprocess_execution.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+
+from tabular_shenanigans.gpu_cuml_preprocess import build_gpu_cuml_dense_preprocessor_from_schema
+from tabular_shenanigans.gpu_preprocess import build_gpu_native_preprocessor_from_schema
+from tabular_shenanigans.preprocess import ResolvedFeatureSchema, build_preprocessor_from_schema
+from tabular_shenanigans.runtime_execution import PATCH_GPU_BACKEND, RuntimeExecutionContext
+
+CPU_SKLEARN_PREPROCESSING_BACKEND = "cpu_sklearn"
+CPU_FREQUENCY_PREPROCESSING_BACKEND = "cpu_frequency"
+CPU_NATIVE_FRAME_PREPROCESSING_BACKEND = "cpu_native_frame"
+GPU_CUML_PREPROCESSING_BACKEND = "gpu_cuml"
+GPU_PATCH_PREPROCESSING_BACKEND = "gpu_patch"
+GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND = "gpu_native_frequency"
+
+
+@dataclass(frozen=True)
+class PreprocessingExecutionPlan:
+    preprocessing_backend: str
+    matrix_output_kind: str
+
+    @property
+    def uses_repo_gpu_native_preprocessing(self) -> bool:
+        return self.preprocessing_backend == GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND
+
+
+def resolve_preprocessing_execution_plan(
+    *,
+    runtime_execution_context: RuntimeExecutionContext,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+    matrix_output_kind: str,
+) -> PreprocessingExecutionPlan:
+    if runtime_execution_context.requested_compute_target == "cpu":
+        if categorical_preprocessor_id == "native":
+            return PreprocessingExecutionPlan(
+                preprocessing_backend=CPU_NATIVE_FRAME_PREPROCESSING_BACKEND,
+                matrix_output_kind=matrix_output_kind,
+            )
+        if categorical_preprocessor_id == "frequency":
+            return PreprocessingExecutionPlan(
+                preprocessing_backend=CPU_FREQUENCY_PREPROCESSING_BACKEND,
+                matrix_output_kind=matrix_output_kind,
+            )
+        return PreprocessingExecutionPlan(
+            preprocessing_backend=CPU_SKLEARN_PREPROCESSING_BACKEND,
+            matrix_output_kind=matrix_output_kind,
+        )
+
+    if categorical_preprocessor_id == "native":
+        return PreprocessingExecutionPlan(
+            preprocessing_backend=CPU_NATIVE_FRAME_PREPROCESSING_BACKEND,
+            matrix_output_kind=matrix_output_kind,
+        )
+
+    gpu_available = runtime_execution_context.capabilities.gpu_available
+
+    if (
+        gpu_available
+        and matrix_output_kind == "dense_array"
+        and categorical_preprocessor_id == "onehot"
+        and numeric_preprocessor_id in {"median", "standardize", "kbins"}
+    ):
+        return PreprocessingExecutionPlan(
+            preprocessing_backend=GPU_CUML_PREPROCESSING_BACKEND,
+            matrix_output_kind="dense_array",
+        )
+
+    if (
+        gpu_available
+        and categorical_preprocessor_id == "frequency"
+        and numeric_preprocessor_id in {"median", "standardize"}
+    ):
+        return PreprocessingExecutionPlan(
+            preprocessing_backend=GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND,
+            matrix_output_kind=matrix_output_kind,
+        )
+
+    if runtime_execution_context.resolved_gpu_backend == PATCH_GPU_BACKEND:
+        return PreprocessingExecutionPlan(
+            preprocessing_backend=GPU_PATCH_PREPROCESSING_BACKEND,
+            matrix_output_kind=matrix_output_kind,
+        )
+
+    if categorical_preprocessor_id == "frequency":
+        return PreprocessingExecutionPlan(
+            preprocessing_backend=CPU_FREQUENCY_PREPROCESSING_BACKEND,
+            matrix_output_kind=matrix_output_kind,
+        )
+
+    return PreprocessingExecutionPlan(
+        preprocessing_backend=CPU_SKLEARN_PREPROCESSING_BACKEND,
+        matrix_output_kind=matrix_output_kind,
+    )
+
+
+def build_preprocessor_for_execution_plan(
+    *,
+    feature_schema: ResolvedFeatureSchema,
+    numeric_preprocessor_id: str,
+    categorical_preprocessor_id: str,
+    execution_plan: PreprocessingExecutionPlan,
+) -> object:
+    if execution_plan.preprocessing_backend == GPU_CUML_PREPROCESSING_BACKEND:
+        return build_gpu_cuml_dense_preprocessor_from_schema(
+            feature_schema=feature_schema,
+            numeric_preprocessor_id=numeric_preprocessor_id,
+            categorical_preprocessor_id=categorical_preprocessor_id,
+        )
+
+    if execution_plan.preprocessing_backend == GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND:
+        return build_gpu_native_preprocessor_from_schema(
+            feature_schema=feature_schema,
+            numeric_preprocessor_id=numeric_preprocessor_id,
+            categorical_preprocessor_id=categorical_preprocessor_id,
+        )
+
+    return build_preprocessor_from_schema(
+        feature_schema=feature_schema,
+        numeric_preprocessor_id=numeric_preprocessor_id,
+        categorical_preprocessor_id=categorical_preprocessor_id,
+        matrix_output_kind=execution_plan.matrix_output_kind,
+    )

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -128,6 +128,7 @@ def _build_candidate_manifest(
         "feature_columns": training_context.x_train_features.columns.tolist(),
         "numeric_preprocessor": candidate.numeric_preprocessor,
         "categorical_preprocessor": candidate.categorical_preprocessor,
+        "preprocessing_backend": training_context.preprocessing_backend,
         "model_registry_key": model_result.model_registry_key,
         "estimator_name": model_result.estimator_name,
         "preprocessing_scheme_id": model_result.preprocessing_scheme_id,


### PR DESCRIPTION
## Summary
- add explicit preprocessing execution planning for CPU, patch-based GPU, and supported repo-owned GPU paths
- add repo-owned cuML dense preprocessing and expanded GPU-native frequency routing under the shared runtime contract
- document the preprocessing backend matrix and runtime behavior changes

## Verification
- `uv run python -m compileall src`
- `PYTHONPATH=src .venv/bin/python -c "import tabular_shenanigans.preprocess_execution; import tabular_shenanigans.model_evaluation; import tabular_shenanigans.config; print("issue-176 import smoke ok")"`

Closes #176