### PR TITLE
Register GPU support for linear models with onehot categorical

### DIFF
--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -78,6 +78,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     )
     _register_model_paths(
         registry,
+        task_types=("binary",),
+        model_family="logistic_regression",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("onehot",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
         task_types=("regression",),
         model_family="ridge",
         numeric_preprocessors=("median", "standardize"),
@@ -103,6 +111,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     _register_model_paths(
         registry,
         task_types=("regression",),
+        model_family="ridge",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("onehot",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("regression",),
         model_family="elasticnet",
         numeric_preprocessors=("median", "standardize"),
         categorical_preprocessors=("frequency",),
@@ -122,6 +138,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
         model_family="elasticnet",
         numeric_preprocessors=("kbins",),
         categorical_preprocessors=("frequency",),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("regression",),
+        model_family="elasticnet",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("onehot",),
         gpu_paths=(NATIVE_GPU_BACKEND,),
     )
     _register_model_paths(

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -1113,12 +1113,14 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="Ridge",
             builder=_build_ridge,
             supports_sparse_preprocessed_input=True,
+            supports_gpu_native_dense_onehot_input=True,
         ),
         "elasticnet": ModelDefinition(
             model_id="elasticnet",
             model_name="ElasticNet",
             builder=_build_elasticnet,
             supports_sparse_preprocessed_input=True,
+            supports_gpu_native_dense_onehot_input=True,
         ),
         "random_forest": ModelDefinition(
             model_id="random_forest",
@@ -1172,6 +1174,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             builder=_build_logreg,
             tuning_space_builder=_build_logreg_tuning_space,
             supports_sparse_preprocessed_input=True,
+            supports_gpu_native_dense_onehot_input=True,
         ),
         "random_forest": ModelDefinition(
             model_id="random_forest",


### PR DESCRIPTION
Closes #205

## Changes

- `execution_routing.py`: registered 9 new combos (`logistic_regression`, `ridge`, `elasticnet` × `median`/`standardize`/`kbins` × `onehot`) with `NATIVE_GPU_BACKEND`
- `models.py`: added `supports_gpu_native_dense_onehot_input=True` to `ridge`, `elasticnet` (regression), and `logistic_regression` (binary)

## How it works

`resolve_model_matrix_output_kind` checks `supports_gpu_native_dense_onehot_input` to return `dense_array` for GPU+onehot. `resolve_preprocessing_execution_plan` then routes to `GpuCumlDensePreprocessor`, which already uses `OneHotEncoder(sparse_output=False)` — no sparse/dense issue.

## Verification

```
$ PYTHONPATH=src .venv/bin/python -c "..."
OK: ('binary', 'logistic_regression', 'median', 'onehot')
OK: ('binary', 'logistic_regression', 'standardize', 'onehot')
OK: ('binary', 'logistic_regression', 'kbins', 'onehot')
OK: ('regression', 'ridge', 'median', 'onehot')
OK: ('regression', 'ridge', 'standardize', 'onehot')
OK: ('regression', 'ridge', 'kbins', 'onehot')
OK: ('regression', 'elasticnet', 'median', 'onehot')
OK: ('regression', 'elasticnet', 'standardize', 'onehot')
OK: ('regression', 'elasticnet', 'kbins', 'onehot')
```

All 9 combos resolve to `NATIVE_GPU_BACKEND` and `dense_array` matrix output kind.