### PR TITLE
Add gpu_native random forest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Required top-level sections:
     | `xgboost` | `gpu_native` for `frequency + median|standardize`; `gpu_patch` for the remaining registered `ordinal` / `frequency` tuples; CPU fallback otherwise | sparse GPU-native inputs remain unsupported |
     | `catboost` | `gpu_native` for `categorical_preprocessor: native`; CPU fallback otherwise | preprocessing stays on `cpu_native_frame` |
     | `ridge`, `elasticnet` | `gpu_native` for `frequency + median|standardize`; CPU fallback otherwise | explicit cuML regressors stay on dense inputs only |
-    | `random_forest` | CPU fallback | no GPU path is registered yet |
+    | `random_forest` | `gpu_native` for `onehot + median|standardize|kbins` and `frequency + median|standardize`; CPU fallback otherwise | explicit cuML random forest stays on dense inputs only |
     | `extra_trees`, `hist_gradient_boosting` | CPU fallback | intentional fallback because no maintained official GPU backend is registered |
 
   - preprocessing backend selection is separate from model routing, so a GPU host can still resolve to explicit GPU preprocessing while the model backend falls back to CPU
@@ -176,11 +176,16 @@ Required top-level sections:
   - on GPU hosts, preprocessing can resolve to an explicit GPU backend even when the model backend falls back to CPU; GPU outputs are coerced back to CPU before fit in those hybrid cases
   - `gpu_cuml` is the current maintained explicit preprocessing backend and currently supports dense `categorical_preprocessor: onehot` with numeric `median`, `standardize`, or `kbins`
   - `gpu_patch` preprocessing currently keeps the existing sklearn/pandas constructors and runs them after RAPIDS hooks are installed when no explicit GPU preprocessing backend is selected
-  - `gpu_native_frequency` is currently the only explicit GPU preprocessing backend
+  - `gpu_native_frequency` is the explicit repo-owned `frequency` preprocessing backend
   - the RAPIDS-backed GPU path currently expects the project environment to be installed with `uv sync --extra boosters --extra gpu` on a Python 3.13 Linux `x86_64` CUDA 12 host
   - the LightGBM `gpu_native` path additionally expects a CUDA-enabled LightGBM source build; the repo ships `./scripts/install_lightgbm_cuda.sh` and `PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py` for that contract
   - when runtime resolves to `gpu_native` for `ridge` or `elasticnet`, the repo builds explicit `cuml.Ridge` / `cuml.ElasticNet` estimators for the `frequency + median|standardize` slice and flattens predictions back to the repo's single-target 1D regression contract
   - the `gpu_native` ridge and elasticnet paths accept only the cuML-overlapping `model_params` subset; unsupported sklearn-only params fail with repo-owned errors
+  - when runtime resolves to `gpu_native` for `random_forest`, the repo builds explicit `cuml.RandomForestClassifier` / `cuml.RandomForestRegressor` estimators instead of relying on patch interception
+  - the `gpu_native` random_forest path supports `categorical_preprocessor: frequency` with `numeric_preprocessor: median|standardize` through `gpu_native_frequency`, plus `categorical_preprocessor: onehot` with `numeric_preprocessor: median|standardize|kbins` through dense `gpu_cuml` outputs
+  - `gpu_native` random_forest requires dense inputs only; when `categorical_preprocessor: onehot` is selected, that branch flips from its usual sparse CSR output to dense arrays only for the native random-forest path
+  - `gpu_native` random_forest normalizes `model_params.criterion` onto cuML's `split_criterion`, normalizes `model_params.max_leaf_nodes` onto `max_leaves`, rejects `model_params.n_jobs`, and only accepts the cuML-overlapping subset: `bootstrap`, `criterion`, `max_batch_size`, `max_depth`, `max_features`, `max_leaf_nodes`, `max_samples`, `min_impurity_decrease`, `min_samples_leaf`, `min_samples_split`, `n_bins`, `n_estimators`, `n_streams`, `oob_score`, `random_state`
+  - `gpu_native` random_forest does not support `model_params.max_depth: null`; omit `max_depth` to use cuML's default finite depth or set an explicit positive integer
   - when runtime resolves to `gpu_native` for the supported XGBoost slice, fold-local preprocessing remains per-CV-split, `frequency` preprocessing is performed by the repo-owned `cudf` path, and the first supported dense outputs stay GPU-resident through fit and predict
   - the current native XGBoost support matrix is intentionally narrow and aligned with the documented `gpu_native` tuples above
   - explicit cuML preprocessing currently stays on dense output only; sparse onehot paths continue to use `gpu_patch` or CPU fallback
