### PR TITLE
Add target-host GPU validation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Available stage-specific commands:
 - `uv run python main.py submit --candidate-id <candidate_id>`
 - `uv run python main.py refresh-submissions`
 - `uv run python scripts/benchmark_gpu_checkpoint.py`
+- `uv run python scripts/validate_gpu_target_matrix.py`
 - `PYTHONPATH=src uv run python scripts/validate_lightgbm_cuda_build.py`
 - `./scripts/install_lightgbm_cuda.sh`
 
@@ -95,6 +96,7 @@ Stage behavior:
 - `submit`: downloads one candidate from MLflow, validates `test_predictions.csv` against `sample_submission.csv`, and when `experiment.submit.enabled=true` submits to Kaggle and records the submission event under that same candidate run.
 - `refresh-submissions`: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and appends new score observations back onto the matching candidate runs.
 - `benchmark_gpu_checkpoint.py`: runs the `#183` CPU vs `gpu_patch` vs `gpu_native` checkpoint matrix, writes a timestamped report plus raw logs under `reports/benchmark_checkpoints/`, temporarily rewrites repository-root `config.yaml` during the session, and restores it at the end while using an isolated file-based MLflow store inside the benchmark output directory.
+- `validate_gpu_target_matrix.py`: runs the `#193` target-host GPU smoke matrix against the repo-owned host install path, validates the bootstrap steps plus representative `gpu_patch` / `gpu_native` model tuples, and writes a timestamped report plus per-case logs under `reports/gpu_target_validation/`. This is the target-machine confirmation step, not the broader parity/performance audit tracked in `#182`. See `docs/TARGET_GPU_SMOKE_VALIDATION.md`.
 - `validate_lightgbm_cuda_build.py`: runs the repo-owned LightGBM CUDA probe and exits non-zero when the installed LightGBM build does not satisfy `device_type="cuda"` on the current host.
 - `install_lightgbm_cuda.sh`: reinstalls LightGBM from source with `USE_CUDA=ON` in the project virtualenv, then runs the validation probe.
 

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -7,7 +7,9 @@ competition:
 
   # Set this when labels are not one of the auto-resolved safe pairs:
   # [0, 1], [False, True], or ["No", "Yes"].
-  # positive_label: "Yes"
+  #
+  # `playground-series-s5e12` stores the target as 0.0 / 1.0, so keep this explicit.
+  positive_label: 1
 
   # Optional schema overrides when inference is ambiguous or the competition is not Playground-shaped.
   # id_column: id

--- a/docs/TARGET_GPU_SMOKE_VALIDATION.md
+++ b/docs/TARGET_GPU_SMOKE_VALIDATION.md
@@ -1,0 +1,62 @@
+# Target GPU Smoke Validation
+
+`scripts/validate_gpu_target_matrix.py` is the target-host smoke harness for `#193`.
+It validates the repo-owned Linux NVIDIA install path on a real GPU machine and is
+intentionally separate from the broader parity/performance audit tracked in `#182`.
+
+Until the Linux image work in `#173` lands, this validation runs against the
+repo-owned host install path rather than a container image.
+
+## What It Covers
+- bootstrap/install validation:
+  - `uv sync --extra boosters --extra gpu`
+  - `./scripts/install_lightgbm_cuda.sh`
+- end-to-end `uv run python main.py train` smoke runs for representative GPU tuples:
+  - `logistic_regression` `gpu_native`
+  - `logistic_regression` `gpu_patch`
+  - `xgboost` `gpu_native`
+  - `xgboost` `gpu_patch`
+  - `catboost` `gpu_native`
+  - `ridge` `gpu_native`
+  - `elasticnet` `gpu_native`
+  - `random_forest` `gpu_native` through `gpu_cuml`
+  - `random_forest` `gpu_native` through `gpu_native_frequency`
+  - `lightgbm` `gpu_native`
+- per-case validation of:
+  - runtime resolution
+  - preprocessing backend selection
+  - fit/predict success
+  - candidate artifact generation
+  - MLflow logging
+  - sampled GPU utilization and memory
+
+## How To Run
+```bash
+uv run python scripts/validate_gpu_target_matrix.py
+```
+
+Useful flags:
+- `--cases <comma-separated-case-ids>` to run a subset of the matrix
+- `--cv-splits <n>` to adjust the smoke-time CV depth
+- `--skip-sync` when the environment is already synced
+- `--skip-lightgbm-install` when the CUDA-enabled LightGBM build is already in place
+- `--output-root <path>` to redirect the session output
+
+## Output Contract
+Each run writes a timestamped session directory under
+`reports/gpu_target_validation/<timestamp>/` containing:
+- `validation_summary.json`
+- `validation_report.md`
+- `bootstrap/` command logs
+- one directory per validation case with train stdout/stderr and `gpu_samples.csv`
+- a local file-based `mlruns/` store used only for the smoke session
+
+The harness temporarily rewrites repository-root `config.yaml` from the tracked
+binary/regression example configs so it can keep the single-config runtime
+contract intact, then restores the original `config.yaml` at the end.
+
+## Interpretation
+- A failed case means the target machine exposed an environment mismatch or a real
+  support-matrix gap. File a follow-up issue before treating the GPU workstream as done.
+- This harness is a smoke/integration check only. It does not claim CPU/GPU score
+  parity or performance improvement; that work remains in `#182`.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -135,6 +135,7 @@ Submission artifacts on the same candidate run:
 - `uv run python main.py submit`
 - `uv run python main.py submit --candidate-id <candidate_id>`
 - `uv run python main.py refresh-submissions`
+- `uv run python scripts/validate_gpu_target_matrix.py`
 
 Stage notes:
 - `main.py` keeps the existing user-facing command but now delegates into a bootstrap module before the runtime imports `pandas`- or `sklearn`-dependent modules.
@@ -171,6 +172,7 @@ Stage notes:
 - [submission_history.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/submission_history.py): candidate-run submission event/observation models and Kaggle refresh helpers.
 - [mlflow_store.py](/Users/hs/dev/TabularShenanigans/src/tabular_shenanigans/mlflow_store.py): MLflow experiment/run lookup, candidate-run creation, candidate download, artifact upload, and submission-history persistence.
 - [benchmark_gpu_checkpoint.py](/Users/hs/dev/TabularShenanigans/scripts/benchmark_gpu_checkpoint.py): issue-scoped benchmark harness for the early CPU vs `gpu_patch` vs `gpu_native` checkpoint, using a temporary file-based MLflow store and timestamped reports under `reports/benchmark_checkpoints/`.
