### PR TITLE
CPU-fallback unregistered GPU combos under compute_target=gpu

### DIFF
--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -256,13 +256,6 @@ def resolve_model_candidate_runtime_execution(
             rapids_hooks_installed=False,
         )
 
-    if requested_compute_target == "gpu":
-        raise RuntimeError(
-            "Configured experiment.runtime.compute_target='gpu' but no supported GPU implementation is "
-            f"registered for {format_model_execution_routing_key(routing_key)}. "
-            f"Reason: {describe_missing_gpu_implementation(routing_key)}"
-        )
-
     return RuntimeExecutionContext(
         requested_compute_target=requested_compute_target,
         resolved_compute_target="cpu",


### PR DESCRIPTION
## Summary

- `compute_target=gpu` previously raised `RuntimeError` for any candidate combination not registered in `GPU_SUPPORT_REGISTRY`, even when GPU hardware was present and CPU could handle the candidate.
- Now those unregistered combos CPU-fallback (with `fallback_reason` set) instead of failing, which matches the expected behavior: every combination runs at minimum on CPU; a registered subset gets GPU acceleration.

## Affected combinations (from the reported config)

| Combination | Status |
|---|---|
| `logistic_regression + standardize + onehot` | not in registry → was error, now CPU |
| `logistic_regression + kbins + onehot` | not in registry → was error, now CPU |
| `random_forest + median + ordinal` | not in registry → was error, now CPU |
| `xgboost + median + ordinal` | registered (gpu_patch) → unchanged |
| `lightgbm + median + ordinal` | registered (gpu_native) → unchanged |
| `catboost + median + native` | registered (gpu_native) → unchanged |

## Guard rails preserved

- `compute_target=gpu` + **GPU hardware unavailable** → still hard-errors in `resolve_runtime_execution`
- `gpu_backend=native` + combo without native impl → still hard-errors
- `gpu_backend=patch` + combo without patch impl → still hard-errors

## Change

Seven lines deleted from `resolve_model_candidate_runtime_execution` in `execution_routing.py`: the `if requested_compute_target == "gpu": raise RuntimeError(...)` branch is removed; the existing CPU-fallback `return` below it now handles all unregistered combos uniformly.

## Verification

Traced routing logic for all three failing combinations: each reaches the final `return RuntimeExecutionContext(resolved_compute_target="cpu", ...)` block with `fallback_reason=describe_missing_gpu_implementation(routing_key)`.

Closes #201