@@ -211,8 +216,8 @@ Required top-level sections:
     - logistic regression Optuna trials fix `solver="saga"` and `max_iter=1000`
     - logistic regression Optuna trials tune `C`, `tol`, `class_weight`, and `l1_ratio`
   - `categorical_preprocessor: onehot` is an internal matrix-output decision, not a config knob:
-    - sparse CSR output: `ridge`, `elasticnet`, `logistic_regression`, `random_forest`, `extra_trees`, `lightgbm`, `catboost`, `xgboost`
-    - dense array output: `hist_gradient_boosting`
+    - sparse CSR output: `ridge`, `elasticnet`, `logistic_regression`, `extra_trees`, `lightgbm`, `catboost`, `xgboost`, and `random_forest` when runtime does not resolve to `gpu_native`
+    - dense array output: `hist_gradient_boosting`, plus `random_forest` when runtime resolves to `gpu_native`
     - `numeric_preprocessor: kbins` follows the same sparse-versus-dense decision when combined with `onehot`
     - when `model_family: xgboost` and runtime resolves to GPU, the sparse CSR branch is rejected before training because XGBoost does not support `cupyx` CSR inputs yet in this runtime
     - when `model_family: logistic_regression` and runtime resolves to GPU, only `categorical_preprocessor: frequency` is currently supported; the `onehot` sparse branch and the current `ordinal` branch are both rejected before training because the RAPIDS-hooked sklearn preprocessing path is not stable there yet in this runtime

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -231,7 +231,7 @@ Required top-level keys:
     | `xgboost` | `gpu_native` for `frequency + median|standardize`; `gpu_patch` for the remaining registered `ordinal` / `frequency` tuples; CPU fallback otherwise | sparse GPU-native inputs remain unsupported |
     | `catboost` | `gpu_native` for `categorical_preprocessor: native`; CPU fallback otherwise | preprocessing stays on `cpu_native_frame` |
     | `ridge`, `elasticnet` | `gpu_native` for `frequency + median|standardize`; CPU fallback otherwise | explicit cuML regressors stay on dense inputs only |
-    | `random_forest` | CPU fallback | no GPU path is registered yet |
+    | `random_forest` | `gpu_native` for `onehot + median|standardize|kbins` and `frequency + median|standardize`; CPU fallback otherwise | explicit cuML random forest stays on dense inputs only |
     | `extra_trees`, `hist_gradient_boosting` | CPU fallback | intentional fallback because no maintained official GPU backend is registered |
 
   - current preprocessing selection on GPU hosts is:
@@ -291,8 +291,8 @@ Hard-invalid preprocessing combination:
 
 Sparse onehot runtime contract:
 - `categorical_preprocessor: onehot` stays an internal runtime choice rather than a user-facing dense/sparse switch
-- sparse CSR output is used for `ridge`, `elasticnet`, `logistic_regression`, `random_forest`, `extra_trees`, `lightgbm`, `catboost`, and `xgboost`
-- dense array output remains in place for `hist_gradient_boosting`
+- sparse CSR output is used for `ridge`, `elasticnet`, `logistic_regression`, `extra_trees`, `lightgbm`, `catboost`, `xgboost`, and `random_forest` when runtime does not resolve to `gpu_native`
+- dense array output remains in place for `hist_gradient_boosting` and is also used for `random_forest` when runtime resolves to `gpu_native`
 - `numeric_preprocessor: kbins` follows the same sparse-versus-dense output contract when composed with `onehot`
 
 Booster GPU routing contract:
