### PR TITLE
Add explicit LightGBM CUDA backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ setups can install RAPIDS acceleration hooks before the training stack loads.
 Supported environment matrix:
 - CPU and local development: `uv sync` or `uv sync --extra boosters`
 - Linux GPU hosts: `uv sync --extra boosters --extra gpu`
+- LightGBM `gpu_native` on Linux GPU hosts also requires a CUDA-enabled source build; run `./scripts/install_lightgbm_cuda.sh` inside the synced repo environment on the target machine
 - RAPIDS GPU support currently targets Python 3.13 on Linux `x86_64` CUDA 12 hosts with NVIDIA-visible devices
 - The repository lockfile is now the source of truth for the RAPIDS-compatible `numpy` / `pandas` range, so `uv run python main.py ...` is safe after syncing the correct extras
 
@@ -83,6 +84,8 @@ Available stage-specific commands:
 - `uv run python main.py submit --candidate-id <candidate_id>`
 - `uv run python main.py refresh-submissions`
 - `uv run python scripts/benchmark_gpu_checkpoint.py`
+- `PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py`
+- `./scripts/install_lightgbm_cuda.sh`
 
 Stage behavior:
 - `fetch`: ensures the competition zip is present locally.
@@ -92,6 +95,8 @@ Stage behavior:
 - `submit`: downloads one candidate from MLflow, validates `test_predictions.csv` against `sample_submission.csv`, and when `experiment.submit.enabled=true` submits to Kaggle and records the submission event under that same candidate run.
 - `refresh-submissions`: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and appends new score observations back onto the matching candidate runs.
 - `benchmark_gpu_checkpoint.py`: runs the `#183` CPU vs `gpu_patch` vs `gpu_native` checkpoint matrix, writes a timestamped report plus raw logs under `reports/benchmark_checkpoints/`, temporarily rewrites repository-root `config.yaml` during the session, and restores it at the end while using an isolated file-based MLflow store inside the benchmark output directory.
+- `validate_lightgbm_cuda_build.py`: runs the repo-owned LightGBM CUDA probe and exits non-zero when the installed LightGBM build does not satisfy `device_type="cuda"` on the current host.
+- `install_lightgbm_cuda.sh`: reinstalls LightGBM from source with `USE_CUDA=ON` in the project virtualenv, then runs the validation probe.
 
 `submit` defaults to the derived `candidate_id` for the current config. Use `--candidate-id` when you want to submit another existing candidate for the same competition experiment.
 