+- [validate_gpu_target_matrix.py](/Users/hs/dev/TabularShenanigans/scripts/validate_gpu_target_matrix.py): issue-scoped target-host smoke harness for `#193`, using a temporary file-based MLflow store, bootstrap/install validation, and timestamped reports under `reports/gpu_target_validation/`.
 - [validate_lightgbm_cuda_build.py](/Users/hs/dev/TabularShenanigans/scripts/validate_lightgbm_cuda_build.py): repo-owned validation probe for the installed LightGBM CUDA build on the current host.
 - [install_lightgbm_cuda.sh](/Users/hs/dev/TabularShenanigans/scripts/install_lightgbm_cuda.sh): source-build helper that reinstalls LightGBM with `USE_CUDA=ON` into the project virtualenv and immediately runs the validation probe.
 

--- a/scripts/install_lightgbm_cuda.sh
+++ b/scripts/install_lightgbm_cuda.sh
@@ -4,6 +4,22 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+if [[ -z "${CUDACXX:-}" ]]; then
+  for candidate in /usr/local/cuda/bin/nvcc /usr/local/cuda-12/bin/nvcc /usr/local/cuda-12.4/bin/nvcc; do
+    if [[ -x "$candidate" ]]; then
+      export CUDACXX="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -n "${CUDACXX:-}" ]]; then
+  CUDA_HOME="$(cd "$(dirname "$(dirname "$CUDACXX")")" && pwd)"
+  export CUDA_HOME
+  export CUDA_PATH="$CUDA_HOME"
+  export PATH="$CUDA_HOME/bin:$PATH"
+fi
+
 uv sync --extra boosters --extra gpu
 uv pip install \
   --python .venv/bin/python \