@@ -312,6 +312,17 @@ Booster GPU routing contract:
   - this removes the current fit/predict feature-name mismatch instead of suppressing it
 - when runtime execution resolves to `gpu_patch`, `logistic_regression` keeps the sklearn estimator surface and runs through the RAPIDS `cuml.accel` hook path
 - when runtime execution resolves to `gpu_native` for `ridge` or `elasticnet`, the repo builds explicit `cuml.Ridge` / `cuml.ElasticNet` estimators on top of the shared dense `gpu_native_frequency` preprocessing outputs
+- when runtime execution resolves to `gpu_native` for `random_forest`, the repo builds explicit `cuml.RandomForestClassifier` / `cuml.RandomForestRegressor` estimators instead of relying on sklearn interception or RAPIDS patch hooks
+- the current `gpu_native` random-forest support matrix is:
+  - `categorical_preprocessor: frequency` with `numeric_preprocessor: median` or `standardize`
+  - `categorical_preprocessor: onehot` with `numeric_preprocessor: median`, `standardize`, or `kbins`
+- fold-local preprocessing still happens per CV split, and the supported native random-forest inputs stay GPU-resident through fit and predict
+  - `gpu_native_frequency` produces dense `cudf.DataFrame` inputs for the `frequency` slice
+  - `gpu_cuml` produces dense `cupy.ndarray` inputs for the `onehot` slice
+- `gpu_native` random_forest requires dense inputs only, so the runtime flips `onehot` from its usual sparse CSR branch onto dense arrays only when the native random-forest path is selected
+- `gpu_native` random_forest normalizes `model_params.criterion` onto cuML's `split_criterion` and `model_params.max_leaf_nodes` onto `max_leaves`
+- `gpu_native` random_forest only accepts the cuML-overlapping `model_params` subset: `bootstrap`, `criterion`, `max_batch_size`, `max_depth`, `max_features`, `max_leaf_nodes`, `max_samples`, `min_impurity_decrease`, `min_samples_leaf`, `min_samples_split`, `n_bins`, `n_estimators`, `n_streams`, `oob_score`, `random_state`
+- `gpu_native` random_forest rejects `model_params.n_jobs`, and `model_params.max_depth` does not support `null`; omit `max_depth` to use cuML's default finite depth or set an explicit positive integer
 - user `model_params` still override repo defaults
 
 XGBoost GPU-native input contract:
@@ -356,6 +367,7 @@ Model candidate manifests currently record:
 - provenance: `config_fingerprint`, `config_snapshot`, `mlflow_run_id`
 - runtime execution: requested/ resolved compute target, acceleration backend, RAPIDS hook status, and hardware capability snapshot
 - runtime profiling: training-context build time, fold-stage CV timings, artifact staging time, and first-fold matrix residency snapshots when collected
+  - together with `runtime_execution.resolved_gpu_backend` and `preprocessing_backend`, this is the repo-owned record of whether a native GPU path used dense `cupy` onehot inputs or dense `cudf` frequency inputs
 - model info: `model_family`, `model_registry_key`, `estimator_name`
 - feature/preprocessing info: `feature_recipe_id`, `feature_columns`, `numeric_preprocessor`, `categorical_preprocessor`, `preprocessing_scheme_id`
 - runtime-selected preprocessing backend: `preprocessing_backend`

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -349,6 +349,7 @@ class AppConfig(BaseModel):
             task_type=self.competition.task_type,
             model_id=self.resolved_model_registry_key,
             categorical_preprocessor_id=candidate.categorical_preprocessor,