@@ -153,6 +158,9 @@ Required top-level sections:
     - `model_family: logistic_regression`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: standardize`
+    - `model_family: lightgbm`
+    - `categorical_preprocessor: onehot`, `ordinal`, or `frequency`
+    - `numeric_preprocessor: median`, `standardize`, or `kbins`
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
@@ -162,16 +170,20 @@ Required top-level sections:
   - unsupported explicit `gpu_backend: patch` / `gpu_backend: native` requests fail fast with repo-owned errors
   - under `compute_target: auto`, tuples with no registered GPU implementation intentionally fall back to CPU
   - `extra_trees` and `hist_gradient_boosting` are currently intentional CPU-fallback families under `compute_target: auto` even on GPU hosts; this repo does not ship custom GPU implementations for them
-  - when GPU execution is active, `xgboost`, `lightgbm`, and `catboost` also switch to their GPU-specific estimator params automatically
+  - when GPU execution is active, `xgboost` and `catboost` switch to their GPU-specific estimator params automatically
+  - when runtime resolves to `gpu_native` for `lightgbm`, the repo uses an explicit LightGBM adapter, validates the installed CUDA build, and then trains with `device_type="cuda"`
   - when GPU execution is active, `logistic_regression` stays on the sklearn API surface but relies on the RAPIDS `cuml.accel` hook path
   - on GPU hosts, preprocessing can resolve to an explicit GPU backend even when the model backend falls back to CPU; GPU outputs are coerced back to CPU before fit in those hybrid cases
   - `gpu_cuml` is the current maintained explicit preprocessing backend and currently supports dense `categorical_preprocessor: onehot` with numeric `median`, `standardize`, or `kbins`
   - `gpu_patch` preprocessing currently keeps the existing sklearn/pandas constructors and runs them after RAPIDS hooks are installed when no explicit GPU preprocessing backend is selected
   - `gpu_native_frequency` is currently the only explicit GPU preprocessing backend
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
+  - the LightGBM `gpu_native` path additionally expects a CUDA-enabled LightGBM source build; the repo ships `./scripts/install_lightgbm_cuda.sh` and `PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py` for that contract
   - when runtime resolves to `gpu_native` for the supported XGBoost slice, fold-local preprocessing remains per-CV-split, `frequency` preprocessing is performed by the repo-owned `cudf` path, and the first supported dense outputs stay GPU-resident through fit and predict
   - the current native XGBoost support matrix is intentionally narrow and aligned with the documented `gpu_native` tuples above
   - explicit cuML preprocessing currently stays on dense output only; sparse onehot paths continue to use `gpu_patch` or CPU fallback
+  - the LightGBM `gpu_native` path currently preserves the existing sparse-CSR contract for `onehot`; that means CUDA training is available there, but explicit GPU preprocessing is currently limited to the `frequency + median|standardize` slice
+  - the repo-owned LightGBM adapter coerces fit and predict inputs onto the same NumPy / SciPy boundary before calling LightGBM so the current feature-name warning is not carried into the CUDA path
   - the XGBoost GPU-native input path currently rejects sparse CSR preprocessing output, including `categorical_preprocessor: onehot` and related sparse `kbins` compositions; use a dense preprocessing option or force CPU execution
   - the `gpu_patch` logistic regression path currently supports `categorical_preprocessor: frequency` only
   - the `gpu_patch` logistic regression path currently rejects `categorical_preprocessor: ordinal`, `categorical_preprocessor: onehot`, and related sparse `kbins` compositions; use `frequency` or force CPU execution

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -153,6 +153,7 @@ Stage notes:
 - [runtime_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/runtime_execution.py): runtime capability detection, RAPIDS hook activation, requested-versus-resolved execution context, and bootstrap/runtime metadata helpers.
 - [preprocess_execution.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/preprocess_execution.py): preprocessing backend selection and preprocessor construction for CPU, `gpu_patch`, and the current explicit GPU-native frequency path.
 - [gpu_cuml_preprocess.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/gpu_cuml_preprocess.py): explicit dense GPU preprocessing adapters built on maintained cuML preprocessing constructors.
+- [lightgbm_cuda_backend.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/lightgbm_cuda_backend.py): repo-owned LightGBM adapter, input-coercion helpers, and CUDA build validation probe for the `gpu_native` LightGBM path.
 - [competition.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/competition.py): in-memory competition preparation, fold assignment materialization, and prepared-context construction.
 - [config.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/config.py): nested config validation, metric normalization, candidate-id derivation, and resolved model lookup.
 - [candidate_artifacts.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
@@ -170,6 +171,8 @@ Stage notes:
 - [submission_history.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/submission_history.py): candidate-run submission event/observation models and Kaggle refresh helpers.
 - [mlflow_store.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/mlflow_store.py): MLflow experiment/run lookup, candidate-run creation, candidate download, artifact upload, and submission-history persistence.
 - [benchmark_gpu_checkpoint.py](/Users/hs/dev/TabularShenanigans/scripts/benchmark_gpu_checkpoint.py): issue-scoped benchmark harness for the early CPU vs `gpu_patch` vs `gpu_native` checkpoint, using a temporary file-based MLflow store and timestamped reports under `reports/benchmark_checkpoints/`.
+- [validate_lightgbm_cuda_build.py](/Users/hs/dev/TabularShenanigans/scripts/validate_lightgbm_cuda_build.py): repo-owned validation probe for the installed LightGBM CUDA build on the current host.
+- [install_lightgbm_cuda.sh](/Users/hs/dev/TabularShenanigans/scripts/install_lightgbm_cuda.sh): source-build helper that reinstalls LightGBM with `USE_CUDA=ON` into the project virtualenv and immediately runs the validation probe.
 
 ## Configuration Contract
 Input:
@@ -223,6 +226,9 @@ Required top-level keys:
     - `model_family: logistic_regression`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: standardize`
