### PR TITLE
Register dense-input GPU combos missing from GPU_SUPPORT_REGISTRY

### DIFF
--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -70,6 +70,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     )
     _register_model_paths(
         registry,
+        task_types=("binary",),
+        model_family="logistic_regression",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("ordinal",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
         task_types=("regression",),
         model_family="ridge",
         numeric_preprocessors=("median", "standardize"),
@@ -79,8 +87,40 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     _register_model_paths(
         registry,
         task_types=("regression",),
+        model_family="ridge",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("ordinal",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("regression",),
+        model_family="ridge",
+        numeric_preprocessors=("kbins",),
+        categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("regression",),
         model_family="elasticnet",
         numeric_preprocessors=("median", "standardize"),
+        categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("regression",),
+        model_family="elasticnet",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("ordinal",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("regression",),
+        model_family="elasticnet",
+        numeric_preprocessors=("kbins",),
         categorical_preprocessors=("frequency",),
         gpu_paths=(NATIVE_GPU_BACKEND,),
     )
@@ -96,8 +136,16 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
         registry,
         task_types=("binary", "regression"),
         model_family="random_forest",
-        numeric_preprocessors=("median", "standardize"),
+        numeric_preprocessors=("median", "standardize", "kbins"),
         categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
+        model_family="random_forest",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("ordinal",),
         gpu_paths=(NATIVE_GPU_BACKEND,),
     )
     _register_model_paths(


### PR DESCRIPTION
## Summary

- Adds 19 missing `(task_type, model_family, numeric, categorical)` registry entries to `GPU_SUPPORT_REGISTRY` — all combinations that produce dense array output and route to already-integrated cuML model builders.
- Registry grows from 53 → 72 entries.

## New entries

| Family | Task | Numeric | Categorical | GPU path |
|---|---|---|---|---|
| logistic_regression | binary | median/standardize/kbins | ordinal | gpu_native |
| ridge | regression | median/standardize/kbins | ordinal | gpu_native |
| ridge | regression | kbins | frequency | gpu_native |
| elasticnet | regression | median/standardize/kbins | ordinal | gpu_native |
| elasticnet | regression | kbins | frequency | gpu_native |
| random_forest | binary+regression | median/standardize/kbins | ordinal | gpu_native |
| random_forest | binary+regression | kbins | frequency | gpu_native |

## Why no code changes beyond the registry

- Ordinal encoding always emits a dense float64 numpy array → cuML accepts it directly.
- kbins + frequency falls through `preprocess_execution.py` to `CPU_FREQUENCY_PREPROCESSING_BACKEND` (sklearn pipeline → numpy array) → cuML accepts it.
- `_coerce_processed_matrix` passes dense numpy through as `np.asarray()` when `model_compute_target == "gpu"`.
- `_build_logreg`, `_build_ridge`, `_build_elasticnet`, `_build_random_forest_*` already switch to cuML when `resolved_gpu_backend == gpu_native`.

## Remaining gaps (tracked in #203)

- logistic_regression / ridge / elasticnet × onehot: sparse_csr output, cuML can't consume sparse
- xgboost × onehot: XGBoost GPU can consume sparse, separate investigation needed

Closes #203