--- a/scripts/validate_gpu_target_matrix.py
+++ b/scripts/validate_gpu_target_matrix.py
@@ -1,0 +1,955 @@
+import argparse
+import json
+import platform
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+import yaml
+from mlflow import MlflowClient
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "config.yaml"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "reports" / "gpu_target_validation"
+DEFAULT_BINARY_TEMPLATE_PATH = REPO_ROOT / "config.binary.example.yaml"
+DEFAULT_REGRESSION_TEMPLATE_PATH = REPO_ROOT / "config.regression.example.yaml"
+REQUIRED_ARTIFACT_PATHS = frozenset(
+    {
+        "candidate",
+        "candidate/candidate.json",
+        "candidate/fold_metrics.csv",
+        "candidate/oof_predictions.csv",
+        "candidate/test_predictions.csv",
+        "config",
+        "config/runtime_config.json",
+        "context",
+        "context/competition.json",
+        "context/folds.csv",
+        "logs",
+        "logs/runtime.log",
+    }
+)
+PACKAGE_VERSION_NAMES = (
+    "numpy",
+    "pandas",
+    "scikit-learn",
+    "mlflow-skinny",
+    "cudf-cu12",
+    "cuml-cu12",
+    "xgboost",
+    "catboost",
+    "lightgbm",
+)
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from tabular_shenanigans.config import load_config
+from tabular_shenanigans.runtime_execution import (
+    NATIVE_GPU_BACKEND,
+    PATCH_GPU_BACKEND,
+    detect_runtime_capabilities,
+)
+
+
+@dataclass(frozen=True)
+class ValidationCase:
+    case_id: str
+    template_config_path: Path
+    model_family: str
+    numeric_preprocessor: str
+    categorical_preprocessor: str
+    gpu_backend: str
+    expected_preprocessing_backend: str
+    notes: str
+
+    @property
+    def expected_resolved_gpu_backend(self) -> str:
+        return NATIVE_GPU_BACKEND if self.gpu_backend == "native" else PATCH_GPU_BACKEND
+
+    @property
+    def expected_rapids_hooks_installed(self) -> bool:
+        return self.expected_resolved_gpu_backend == PATCH_GPU_BACKEND
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the #193 target-host GPU smoke validation matrix."
+    )
+    parser.add_argument(
+        "--output-root",
+        default=str(DEFAULT_OUTPUT_ROOT),
+        help="Directory where the timestamped validation session should be written.",
+    )
+    parser.add_argument(
+        "--cases",
+        default=None,
+        help="Optional comma-separated case IDs to run. Defaults to the full target-host matrix.",
+    )
+    parser.add_argument(
+        "--cv-splits",
+        type=int,
+        default=3,
+        help="CV split count for the smoke session. Defaults to 3 for faster target-host validation.",
+    )
+    parser.add_argument(
+        "--skip-sync",
+        action="store_true",
+        help="Skip `uv sync --extra boosters --extra gpu` before running the matrix.",
+    )
+    parser.add_argument(
+        "--skip-lightgbm-install",
+        action="store_true",
+        help="Skip `./scripts/install_lightgbm_cuda.sh` before running the matrix.",
+    )
+    return parser
+
+
+def _default_cases() -> list[ValidationCase]:
+    return [
+        ValidationCase(
+            case_id="binary_logistic_native_frequency_standardize",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="logistic_regression",
+            numeric_preprocessor="standardize",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates explicit gpu_native logistic regression on the repo-owned frequency backend.",
+        ),
+        ValidationCase(
+            case_id="binary_logistic_patch_frequency_kbins",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="logistic_regression",
+            numeric_preprocessor="kbins",
+            categorical_preprocessor="frequency",
+            gpu_backend="patch",
+            expected_preprocessing_backend="gpu_patch",
+            notes="Validates the retained RAPIDS hook path for logistic regression.",
+        ),
+        ValidationCase(
+            case_id="binary_xgboost_native_frequency_standardize",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="xgboost",
+            numeric_preprocessor="standardize",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates the explicit gpu_native XGBoost path.",
+        ),
+        ValidationCase(
+            case_id="binary_xgboost_patch_ordinal_kbins",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="xgboost",
+            numeric_preprocessor="kbins",
+            categorical_preprocessor="ordinal",
+            gpu_backend="patch",
+            expected_preprocessing_backend="gpu_patch",
+            notes="Validates the remaining registered GPU patch XGBoost tuple.",
+        ),
+        ValidationCase(
+            case_id="binary_catboost_native_native_median",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="catboost",
+            numeric_preprocessor="median",
+            categorical_preprocessor="native",
+            gpu_backend="native",
+            expected_preprocessing_backend="cpu_native_frame",
+            notes="Validates explicit gpu_native CatBoost with native categorical preprocessing.",
+        ),
+        ValidationCase(
+            case_id="regression_ridge_native_frequency_standardize",
+            template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
+            model_family="ridge",
+            numeric_preprocessor="standardize",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates the explicit cuML ridge backend from #177.",
+        ),
+        ValidationCase(
+            case_id="regression_elasticnet_native_frequency_standardize",
+            template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
+            model_family="elasticnet",
+            numeric_preprocessor="standardize",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates the explicit cuML elasticnet backend from #177.",
+        ),
+        ValidationCase(
+            case_id="binary_random_forest_native_onehot_kbins",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="random_forest",
+            numeric_preprocessor="kbins",
+            categorical_preprocessor="onehot",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_cuml",
+            notes="Validates gpu_native random forest through the dense cuML preprocessing path.",
+        ),
+        ValidationCase(
+            case_id="regression_random_forest_native_frequency_standardize",
+            template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
+            model_family="random_forest",
+            numeric_preprocessor="standardize",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates gpu_native random forest through the frequency preprocessing path.",
+        ),
+        ValidationCase(
+            case_id="regression_lightgbm_native_onehot_median",
+            template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
+            model_family="lightgbm",
+            numeric_preprocessor="median",
+            categorical_preprocessor="onehot",
+            gpu_backend="native",
+            expected_preprocessing_backend="cpu_sklearn",
+            notes="Validates the explicit LightGBM CUDA adapter on the sparse onehot boundary.",
+        ),
+    ]
+
+
+def _resolve_cases(case_filter: str | None) -> list[ValidationCase]:
+    cases_by_id = {case.case_id: case for case in _default_cases()}
+    if case_filter is None:
+        return list(cases_by_id.values())
+
+    requested_case_ids = [case_id.strip() for case_id in case_filter.split(",") if case_id.strip()]
+    if not requested_case_ids:
+        raise ValueError("--cases must include at least one non-empty case ID.")
+
+    unknown_case_ids = [case_id for case_id in requested_case_ids if case_id not in cases_by_id]
+    if unknown_case_ids:
+        raise ValueError(
+            f"Unknown validation case IDs: {unknown_case_ids}. Supported case IDs: {sorted(cases_by_id)}"
+        )
+    return [cases_by_id[case_id] for case_id in requested_case_ids]
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected a top-level mapping in {path}.")
+    return payload
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _set_nested(payload: dict[str, object], path: list[str], value: object) -> None:
+    cursor = payload
+    for key in path[:-1]:
+        next_value = cursor.get(key)
+        if not isinstance(next_value, dict):
+            next_value = {}
+            cursor[key] = next_value
+        cursor = next_value
+    cursor[path[-1]] = value
+
+
+def _build_case_config(
+    *,
+    base_config: dict[str, object],
+    case: ValidationCase,
+    tracking_uri: str,
+    cv_splits: int,
+) -> dict[str, object]:
+    payload = json.loads(json.dumps(base_config))
+    _set_nested(payload, ["competition", "cv", "n_splits"], cv_splits)
+    _set_nested(payload, ["experiment", "tracking", "tracking_uri"], tracking_uri)
+    _set_nested(payload, ["experiment", "submit", "enabled"], False)
+    _set_nested(payload, ["experiment", "runtime", "compute_target"], "gpu")
+    _set_nested(payload, ["experiment", "runtime", "gpu_backend"], case.gpu_backend)
+    _set_nested(payload, ["experiment", "candidate", "candidate_type"], "model")
+    _set_nested(payload, ["experiment", "candidate", "model_family"], case.model_family)
+    _set_nested(
+        payload,
+        ["experiment", "candidate", "numeric_preprocessor"],
+        case.numeric_preprocessor,
+    )
+    _set_nested(
+        payload,
+        ["experiment", "candidate", "categorical_preprocessor"],
+        case.categorical_preprocessor,
+    )
+    _set_nested(payload, ["experiment", "candidate", "model_params"], {})
+    _set_nested(payload, ["experiment", "candidate", "optimization", "enabled"], False)
+    return payload
+
+
+def _run_command(
+    *,
+    command: list[str],
+    stdout_path: Path,
+    stderr_path: Path,
+) -> dict[str, object]:
+    started = time.perf_counter()
+    with stdout_path.open("w", encoding="utf-8") as stdout_handle, stderr_path.open(
+        "w",
+        encoding="utf-8",
+    ) as stderr_handle:
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            text=True,
+            check=False,
+        )
+    return {
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "wall_seconds": time.perf_counter() - started,
+    }
+
+
+def _capture_command(command: list[str]) -> dict[str, object]:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return {
+            "command": command,
+            "returncode": 127,
+            "stdout": "",
+            "stderr": str(exc),
+        }
+
+    return {
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+    }
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib_metadata.version(name)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def _collect_environment_snapshot() -> dict[str, object]:
+    capabilities = detect_runtime_capabilities()
+    return {
+        "validation_path": "repo_owned_install",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "python_version": platform.python_version(),
+        },
+        "runtime_capabilities": capabilities.to_dict(),
+        "package_versions": {name: _package_version(name) for name in PACKAGE_VERSION_NAMES},
+        "uv_version": _capture_command(["uv", "--version"]),
+        "uname": _capture_command(["uname", "-a"]),
+        "os_release": {
+            "path": "/etc/os-release",
+            "content": Path("/etc/os-release").read_text(encoding="utf-8")
+            if Path("/etc/os-release").exists()
+            else None,
+        },
+        "nvidia_smi_summary": _capture_command(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,name,driver_version,memory.total",
+                "--format=csv,noheader,nounits",
+            ]
+        ),
+        "nvidia_smi_full": _capture_command(["nvidia-smi"]),
+    }
+
+
+def _start_gpu_monitor(log_path: Path) -> subprocess.Popen[str] | None:
+    command = [
+        "nvidia-smi",
+        "--query-gpu=timestamp,utilization.gpu,memory.used",
+        "--format=csv,noheader,nounits",
+        "-lms",
+        "500",
+    ]
+    try:
+        handle = log_path.open("w", encoding="utf-8")
+        process = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        handle.close()
+        return process
+    except FileNotFoundError:
+        return None
+
+
+def _stop_gpu_monitor(process: subprocess.Popen[str] | None) -> None:
+    if process is None:
+        return
+    process.terminate()
+    with suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=5)
+        return
+    process.kill()
+    process.wait(timeout=5)
+
+
+def _parse_gpu_samples(path: Path) -> dict[str, float | int | None]:
+    if not path.exists():
+        return {
+            "sample_count": 0,
+            "gpu_util_mean": None,
+            "gpu_util_peak": None,
+            "memory_used_peak_mb": None,
+        }
+
+    gpu_utils: list[float] = []
+    memory_used: list[float] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 3:
+            continue
+        with suppress(ValueError):
+            gpu_utils.append(float(parts[1]))
+            memory_used.append(float(parts[2]))
+    if not gpu_utils:
+        return {
+            "sample_count": 0,
+            "gpu_util_mean": None,
+            "gpu_util_peak": None,
+            "memory_used_peak_mb": None,
+        }
+    return {
+        "sample_count": len(gpu_utils),
+        "gpu_util_mean": sum(gpu_utils) / len(gpu_utils),
+        "gpu_util_peak": max(gpu_utils),
+        "memory_used_peak_mb": max(memory_used) if memory_used else None,
+    }
+
+
+def _find_run(client: MlflowClient, experiment_name: str, candidate_id: str):
+    experiment = client.get_experiment_by_name(experiment_name)
+    if experiment is None:
+        raise ValueError(f"Experiment '{experiment_name}' was not created.")
+    runs = client.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string=f"tags.candidate_id = '{candidate_id}'",
+        max_results=1,
+    )
+    if len(runs) != 1:
+        raise ValueError(f"Expected one run for candidate_id '{candidate_id}', got {len(runs)}.")
+    return runs[0]
+
+
+def _collect_artifact_paths(client: MlflowClient, run_id: str, artifact_path: str = "") -> set[str]:
+    collected: set[str] = set()
+    for entry in client.list_artifacts(run_id, artifact_path):
+        collected.add(entry.path)
+        if entry.is_dir:
+            collected.update(_collect_artifact_paths(client, run_id, entry.path))
+    return collected
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected a JSON object in {path}.")
+    return payload
+
+
+def _download_artifact(client: MlflowClient, run_id: str, artifact_path: str, target_dir: Path) -> Path:
+    return Path(client.download_artifacts(run_id=run_id, path=artifact_path, dst_path=str(target_dir)))
+
+
+def _count_csv_rows(path: Path) -> int:
+    with path.open("r", encoding="utf-8") as handle:
+        row_count = sum(1 for _ in handle)
+    return max(row_count - 1, 0)
+
+
+def _validate_case_result(
+    *,
+    case: ValidationCase,
+    run,
+    manifest: dict[str, object],
+    artifact_paths: set[str],
+    runtime_log_path: Path,
+    oof_predictions_path: Path,
+    test_predictions_path: Path,
+) -> list[str]:
+    failures: list[str] = []
+    tags = run.data.tags
+    params = run.data.params
+    metrics = run.data.metrics
+
+    if run.info.status != "FINISHED":
+        failures.append(f"MLflow run status is {run.info.status}, expected FINISHED.")
+
+    if tags.get("runtime_resolved_compute_target") != "gpu":
+        failures.append(
+            "MLflow tag runtime_resolved_compute_target "
+            f"is {tags.get('runtime_resolved_compute_target')!r}, expected 'gpu'."
+        )
+
+    if tags.get("runtime_resolved_gpu_backend") != case.expected_resolved_gpu_backend:
+        failures.append(
+            "MLflow tag runtime_resolved_gpu_backend "
+            f"is {tags.get('runtime_resolved_gpu_backend')!r}, "
+            f"expected {case.expected_resolved_gpu_backend!r}."
+        )
+
+    if tags.get("runtime_preprocessing_backend") != case.expected_preprocessing_backend:
+        failures.append(
+            "MLflow tag runtime_preprocessing_backend "
+            f"is {tags.get('runtime_preprocessing_backend')!r}, "
+            f"expected {case.expected_preprocessing_backend!r}."
+        )
+
+    if params.get("runtime__gpu_available") != "True":
+        failures.append(
+            f"MLflow param runtime__gpu_available is {params.get('runtime__gpu_available')!r}, expected 'True'."
+        )
+
+    if params.get("runtime__resolved_gpu_backend") != case.expected_resolved_gpu_backend:
+        failures.append(
+            "MLflow param runtime__resolved_gpu_backend "
+            f"is {params.get('runtime__resolved_gpu_backend')!r}, "
+            f"expected {case.expected_resolved_gpu_backend!r}."
+        )
+
+    if params.get("runtime__preprocessing_backend") != case.expected_preprocessing_backend:
+        failures.append(
+            "MLflow param runtime__preprocessing_backend "
+            f"is {params.get('runtime__preprocessing_backend')!r}, "
+            f"expected {case.expected_preprocessing_backend!r}."
+        )
+
+    expected_hooks_value = str(case.expected_rapids_hooks_installed)
+    if params.get("runtime__rapids_hooks_installed") != expected_hooks_value:
+        failures.append(
+            "MLflow param runtime__rapids_hooks_installed "
+            f"is {params.get('runtime__rapids_hooks_installed')!r}, "
+            f"expected {expected_hooks_value!r}."
+        )
+
+    missing_artifacts = sorted(REQUIRED_ARTIFACT_PATHS - artifact_paths)
+    if missing_artifacts:
+        failures.append(f"Missing required MLflow artifacts: {missing_artifacts}")
+
+    if not runtime_log_path.exists() or runtime_log_path.stat().st_size == 0:
+        failures.append("Downloaded logs/runtime.log is missing or empty.")
+
+    if _count_csv_rows(oof_predictions_path) == 0:
+        failures.append("candidate/oof_predictions.csv did not contain any data rows.")
+
+    if _count_csv_rows(test_predictions_path) == 0:
+        failures.append("candidate/test_predictions.csv did not contain any data rows.")
+
+    runtime_execution = manifest.get("runtime_execution")
+    if not isinstance(runtime_execution, dict):
+        failures.append("candidate manifest did not contain runtime_execution metadata.")
+    else:
+        if runtime_execution.get("resolved_compute_target") != "gpu":
+            failures.append(
+                "candidate manifest runtime_execution.resolved_compute_target "
+                f"is {runtime_execution.get('resolved_compute_target')!r}, expected 'gpu'."
+            )
+        if runtime_execution.get("resolved_gpu_backend") != case.expected_resolved_gpu_backend:
+            failures.append(
+                "candidate manifest runtime_execution.resolved_gpu_backend "
+                f"is {runtime_execution.get('resolved_gpu_backend')!r}, "
+                f"expected {case.expected_resolved_gpu_backend!r}."
+            )
+        if runtime_execution.get("rapids_hooks_installed") != case.expected_rapids_hooks_installed:
+            failures.append(
+                "candidate manifest runtime_execution.rapids_hooks_installed "
+                f"is {runtime_execution.get('rapids_hooks_installed')!r}, "
+                f"expected {case.expected_rapids_hooks_installed!r}."
+            )
+
+    if manifest.get("preprocessing_backend") != case.expected_preprocessing_backend:
+        failures.append(
+            "candidate manifest preprocessing_backend "
+            f"is {manifest.get('preprocessing_backend')!r}, "
+            f"expected {case.expected_preprocessing_backend!r}."
+        )
+
+    runtime_profile = manifest.get("runtime_profile")
+    if not isinstance(runtime_profile, dict):
+        failures.append("candidate manifest did not contain runtime_profile.")
+
+    if metrics.get("cv_score_mean") is None:
+        failures.append("MLflow metric cv_score_mean is missing.")
+
+    return failures
+
+
+def _build_bootstrap_result(
+    *,
+    step_id: str,
+    skipped: bool,
+    command_result: dict[str, object] | None = None,
+) -> dict[str, object]:
+    result = {
+        "step_id": step_id,
+        "status": "skipped" if skipped else "passed",
+        "command": None,
+        "returncode": None,
+        "stdout_path": None,
+        "stderr_path": None,
+        "wall_seconds": None,
+    }
+    if command_result is None:
+        return result
+    result.update(command_result)
+    result["status"] = "passed" if command_result["returncode"] == 0 else "failed"
+    return result
+
+
+def _format_float(value: object, digits: int = 3) -> str:
+    if isinstance(value, int | float):
+        return f"{float(value):.{digits}f}"
+    return "-"
+
+
+def _build_markdown_report(session_summary: dict[str, object]) -> str:
+    bootstrap_rows = [
+        "| Step | Status | Wall s |",
+        "| --- | --- | ---: |",
+    ]
+    for bootstrap_result in session_summary["bootstrap"]:
+        bootstrap_rows.append(
+            "| "
+            + " | ".join(
+                [
+                    str(bootstrap_result["step_id"]),
+                    str(bootstrap_result["status"]),
+                    _format_float(bootstrap_result.get("wall_seconds")),
+                ]
+            )
+            + " |"
+        )
+
+    case_rows = [
+        "| Case | Status | Competition | Model | GPU backend | Preprocessing | CV score | GPU util mean | GPU mem peak MB |",
+        "| --- | --- | --- | --- | --- | --- | ---: | ---: | ---: |",
+    ]
+    for case_result in session_summary["cases"]:
+        case_rows.append(
+            "| "
+            + " | ".join(
+                [
+                    str(case_result["case_id"]),
+                    str(case_result["status"]),
+                    str(case_result.get("competition_slug", "-")),
+                    str(case_result.get("model_family", "-")),
+                    str(case_result.get("resolved_gpu_backend", "-")),
+                    str(case_result.get("resolved_preprocessing_backend", "-")),
+                    _format_float(case_result.get("cv_score_mean"), 6),
+                    _format_float(case_result.get("gpu_util_mean")),
+                    _format_float(case_result.get("memory_used_peak_mb"), 1),
+                ]
+            )
+            + " |"
+        )
+
+    environment = session_summary.get("environment") or {}
+    runtime_capabilities = environment.get("runtime_capabilities") or {}
+    package_versions = environment.get("package_versions") or {}
+    nvidia_smi_summary = environment.get("nvidia_smi_summary") or {}
+
+    lines = [
+        "# Target GPU Smoke Validation",
+        "",
+        f"- Generated at: {session_summary['generated_at_utc']}",
+        f"- Validation path: {environment.get('validation_path', 'repo_owned_install')}",
+        f"- Tracking URI root: `{session_summary['tracking_uri']}`",
+        f"- Output directory: `{session_summary['session_dir']}`",
+        "",
+        "## Bootstrap",
+        "",
+        *bootstrap_rows,
+        "",
+        "## Environment",
+        "",
+        f"- Platform: {environment.get('platform', {})}",
+        f"- Runtime capabilities: {runtime_capabilities}",
+        f"- Package versions: {package_versions}",
+        f"- nvidia-smi summary: {nvidia_smi_summary.get('stdout', '-')}",
+        "",
+        "## Cases",
+        "",
+        *case_rows,
+        "",
+        "## Findings",
+        "",
+    ]
+
+    finding_lines: list[str] = []
+    if session_summary.get("fatal_error") is not None:
+        finding_lines.append(f"- Fatal error: {session_summary['fatal_error']}")
+
+    for bootstrap_result in session_summary["bootstrap"]:
+        if bootstrap_result["status"] == "failed":
+            finding_lines.append(
+                "- Bootstrap step "
+                f"`{bootstrap_result['step_id']}` failed with return code {bootstrap_result['returncode']}."
+            )
+
+    for case_result in session_summary["cases"]:
+        failures = case_result.get("failures") or []
+        if failures:
+            finding_lines.append(f"- `{case_result['case_id']}`: {'; '.join(str(item) for item in failures)}")
+
+    if not finding_lines:
+        finding_lines.append("- No validation failures were recorded.")
+
+    lines.extend(finding_lines)
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "- This report covers the target-host install/runtime smoke step for `#193` only.",
+            "- It is intentionally separate from the broader parity/performance audit tracked in `#182`.",
+            "- Until the Linux image path in `#173` lands, this validation runs against the repo-owned host install path.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.cv_splits < 2:
+        raise ValueError("--cv-splits must be >= 2.")
+
+    output_root = Path(args.output_root)
+    session_dir = output_root / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    session_dir.mkdir(parents=True, exist_ok=False)
+    tracking_dir = session_dir / "mlruns"
+    tracking_uri = tracking_dir.resolve().as_uri()
+    cases = _resolve_cases(args.cases)
+    client = MlflowClient(tracking_uri=tracking_uri)
+    template_cache: dict[Path, dict[str, object]] = {}
+    original_config_text = CONFIG_PATH.read_text(encoding="utf-8") if CONFIG_PATH.exists() else None
+    fatal_error: str | None = None
+    bootstrap_results: list[dict[str, object]] = []
+    case_results: list[dict[str, object]] = []
+    environment_snapshot: dict[str, object] | None = None
+
+    try:
+        bootstrap_dir = session_dir / "bootstrap"
+        bootstrap_dir.mkdir()
+
+        if args.skip_sync:
+            bootstrap_results.append(_build_bootstrap_result(step_id="uv_sync", skipped=True))
+        else:
+            sync_result = _run_command(
+                command=["uv", "sync", "--extra", "boosters", "--extra", "gpu"],
+                stdout_path=bootstrap_dir / "uv_sync.stdout.log",
+                stderr_path=bootstrap_dir / "uv_sync.stderr.log",
+            )
+            bootstrap_results.append(
+                _build_bootstrap_result(step_id="uv_sync", skipped=False, command_result=sync_result)
+            )
+            if sync_result["returncode"] != 0:
+                fatal_error = "uv sync failed; target-host validation could not continue."
+
+        if fatal_error is None:
+            if args.skip_lightgbm_install:
+                bootstrap_results.append(
+                    _build_bootstrap_result(step_id="lightgbm_cuda_install", skipped=True)
+                )
+            else:
+                lightgbm_result = _run_command(
+                    command=["bash", "scripts/install_lightgbm_cuda.sh"],
+                    stdout_path=bootstrap_dir / "lightgbm_cuda_install.stdout.log",
+                    stderr_path=bootstrap_dir / "lightgbm_cuda_install.stderr.log",
+                )
+                bootstrap_results.append(
+                    _build_bootstrap_result(
+                        step_id="lightgbm_cuda_install",
+                        skipped=False,
+                        command_result=lightgbm_result,
+                    )
+                )
+
+        environment_snapshot = _collect_environment_snapshot()
+
+        if fatal_error is None:
+            for case in cases:
+                case_dir = session_dir / case.case_id
+                case_dir.mkdir()
+                base_config = template_cache.get(case.template_config_path)
+                if base_config is None:
+                    base_config = _load_yaml(case.template_config_path)
+                    template_cache[case.template_config_path] = base_config
+
+                case_config = _build_case_config(
+                    base_config=base_config,
+                    case=case,
+                    tracking_uri=tracking_uri,
+                    cv_splits=args.cv_splits,
+                )
+                _write_yaml(CONFIG_PATH, case_config)
+                resolved_config = load_config(str(CONFIG_PATH))
+                gpu_log_path = case_dir / "gpu_samples.csv"
+                monitor = _start_gpu_monitor(gpu_log_path)
+
+                command_result: dict[str, object]
+                started = time.perf_counter()
+                try:
+                    command_result = _run_command(
+                        command=["uv", "run", "python", "main.py", "train"],
+                        stdout_path=case_dir / "train.stdout.log",
+                        stderr_path=case_dir / "train.stderr.log",
+                    )
+                finally:
+                    _stop_gpu_monitor(monitor)
+
+                gpu_metrics = _parse_gpu_samples(gpu_log_path)
+                case_result = {
+                    "case_id": case.case_id,
+                    "notes": case.notes,
+                    "status": "passed" if command_result["returncode"] == 0 else "failed",
+                    "task_type": resolved_config.competition.task_type,
+                    "competition_slug": resolved_config.competition.slug,
+                    "feature_recipe_id": resolved_config.experiment.candidate.feature_recipe_id,
+                    "model_family": case.model_family,
+                    "numeric_preprocessor": case.numeric_preprocessor,
+                    "categorical_preprocessor": case.categorical_preprocessor,
+                    "requested_gpu_backend": case.gpu_backend,
+                    "expected_resolved_gpu_backend": case.expected_resolved_gpu_backend,
+                    "expected_preprocessing_backend": case.expected_preprocessing_backend,
+                    "candidate_id": resolved_config.resolved_candidate_id,
+                    "process_wall_seconds": time.perf_counter() - started,
+                    "stdout_path": command_result["stdout_path"],
+                    "stderr_path": command_result["stderr_path"],
+                    "returncode": command_result["returncode"],
+                    "failures": [],
+                    **gpu_metrics,
+                }
+
+                if command_result["returncode"] != 0:
+                    case_result["failures"] = [
+                        "Training command failed. See stdout/stderr logs in the case directory."
+                    ]
+                    case_results.append(case_result)
+                    continue
+
+                try:
+                    run = _find_run(
+                        client=client,
+                        experiment_name=resolved_config.competition.slug,
+                        candidate_id=resolved_config.resolved_candidate_id,
+                    )
+                    artifact_paths = _collect_artifact_paths(client=client, run_id=run.info.run_id)
+                    downloads_dir = case_dir / "downloaded"
+                    downloads_dir.mkdir()
+                    manifest_path = _download_artifact(
+                        client=client,
+                        run_id=run.info.run_id,
+                        artifact_path="candidate/candidate.json",
+                        target_dir=downloads_dir,
+                    )
+                    runtime_log_path = _download_artifact(
+                        client=client,
+                        run_id=run.info.run_id,
+                        artifact_path="logs/runtime.log",
+                        target_dir=downloads_dir,
+                    )
+                    oof_predictions_path = _download_artifact(
+                        client=client,
+                        run_id=run.info.run_id,
+                        artifact_path="candidate/oof_predictions.csv",
+                        target_dir=downloads_dir,
+                    )
+                    test_predictions_path = _download_artifact(
+                        client=client,
+                        run_id=run.info.run_id,
+                        artifact_path="candidate/test_predictions.csv",
+                        target_dir=downloads_dir,
+                    )
+                    manifest = _read_json(manifest_path)
+                    failures = _validate_case_result(
+                        case=case,
+                        run=run,
+                        manifest=manifest,
+                        artifact_paths=artifact_paths,
+                        runtime_log_path=runtime_log_path,
+                        oof_predictions_path=oof_predictions_path,
+                        test_predictions_path=test_predictions_path,
+                    )
+                    case_result.update(
+                        {
+                            "run_id": run.info.run_id,
+                            "mlflow_status": run.info.status,
+                            "resolved_gpu_backend": run.data.tags.get("runtime_resolved_gpu_backend"),
+                            "resolved_preprocessing_backend": run.data.tags.get(
+                                "runtime_preprocessing_backend"
+                            ),
+                            "cv_score_mean": run.data.metrics.get("cv_score_mean"),
+                            "artifact_paths": sorted(artifact_paths),
+                            "failures": failures,
+                        }
+                    )
+                    if failures:
+                        case_result["status"] = "failed"
+                except Exception as exc:
+                    case_result["status"] = "failed"
+                    case_result["failures"] = [str(exc)]
+
+                case_results.append(case_result)
+    except Exception as exc:
+        fatal_error = str(exc)
+    finally:
+        if original_config_text is None:
+            with suppress(FileNotFoundError):
+                CONFIG_PATH.unlink()
+        else:
+            CONFIG_PATH.write_text(original_config_text, encoding="utf-8")
+
+    session_summary = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "tracking_uri": tracking_uri,
+        "session_dir": str(session_dir),
+        "bootstrap": bootstrap_results,
+        "environment": environment_snapshot,
+        "cases": case_results,
+        "fatal_error": fatal_error,
+    }
+    summary_path = session_dir / "validation_summary.json"
+    report_path = session_dir / "validation_report.md"
+    summary_path.write_text(
+        json.dumps(session_summary, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    report_path.write_text(_build_markdown_report(session_summary), encoding="utf-8")
+
+    print(json.dumps(session_summary, indent=2, sort_keys=True))
+    print(f"Validation report: {report_path}")
+
+    any_bootstrap_failures = any(result["status"] == "failed" for result in bootstrap_results)
+    any_case_failures = any(case_result["status"] != "passed" for case_result in case_results)
+    if fatal_error is not None or any_bootstrap_failures or any_case_failures:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tabular_shenanigans/gpu_cuml_preprocess.py
+++ b/src/tabular_shenanigans/gpu_cuml_preprocess.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import pandas as pd
+from sklearn.preprocessing import KBinsDiscretizer as SklearnKBinsDiscretizer
 
 from tabular_shenanigans.preprocess import ResolvedFeatureSchema
 
@@ -49,7 +50,53 @@ class _ResolvedNumericGpuTransformers:
     post_imputer_transformer: object | None
 
 
+def _build_gpu_kbins_discretizer(kbins_discretizer_class: type[object]) -> object:
+    try:
+        return kbins_discretizer_class(
+            n_bins=5,
+            encode="onehot-dense",
+            strategy="quantile",
+            quantile_method="averaged_inverted_cdf",
+        )
+    except TypeError as exc:
+        if "quantile_method" not in str(exc):
+            raise
+        return kbins_discretizer_class(
+            n_bins=5,
+            encode="onehot-dense",
+            strategy="quantile",
+        )
+
+
+def _fit_kbins_transformer(imputed_numeric: object, kbins_discretizer_class: type[object]) -> tuple[object, object]:
+    post_imputer_transformer = _build_gpu_kbins_discretizer(kbins_discretizer_class)
+    try:
+        transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
+    except TypeError as exc:
+        if "Implicit conversion to a NumPy array is not allowed" not in str(exc):
+            raise
+        cpu_kbins = SklearnKBinsDiscretizer(
+            n_bins=5,
+            encode="onehot-dense",
+            strategy="quantile",
+            quantile_method="averaged_inverted_cdf",
+        )
+        cpu_input = imputed_numeric.to_pandas() if hasattr(imputed_numeric, "to_pandas") else imputed_numeric
+        transformed_numeric = cpu_kbins.fit_transform(cpu_input)
+        return cpu_kbins, transformed_numeric
+    return post_imputer_transformer, transformed_numeric
+
+
+def _transform_kbins_values(post_imputer_transformer: object, imputed_numeric: object) -> object:
+    if type(post_imputer_transformer).__module__.startswith("sklearn"):
+        cpu_input = imputed_numeric.to_pandas() if hasattr(imputed_numeric, "to_pandas") else imputed_numeric
+        return post_imputer_transformer.transform(cpu_input)
+    return post_imputer_transformer.transform(imputed_numeric)
+
+
 class GpuCumlDensePreprocessor:
+    CATEGORICAL_MISSING_VALUE = "__missing__"
+
     def __init__(
         self,
         feature_schema: ResolvedFeatureSchema,
@@ -60,7 +107,7 @@ class GpuCumlDensePreprocessor:
         self.numeric_preprocessor_id = numeric_preprocessor_id
         self.categorical_preprocessor_id = categorical_preprocessor_id
         self.numeric_transformers: _ResolvedNumericGpuTransformers | None = None
-        self.categorical_imputer: object | None = None
+        self.categorical_fill_values: dict[str, object] | None = None
         self.categorical_encoder: object | None = None
 
     def _fit_numeric(self, frame: pd.DataFrame) -> object | None:
@@ -77,13 +124,10 @@ class GpuCumlDensePreprocessor:
             post_imputer_transformer = StandardScaler()
             transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
         elif self.numeric_preprocessor_id == "kbins":
-            post_imputer_transformer = KBinsDiscretizer(
-                n_bins=5,
-                encode="onehot-dense",
-                strategy="quantile",
-                quantile_method="averaged_inverted_cdf",
+            post_imputer_transformer, transformed_numeric = _fit_kbins_transformer(
+                imputed_numeric,
+                KBinsDiscretizer,
             )
-            transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
 
         self.numeric_transformers = _ResolvedNumericGpuTransformers(
             imputer=numeric_imputer,
@@ -94,13 +138,24 @@ class GpuCumlDensePreprocessor:
     def _fit_categorical(self, frame: pd.DataFrame) -> object | None:
         if not self.feature_schema.categorical_columns:
             return None
-        _, cudf, SimpleImputer, _, OneHotEncoder, _ = _import_gpu_preprocessing_modules()
-        categorical_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.categorical_columns])
-        categorical_imputer = SimpleImputer(strategy="most_frequent")
-        imputed_categorical = categorical_imputer.fit_transform(categorical_frame)
+        _, cudf, _, _, OneHotEncoder, _ = _import_gpu_preprocessing_modules()
+        categorical_fill_values: dict[str, object] = {}
+        filled_categorical_frame = frame.loc[:, self.feature_schema.categorical_columns].astype(object).copy()
+        for column in self.feature_schema.categorical_columns:
+            non_null_values = filled_categorical_frame[column].dropna()
+            fill_value = self.CATEGORICAL_MISSING_VALUE
+            if not non_null_values.empty:
+                fill_value = non_null_values.mode(dropna=True).iloc[0]
+            categorical_fill_values[column] = fill_value
+            filled_categorical_frame[column] = filled_categorical_frame[column].where(
+                filled_categorical_frame[column].notna(),
+                fill_value,
+            )
+
+        categorical_frame = cudf.from_pandas(filled_categorical_frame)
         categorical_encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
-        transformed_categorical = categorical_encoder.fit_transform(imputed_categorical)
-        self.categorical_imputer = categorical_imputer
+        transformed_categorical = categorical_encoder.fit_transform(categorical_frame)
+        self.categorical_fill_values = categorical_fill_values
         self.categorical_encoder = categorical_encoder
         return _to_cupy_dense(transformed_categorical)
 
@@ -118,18 +173,31 @@ class GpuCumlDensePreprocessor:
         numeric_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.numeric_columns]).astype("float64")
         transformed_numeric = self.numeric_transformers.imputer.transform(numeric_frame)
         if self.numeric_transformers.post_imputer_transformer is not None:
-            transformed_numeric = self.numeric_transformers.post_imputer_transformer.transform(transformed_numeric)
+            if self.numeric_preprocessor_id == "kbins":
+                transformed_numeric = _transform_kbins_values(
+                    self.numeric_transformers.post_imputer_transformer,
+                    transformed_numeric,
+                )
+            else:
+                transformed_numeric = self.numeric_transformers.post_imputer_transformer.transform(
+                    transformed_numeric
+                )
         return _to_cupy_dense(transformed_numeric)
 
     def _transform_categorical(self, frame: pd.DataFrame) -> object | None:
         if not self.feature_schema.categorical_columns:
             return None
-        if self.categorical_imputer is None or self.categorical_encoder is None:
+        if self.categorical_fill_values is None or self.categorical_encoder is None:
             raise ValueError("Categorical GPU preprocessing must be fit before transform.")
         _, cudf, _, _, _, _ = _import_gpu_preprocessing_modules()
-        categorical_frame = cudf.from_pandas(frame.loc[:, self.feature_schema.categorical_columns])
-        transformed_categorical = self.categorical_imputer.transform(categorical_frame)
-        transformed_categorical = self.categorical_encoder.transform(transformed_categorical)
+        filled_categorical_frame = frame.loc[:, self.feature_schema.categorical_columns].astype(object).copy()
+        for column, fill_value in self.categorical_fill_values.items():
+            filled_categorical_frame[column] = filled_categorical_frame[column].where(
+                filled_categorical_frame[column].notna(),
+                fill_value,
+            )
+        categorical_frame = cudf.from_pandas(filled_categorical_frame)
+        transformed_categorical = self.categorical_encoder.transform(categorical_frame)
         return _to_cupy_dense(transformed_categorical)
 
     def transform(self, frame: pd.DataFrame):

--- a/src/tabular_shenanigans/preprocess.py
+++ b/src/tabular_shenanigans/preprocess.py
@@ -346,7 +346,7 @@ def _build_categorical_onehot_preprocessor(matrix_output_kind: MatrixOutputKind)
     sparse_output = matrix_output_kind == "sparse_csr"
     return Pipeline(
         steps=[
-            ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
+            ("coerce_object", FunctionTransformer(_coerce_object)),
             ("imputer", SimpleImputer(strategy="most_frequent")),
             ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=sparse_output)),
         ]