+    - `model_family: lightgbm`
+    - `categorical_preprocessor: onehot`, `ordinal`, or `frequency`
+    - `numeric_preprocessor: median`, `standardize`, or `kbins`
     - `model_family: xgboost`
     - `categorical_preprocessor: frequency`
     - `numeric_preprocessor: median` or `standardize`
@@ -240,6 +246,11 @@ GPU dependency contract:
 - the project currently supports Python `>=3.13,<3.14`
 - the `gpu` extra currently targets Python 3.13 Linux `x86_64` CUDA 12 hosts via NVIDIA's Python package index
 - expected install command on GPU hosts: `uv sync --extra boosters --extra gpu`
+- `lightgbm` is still declared in the `boosters` extra, but the stock wheel is not accepted for the explicit `gpu_native` CUDA path
+- the repo-owned LightGBM CUDA contract is:
+  - sync the shared dependencies with `uv sync --extra boosters --extra gpu`
+  - run `./scripts/install_lightgbm_cuda.sh` on the target Linux GPU host
+  - validate the result with `PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py`
 - CPU and macOS installs should continue using `uv sync` or `uv sync --extra boosters`
 
 Model candidate contract:
@@ -278,8 +289,8 @@ Sparse onehot runtime contract:
 
 Booster GPU routing contract:
 - when runtime execution resolves to GPU, `xgboost` adds `device="cuda"`
-- when runtime execution resolves to GPU, `lightgbm` adds `device_type="cuda"`
 - when runtime execution resolves to GPU, `catboost` adds `task_type="GPU"`
+- when runtime execution resolves to `gpu_native` for `lightgbm`, the repo builds a `RepositoryLightGbmEstimator`, validates the installed CUDA build once per process, and trains with `device_type="cuda"`
 - on GPU hosts, preprocessing can resolve to an explicit GPU backend even when the model backend still resolves to CPU; in those hybrid cases the runtime converts the preprocessed outputs back to CPU arrays before fit/predict
 - `gpu_cuml` is the current maintained explicit preprocessing backend and currently supports dense `categorical_preprocessor: onehot` with numeric `median`, `standardize`, or `kbins`
 - when runtime execution resolves to `gpu_patch`, preprocessing currently stays on the existing sklearn/pandas constructors and relies on the installed RAPIDS hooks rather than explicit repo-owned GPU preprocessing adapters
@@ -288,6 +299,9 @@ Booster GPU routing contract:
   - `gpu_cuml` for dense `onehot` plus numeric `median`, `standardize`, or `kbins`
   - `gpu_native_frequency` for `categorical_preprocessor: frequency` with numeric `median` or `standardize`
   - other preprocessing schemes currently stay on CPU-backed constructors unless the runtime is using `gpu_patch`
+- the LightGBM `gpu_native` path keeps the current sparse-CSR contract for `onehot`, so CUDA training is available there even though explicit GPU preprocessing is currently limited to the `frequency + median|standardize` slice
+- the repo-owned LightGBM adapter coerces fit and predict inputs onto the same NumPy / SciPy boundary before calling LightGBM
+  - this removes the current fit/predict feature-name mismatch instead of suppressing it
 - when runtime execution resolves to GPU, `logistic_regression` continues to use the sklearn estimator surface but runs through the RAPIDS `cuml.accel` hook path
 - user `model_params` still override repo defaults
 

--- a/scripts/install_lightgbm_cuda.sh
+++ b/scripts/install_lightgbm_cuda.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+uv sync --extra boosters --extra gpu
+uv pip install \
+  --python .venv/bin/python \
+  --reinstall-package lightgbm \
+  --no-binary lightgbm \
+  -C cmake.define.USE_CUDA=ON \
+  "lightgbm>=4.6.0"
+PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py