+            runtime_execution_context=self.runtime_execution_context,
         )
         return resolve_preprocessing_execution_plan(
             runtime_execution_context=self.runtime_execution_context,

--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -87,6 +87,22 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     _register_model_paths(
         registry,
         task_types=("binary", "regression"),
+        model_family="random_forest",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("onehot",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
+        model_family="random_forest",
+        numeric_preprocessors=("median", "standardize"),
+        categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
         model_family="lightgbm",
         numeric_preprocessors=("median", "standardize", "kbins"),
         categorical_preprocessors=("onehot", "ordinal", "frequency"),

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -187,6 +187,7 @@ def build_prepared_training_context(
         task_type=competition.task_type,
         model_id=config.resolved_model_registry_key,
         categorical_preprocessor_id=candidate.categorical_preprocessor,
+        runtime_execution_context=config.runtime_execution_context,
     )
     preprocessing_execution_plan = config.preprocessing_execution_plan
     uses_xgboost_gpu_native_inputs = (

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -16,7 +16,11 @@ from sklearn.ensemble import (
 from sklearn.linear_model import ElasticNet, LogisticRegression, Ridge
 
 from tabular_shenanigans.lightgbm_cuda_backend import RepositoryLightGbmEstimator
-from tabular_shenanigans.runtime_execution import get_runtime_execution_context
+from tabular_shenanigans.runtime_execution import (
+    NATIVE_GPU_BACKEND,
+    RuntimeExecutionContext,
+    get_runtime_execution_context,
+)
 
 ModelBuilder = Callable[[int, dict[str, object] | None], tuple[object, dict[str, object]]]
 FitKwargsBuilder = Callable[[object, list[str], list[str]], dict[str, object]]
@@ -29,6 +33,35 @@ GPU_NATIVE_ELASTICNET_SUPPORTED_PARAM_NAMES = frozenset(
 )
 GPU_NATIVE_ELASTICNET_SUPPORTED_SOLVERS = frozenset({"cd", "qn"})
 GPU_NATIVE_ELASTICNET_SUPPORTED_SELECTIONS = frozenset({"cyclic", "random"})
+GPU_NATIVE_RANDOM_FOREST_SUPPORTED_PARAM_NAMES = frozenset(
+    {
+        "bootstrap",
+        "criterion",
+        "max_batch_size",
+        "max_depth",
+        "max_features",
+        "max_leaf_nodes",
+        "max_samples",
+        "min_impurity_decrease",
+        "min_samples_leaf",
+        "min_samples_split",
+        "n_bins",
+        "n_estimators",
+        "n_streams",
+        "oob_score",
+        "random_state",
+    }
+)
+GPU_NATIVE_RANDOM_FOREST_MAX_FEATURE_KEYWORDS = frozenset({"auto", "log2", "sqrt"})
+GPU_NATIVE_RANDOM_FOREST_CLASSIFIER_CRITERION_MAP = {
+    "entropy": "entropy",
+    "gini": "gini",
+}
+GPU_NATIVE_RANDOM_FOREST_REGRESSOR_CRITERION_MAP = {
+    "mse": "mse",
+    "poisson": "poisson",
+    "squared_error": "mse",
+}
 
 
 @dataclass(frozen=True)
@@ -40,6 +73,7 @@ class ModelDefinition:
     tuning_space_builder: TuningSpaceBuilder | None = None
     supports_native_categorical_preprocessing: bool = False
     supports_sparse_preprocessed_input: bool = False
+    supports_gpu_native_dense_onehot_input: bool = False
 
 
 class BinaryLabelEncodingClassifier:
@@ -150,6 +184,25 @@ def _import_cuml_linear_model(
     model_class = getattr(cuml_linear_model, model_class_name, None)
     if model_class is None:
         raise ImportError(f"cuml.linear_model.{model_class_name} is unavailable in this environment.")
+    return model_class
+
+
+def _import_cuml_ensemble_model(
+    model_class_name: str,
+    *,
+    model_label: str,
+) -> type[object]:
+    try:
+        from cuml import ensemble as cuml_ensemble
+    except ImportError as exc:
+        raise ImportError(
+            f"gpu_native {model_label} requires the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    model_class = getattr(cuml_ensemble, model_class_name, None)
+    if model_class is None:
+        raise ImportError(f"cuml.ensemble.{model_class_name} is unavailable in this environment.")
     return model_class
 
 
@@ -271,6 +324,250 @@ def _build_gpu_native_elasticnet_params(
     return _merge_model_params({}, resolved_overrides)
 
 
+def _normalize_gpu_native_random_forest_int_param(
+    *,
+    param_name: str,
+    value: object,
+    minimum_value: int,
+) -> int:
+    if not isinstance(value, (int, np.integer)) or isinstance(value, bool):
+        raise ValueError(f"gpu_native random_forest model_params.{param_name} must be an integer.")
+    int_value = int(value)
+    if int_value < minimum_value:
+        raise ValueError(
+            f"gpu_native random_forest model_params.{param_name} must be >= {minimum_value}."
+        )
+    return int_value
+
+
+def _normalize_gpu_native_random_forest_bool_param(
+    *,
+    param_name: str,
+    value: object,
+) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"gpu_native random_forest model_params.{param_name} must be a boolean.")
+    return value
+
+
+def _normalize_gpu_native_random_forest_non_negative_float_param(
+    *,
+    param_name: str,
+    value: object,
+) -> float:
+    if not _is_numeric_scalar_param(value):
+        raise ValueError(f"gpu_native random_forest model_params.{param_name} must be numeric.")
+    float_value = float(value)
+    if not np.isfinite(float_value) or float_value < 0.0:
+        raise ValueError(
+            f"gpu_native random_forest model_params.{param_name} must be finite and >= 0."
+        )
+    return float_value
+
+
+def _normalize_gpu_native_random_forest_count_or_fraction_param(
+    *,
+    param_name: str,
+    value: object,
+    minimum_count: int,
+) -> int | float:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"gpu_native random_forest model_params.{param_name} must be an integer count "
+            "or a float fraction within (0, 1]."
+        )
+
+    if isinstance(value, (int, np.integer)):
+        int_value = int(value)
+        if int_value < minimum_count:
+            raise ValueError(
+                f"gpu_native random_forest model_params.{param_name} must be >= {minimum_count}."
+            )
+        return int_value
+
+    if not _is_numeric_scalar_param(value):
+        raise ValueError(
+            f"gpu_native random_forest model_params.{param_name} must be an integer count "
+            "or a float fraction within (0, 1]."
+        )
+
+    float_value = float(value)
+    if not np.isfinite(float_value):
+        raise ValueError(
+            f"gpu_native random_forest model_params.{param_name} must be finite."
+        )
+    if float_value.is_integer():
+        int_value = int(float_value)
+        if int_value < minimum_count:
+            raise ValueError(
+                f"gpu_native random_forest model_params.{param_name} must be >= {minimum_count}."
+            )
+        return int_value
+    if 0.0 < float_value <= 1.0:
+        return float_value
+    raise ValueError(
+        f"gpu_native random_forest model_params.{param_name} must be >= {minimum_count} "
+        "when passed as a count or within (0, 1] when passed as a fraction."
+    )
+
+
+def _normalize_gpu_native_random_forest_max_features(value: object) -> int | float | str:
+    if isinstance(value, bool):
+        raise ValueError(
+            "gpu_native random_forest model_params.max_features must be an integer, a float "
+            "within (0, 1], or one of ['auto', 'log2', 'sqrt']."
+        )
+
+    if isinstance(value, (int, np.integer)):
+        int_value = int(value)
+        if int_value <= 0:
+            raise ValueError("gpu_native random_forest model_params.max_features must be > 0.")
+        return int_value
+
+    if _is_numeric_scalar_param(value):
+        float_value = float(value)
+        if not np.isfinite(float_value):
+            raise ValueError("gpu_native random_forest model_params.max_features must be finite.")
+        if float_value.is_integer() and float_value > 0.0:
+            return int(float_value)
+        if 0.0 < float_value <= 1.0:
+            return float_value
+        raise ValueError(
+            "gpu_native random_forest model_params.max_features must be > 0 when passed "
+            "as a count or within (0, 1] when passed as a fraction."
+        )
+
+    if isinstance(value, str):
+        normalized_value = value.strip().lower()
+        if normalized_value in GPU_NATIVE_RANDOM_FOREST_MAX_FEATURE_KEYWORDS:
+            return normalized_value
+
+    raise ValueError(
+        "gpu_native random_forest model_params.max_features must be an integer, a float "
+        "within (0, 1], or one of ['auto', 'log2', 'sqrt']."
+    )
+
+
+def _normalize_gpu_native_random_forest_criterion(
+    *,
+    criterion_value: object,
+    criterion_map: Mapping[str, str],
+) -> str:
+    if not isinstance(criterion_value, str):
+        raise ValueError("gpu_native random_forest model_params.criterion must be a string.")
+
+    normalized_value = criterion_value.strip().lower()
+    normalized_criterion = criterion_map.get(normalized_value)
+    if normalized_criterion is None:
+        raise ValueError(
+            "gpu_native random_forest model_params.criterion must be one of "
+            f"{sorted(criterion_map)}."
+        )
+    return normalized_criterion
+
+
+def _build_gpu_native_random_forest_params(
+    *,
+    parameter_overrides: Mapping[str, object] | None,
+    random_state: int,
+    criterion_map: Mapping[str, str],
+) -> dict[str, object]:
+    raw_overrides = dict(parameter_overrides or {})
+    if "n_jobs" in raw_overrides:
+        raise ValueError(
+            "gpu_native random_forest does not support model_params.n_jobs. "
+            "Use model_params.n_streams or omit the override."
+        )
+
+    resolved_overrides = _resolve_supported_gpu_native_params(
+        model_label="random_forest",
+        parameter_overrides=raw_overrides,
+        supported_param_names=GPU_NATIVE_RANDOM_FOREST_SUPPORTED_PARAM_NAMES,
+    )
+
+    normalized_overrides: dict[str, object] = {}
+    for param_name, param_value in resolved_overrides.items():
+        if param_name == "criterion":
+            normalized_overrides["split_criterion"] = _normalize_gpu_native_random_forest_criterion(
+                criterion_value=param_value,
+                criterion_map=criterion_map,
+            )
+            continue
+        if param_name == "max_leaf_nodes":
+            normalized_overrides["max_leaves"] = _normalize_gpu_native_random_forest_int_param(
+                param_name="max_leaf_nodes",
+                value=param_value,
+                minimum_value=2,
+            )
+            continue
+        if param_name == "max_features":
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_max_features(param_value)
+            continue
+        if param_name in {"bootstrap", "oob_score"}:
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_bool_param(
+                param_name=param_name,
+                value=param_value,
+            )
+            continue
+        if param_name == "max_depth":
+            if param_value is None:
+                raise ValueError(
+                    "gpu_native random_forest model_params.max_depth does not support null. "
+                    "Set a positive integer or omit the override to use the cuML default depth."
+                )
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_int_param(
+                param_name=param_name,
+                value=param_value,
+                minimum_value=1,
+            )
+            continue
+        if param_name in {"max_batch_size", "n_bins", "n_estimators", "n_streams", "random_state"}:
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_int_param(
+                param_name=param_name,
+                value=param_value,
+                minimum_value=1,
+            )
+            continue
+        if param_name == "min_samples_split":
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_count_or_fraction_param(
+                param_name=param_name,
+                value=param_value,
+                minimum_count=2,
+            )
+            continue
+        if param_name in {"max_samples", "min_samples_leaf"}:
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_count_or_fraction_param(
+                param_name=param_name,
+                value=param_value,
+                minimum_count=1,
+            )
+            continue
+        if param_name == "min_impurity_decrease":
+            normalized_overrides[param_name] = _normalize_gpu_native_random_forest_non_negative_float_param(
+                param_name=param_name,
+                value=param_value,
+            )
+            continue
+        normalized_overrides[param_name] = param_value
+
+    resolved_bootstrap = normalized_overrides.get("bootstrap", True)
+    resolved_oob_score = normalized_overrides.get("oob_score", False)
+    if resolved_oob_score and not resolved_bootstrap:
+        raise ValueError(
+            "gpu_native random_forest model_params.oob_score requires bootstrap=True."
+        )
+    if "max_samples" in normalized_overrides and not resolved_bootstrap:
+        raise ValueError(
+            "gpu_native random_forest model_params.max_samples requires bootstrap=True."
+        )
+
+    default_params = {
+        "n_estimators": 500,
+        "random_state": random_state,
+    }
+    return _merge_model_params(default_params, normalized_overrides)
+
+
 def _build_ridge(random_state: int, parameter_overrides: dict[str, object] | None = None) -> tuple[object, dict[str, object]]:
     del random_state
     runtime_execution_context = get_runtime_execution_context()
@@ -301,7 +598,20 @@ def _build_elasticnet(
 def _build_random_forest_regressor(
     random_state: int,
     parameter_overrides: dict[str, object] | None = None,
-) -> tuple[RandomForestRegressor, dict[str, object]]:
+) -> tuple[object, dict[str, object]]:
+    runtime_execution_context = get_runtime_execution_context()
+    if runtime_execution_context.resolved_gpu_backend == NATIVE_GPU_BACKEND:
+        params = _build_gpu_native_random_forest_params(
+            parameter_overrides=parameter_overrides,
+            random_state=random_state,
+            criterion_map=GPU_NATIVE_RANDOM_FOREST_REGRESSOR_CRITERION_MAP,
+        )
+        estimator_class = _import_cuml_ensemble_model(
+            "RandomForestRegressor",
+            model_label="random_forest",
+        )
+        return SingleTargetRegressionAdapter(estimator_class(**params)), params
+
     params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return RandomForestRegressor(**params), params
 
@@ -390,7 +700,20 @@ def _build_gpu_native_logreg_params(
 def _build_random_forest_classifier(
     random_state: int,
     parameter_overrides: dict[str, object] | None = None,
-) -> tuple[RandomForestClassifier, dict[str, object]]:
+) -> tuple[object, dict[str, object]]:
+    runtime_execution_context = get_runtime_execution_context()
+    if runtime_execution_context.resolved_gpu_backend == NATIVE_GPU_BACKEND:
+        params = _build_gpu_native_random_forest_params(
+            parameter_overrides=parameter_overrides,
+            random_state=random_state,
+            criterion_map=GPU_NATIVE_RANDOM_FOREST_CLASSIFIER_CRITERION_MAP,
+        )
+        estimator_class = _import_cuml_ensemble_model(
+            "RandomForestClassifier",
+            model_label="random_forest",
+        )
+        return BinaryLabelEncodingClassifier(estimator_class(**params)), params
+
     params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return RandomForestClassifier(**params), params
 
@@ -803,6 +1126,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             builder=_build_random_forest_regressor,
             tuning_space_builder=_build_random_forest_tuning_space,
             supports_sparse_preprocessed_input=True,
+            supports_gpu_native_dense_onehot_input=True,
         ),
         "extra_trees": ModelDefinition(
             model_id="extra_trees",
@@ -855,6 +1179,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             builder=_build_random_forest_classifier,
             tuning_space_builder=_build_random_forest_tuning_space,
             supports_sparse_preprocessed_input=True,
+            supports_gpu_native_dense_onehot_input=True,
         ),
         "extra_trees": ModelDefinition(
             model_id="extra_trees",
@@ -958,10 +1283,18 @@ def resolve_model_matrix_output_kind(
     task_type: str,
     model_id: str,
     categorical_preprocessor_id: str,
+    runtime_execution_context: RuntimeExecutionContext | None = None,
 ) -> str:
     model_definition = get_model_definition(task_type, model_id)
     if categorical_preprocessor_id == "native":
         return "native_frame"
+    if (
+        categorical_preprocessor_id == "onehot"
+        and runtime_execution_context is not None
+        and runtime_execution_context.resolved_gpu_backend == NATIVE_GPU_BACKEND
+        and model_definition.supports_gpu_native_dense_onehot_input
+    ):
+        return "dense_array"
     if categorical_preprocessor_id == "onehot" and model_definition.supports_sparse_preprocessed_input:
         return "sparse_csr"
     return "dense_array"


### PR DESCRIPTION
## Summary
- add an explicit cuML-backed gpu_native random forest path for binary and regression candidates
- register the supported gpu_native routing tuples and switch onehot random forest preprocessing to dense output only when that native path is selected
- document the supported preprocessing and parameter-normalization contract for native random forest

Closes #178

## Verification
- uv run python -m compileall src
- mocked PYTHONPATH=src uv run python smoke script covering routing, preprocessing backend selection, and cuML random forest builder normalization
- real Linux NVIDIA host validation is still pending and tracked in #193
