### PR TITLE
Register xgboost onehot GPU combos in GPU_SUPPORT_REGISTRY

### DIFF
--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -199,6 +199,14 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
     _register_model_paths(
         registry,
         task_types=("binary", "regression"),
+        model_family="xgboost",
+        numeric_preprocessors=("median", "standardize", "kbins"),
+        categorical_preprocessors=("onehot",),
+        gpu_paths=(PATCH_GPU_BACKEND,),
+    )
+    _register_model_paths(
+        registry,
+        task_types=("binary", "regression"),
         model_family="catboost",
         numeric_preprocessors=("median", "standardize", "kbins"),
         categorical_preprocessors=("native",),


### PR DESCRIPTION
## Summary

- Adds 6 missing xgboost entries to `GPU_SUPPORT_REGISTRY`: `binary`+`regression` × `median`/`standardize`/`kbins` × `onehot`, all with `gpu_patch` backend
- The `ordinal` combinations for `median`/`standardize` mentioned in the issue were already covered by a prior entry (lines 183–190)
- `compute_target=gpu` no longer falls back to CPU for these combos

## Verification

Confirmed all 10 combos from the issue are registered:
- 6 onehot combos now return `('gpu_patch',)`
- 4 ordinal combos (median/standardize) were already returning `('gpu_patch',)` from the existing entry

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)