--- a/scripts/validate_lightgbm_cuda_build.py
+++ b/scripts/validate_lightgbm_cuda_build.py
@@ -1,0 +1,25 @@
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from tabular_shenanigans.lightgbm_cuda_backend import probe_lightgbm_cuda_build
+
+
+def main() -> int:
+    try:
+        validation_result = probe_lightgbm_cuda_build()
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(validation_result.to_dict(), indent=2, sort_keys=True))
+    if validation_result.validated:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -71,6 +71,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     _register_model_paths(
         registry,
         task_types=("binary", "regression"),
+        model_family="lightgbm",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("onehot", "ordinal", "frequency"),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
         model_family="xgboost",
         numeric_preprocessors=("median", "standardize", "kbins"),
         categorical_preprocessors=("ordinal", "frequency"),

--- a/src/tabular_shenanigans/lightgbm_cuda_backend.py
+++ b/src/tabular_shenanigans/lightgbm_cuda_backend.py
@@ -1,0 +1,234 @@
+from dataclasses import dataclass
+from functools import lru_cache
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+LIGHTGBM_CUDA_BUILD_DISABLED_FRAGMENT = "CUDA Tree Learner was not enabled in this build."
+
+
+def _module_startswith(values: object, prefix: str) -> bool:
+    return type(values).__module__.startswith(prefix)
+
+
+def coerce_lightgbm_matrix_input(values: object) -> object:
+    if sparse.issparse(values):
+        return sparse.csr_matrix(values)
+
+    if isinstance(values, pd.DataFrame | pd.Series):
+        return values.to_numpy()
+
+    if _module_startswith(values, "cudf"):
+        return values.to_pandas().to_numpy()
+
+    if _module_startswith(values, "cupy"):
+        import cupy as cp
+
+        return cp.asnumpy(values)
+
+    if hasattr(values, "to_numpy"):
+        return np.asarray(values.to_numpy())
+
+    return np.asarray(values)
+
+
+def _coerce_lightgbm_eval_set(eval_set: object) -> object:
+    if eval_set is None:
+        return None
+
+    coerced_eval_set = []
+    for x_values, y_values in eval_set:
+        coerced_eval_set.append((coerce_lightgbm_matrix_input(x_values), y_values))
+    return coerced_eval_set
+
+
+@dataclass(frozen=True)
+class LightGbmCudaValidationResult:
+    lightgbm_version: str
+    validated: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "lightgbm_version": self.lightgbm_version,
+            "validated": self.validated,
+            "detail": self.detail,
+        }
+
+
+@lru_cache(maxsize=1)
+def probe_lightgbm_cuda_build() -> LightGbmCudaValidationResult:
+    try:
+        import lightgbm
+        from lightgbm import LGBMClassifier
+    except ImportError as exc:
+        raise ImportError(
+            "LightGBM support requires the optional boosters dependencies. "
+            "Install them with `uv sync --extra boosters`."
+        ) from exc
+
+    x_probe = np.asarray(
+        [
+            [0.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    y_probe = np.asarray([0, 1, 1, 0], dtype=np.int64)
+    estimator = LGBMClassifier(
+        device_type="cuda",
+        min_child_samples=1,
+        min_child_weight=0.0,
+        min_data_in_bin=1,
+        n_estimators=1,
+        num_leaves=4,
+        verbosity=-1,
+    )
+    try:
+        estimator.fit(x_probe, y_probe)
+    except Exception as exc:
+        message = str(exc)
+        if LIGHTGBM_CUDA_BUILD_DISABLED_FRAGMENT in message:
+            return LightGbmCudaValidationResult(
+                lightgbm_version=lightgbm.__version__,
+                validated=False,
+                detail=message,
+            )
+        raise RuntimeError(
+            "The LightGBM CUDA validation probe failed before a training run could start. "
+            f"Reason: {message}"
+        ) from exc
+
+    return LightGbmCudaValidationResult(
+        lightgbm_version=lightgbm.__version__,
+        validated=True,
+        detail="LightGBM accepted a CUDA training probe on this host.",
+    )
+
+
+def ensure_lightgbm_cuda_build() -> None:
+    validation_result = probe_lightgbm_cuda_build()
+    if validation_result.validated:
+        return
+
+    raise RuntimeError(
+        "gpu_native LightGBM requires a CUDA-enabled LightGBM build. "
+        "The stock wheel does not satisfy `device_type=\"cuda\"`. "
+        "Reinstall LightGBM from source with "
+        "`uv pip install --python .venv/bin/python --reinstall-package lightgbm "
+        "--no-binary lightgbm -C cmake.define.USE_CUDA=ON \"lightgbm>=4.6.0\"` "
+        "and validate it on the GPU host with "
+        "`PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py`. "
+        f"Probe detail: {validation_result.detail}"
+    )
+
+
+class RepositoryLightGbmEstimator:
+    def __init__(self, estimator: object, *, requires_cuda_build: bool) -> None:
+        self.estimator = estimator
+        self.requires_cuda_build = requires_cuda_build
+
+    def fit(self, x_train: object, y_train: object, **fit_kwargs: object) -> "RepositoryLightGbmEstimator":
+        if self.requires_cuda_build:
+            ensure_lightgbm_cuda_build()
+
+        resolved_fit_kwargs = dict(fit_kwargs)
+        if "eval_set" in resolved_fit_kwargs:
+            resolved_fit_kwargs["eval_set"] = _coerce_lightgbm_eval_set(resolved_fit_kwargs["eval_set"])
+
+        self.estimator.fit(coerce_lightgbm_matrix_input(x_train), y_train, **resolved_fit_kwargs)
+        return self
+
+    def _predict_with_booster(
+        self,
+        x_values: object,
+        *,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: int | None = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        **kwargs: object,
+    ) -> object:
+        if not hasattr(self.estimator, "booster_"):
+            raise ValueError("LightGBM estimator must be fit before predict.")
+
+        return self.estimator.booster_.predict(
+            coerce_lightgbm_matrix_input(x_values),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=False,
+            **kwargs,
+        )
+
+    def predict(
+        self,
+        x_values: object,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: int | None = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        **kwargs: object,
+    ) -> object:
+        raw_predictions = self._predict_with_booster(
+            x_values,
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            **kwargs,
+        )
+        if not hasattr(self.estimator, "classes_") or raw_score or pred_leaf or pred_contrib:
+            return raw_predictions
+
+        probability_values = np.asarray(
+            self.predict_proba(
+                x_values,
+                start_iteration=start_iteration,
+                num_iteration=num_iteration,
+                **kwargs,
+            )
+        )
+        if probability_values.ndim == 1:
+            predicted_indices = (probability_values >= 0.5).astype(int)
+        else:
+            predicted_indices = np.argmax(probability_values, axis=1)
+        return self.estimator.classes_[predicted_indices]
+
+    def predict_proba(
+        self,
+        x_values: object,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: int | None = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        **kwargs: object,
+    ) -> object:
+        raw_predictions = self._predict_with_booster(
+            x_values,
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            **kwargs,
+        )
+        if raw_score or pred_leaf or pred_contrib:
+            return raw_predictions
+
+        prediction_array = np.asarray(raw_predictions)
+        if prediction_array.ndim != 1:
+            return prediction_array
+        return np.vstack((1.0 - prediction_array, prediction_array)).transpose()
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.estimator, name)

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -6,6 +6,7 @@ import pandas as pd
 from scipy import sparse
 
 from tabular_shenanigans.candidate_artifacts import build_target_summary
+from tabular_shenanigans.lightgbm_cuda_backend import coerce_lightgbm_matrix_input
 from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
@@ -429,6 +430,11 @@ def _run_cv_evaluation(
             x_fold_valid_processed = _coerce_xgboost_gpu_input(x_fold_valid_processed, matrix_output_kind)
             if x_test_processed is not None:
                 x_test_processed = _coerce_xgboost_gpu_input(x_test_processed, matrix_output_kind)
+        elif resolved_model_registry_key == "lightgbm":
+            x_fold_train_processed = coerce_lightgbm_matrix_input(x_fold_train_processed)
+            x_fold_valid_processed = coerce_lightgbm_matrix_input(x_fold_valid_processed)
+            if x_test_processed is not None:
+                x_test_processed = coerce_lightgbm_matrix_input(x_test_processed)
         preprocess_wall_seconds += time.perf_counter() - preprocess_started
         if first_fold_residency is None:
             first_fold_residency = {

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -15,6 +15,7 @@ from sklearn.ensemble import (
 )
 from sklearn.linear_model import ElasticNet, LogisticRegression, Ridge
 
+from tabular_shenanigans.lightgbm_cuda_backend import RepositoryLightGbmEstimator
 from tabular_shenanigans.runtime_execution import get_runtime_execution_context
 
 ModelBuilder = Callable[[int, dict[str, object] | None], tuple[object, dict[str, object]]]
@@ -82,7 +83,7 @@ def _resolve_booster_runtime_defaults(model_id: str) -> dict[str, object]:
 
     if model_id == "xgboost":
         return {"device": "cuda"}
-    if model_id == "lightgbm":
+    if model_id == "lightgbm" and runtime_execution_context.resolved_gpu_backend == "gpu_native":
         return {"device_type": "cuda"}
     if model_id == "catboost":
         return {"task_type": "GPU"}
@@ -237,6 +238,7 @@ def _build_lightgbm_regressor(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
+    runtime_execution_context = get_runtime_execution_context()
     params = {
         "colsample_bytree": 0.8,
         "learning_rate": 0.05,
@@ -248,7 +250,11 @@ def _build_lightgbm_regressor(
         **_resolve_booster_runtime_defaults("lightgbm"),
     }
     params = _merge_model_params(params, parameter_overrides)
-    return LGBMRegressor(**params), params
+    estimator = RepositoryLightGbmEstimator(
+        LGBMRegressor(**params),
+        requires_cuda_build=runtime_execution_context.resolved_gpu_backend == "gpu_native",
+    )
+    return estimator, params
 
 
 def _build_lightgbm_classifier(
@@ -263,6 +269,7 @@ def _build_lightgbm_classifier(
             "Install them with `uv sync --extra boosters`."
         ) from exc
 
+    runtime_execution_context = get_runtime_execution_context()
     params = {
         "colsample_bytree": 0.8,
         "learning_rate": 0.05,
@@ -274,7 +281,11 @@ def _build_lightgbm_classifier(
         **_resolve_booster_runtime_defaults("lightgbm"),
     }
     params = _merge_model_params(params, parameter_overrides)
-    return LGBMClassifier(**params), params
+    estimator = RepositoryLightGbmEstimator(
+        LGBMClassifier(**params),
+        requires_cuda_build=runtime_execution_context.resolved_gpu_backend == "gpu_native",
+    )
+    return estimator, params
 
 
 def _build_catboost_regressor(


### PR DESCRIPTION
## Summary
- add a repo-owned LightGBM CUDA adapter plus a host validation probe for the `gpu_native` runtime
- add install and validation scripts for the CUDA-enabled LightGBM build contract on Linux GPU hosts
- document and wire the runtime/backend changes so LightGBM uses the explicit CUDA path instead of an implicit best-effort parameter tweak

## Verification
- `PYTHONPATH=src .venv/bin/python -m compileall src scripts`
- `PYTHONPATH=src .venv/bin/python -c "import tabular_shenanigans.lightgbm_cuda_backend; import tabular_shenanigans.models; import tabular_shenanigans.execution_routing; print("issue-180 import smoke ok")"`

## Notes
- explicit target-machine GPU validation for the finalized stack is tracked in `#193`

Closes #180