@@ -357,7 +357,7 @@ def _build_categorical_ordinal_preprocessor(matrix_output_kind: MatrixOutputKind
     del matrix_output_kind
     return Pipeline(
         steps=[
-            ("coerce_object", FunctionTransformer(_coerce_object, feature_names_out="one-to-one")),
+            ("coerce_object", FunctionTransformer(_coerce_object)),
             ("imputer", SimpleImputer(strategy="most_frequent")),
             (
                 "ordinal",


### PR DESCRIPTION
## Summary
- add the #193 target-host GPU smoke validation harness and docs/reporting contract
- harden the repo-owned LightGBM CUDA install path and the example binary config for the target-machine run
- fix the preprocessing compatibility issues uncovered on the target L4 host so the full supported GPU matrix runs end-to-end

## Verification
- `uv run python -m py_compile src/tabular_shenanigans/preprocess.py src/tabular_shenanigans/gpu_cuml_preprocess.py scripts/validate_gpu_target_matrix.py`
- Remote target host on March 16, 2026: `ssh -o StrictHostKeyChecking=no ubuntu@217.18.55.46`
- Remote environment: Ubuntu 22.04.5, NVIDIA L4, driver 570.211.01, CUDA 12.8, Python 3.13.12, `uv 0.10.10`
- `uv run python scripts/validate_gpu_target_matrix.py`
- Final all-pass report: `/home/ubuntu/TabularShenanigans-issue193/reports/gpu_target_validation/20260316T121621Z/validation_report.md`
- Final all-pass matrix cases:
  - `binary_logistic_native_frequency_standardize`
  - `binary_logistic_patch_frequency_kbins`
  - `binary_xgboost_native_frequency_standardize`
  - `binary_xgboost_patch_ordinal_kbins`
  - `binary_catboost_native_native_median`
  - `regression_ridge_native_frequency_standardize`
  - `regression_elasticnet_native_frequency_standardize`
  - `binary_random_forest_native_onehot_kbins`
  - `regression_random_forest_native_frequency_standardize`
  - `regression_lightgbm_native_onehot_median`

Closes #193
