### PR TITLE
Fix validation harness for multi-candidate schema + add #205 cases

### DIFF
--- a/scripts/validate_gpu_target_matrix.py
+++ b/scripts/validate_gpu_target_matrix.py
@@ -252,27 +252,8 @@ def _default_cases() -> list[ValidationCase]:
             expected_preprocessing_backend="gpu_cuml",
             notes="Validates #205 — elasticnet onehot registered in GPU_SUPPORT_REGISTRY.",
         ),
-        # #206: xgboost with onehot categorical
-        ValidationCase(
-            case_id="binary_xgboost_patch_onehot_standardize",
-            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
-            model_family="xgboost",
-            numeric_preprocessor="standardize",
-            categorical_preprocessor="onehot",
-            gpu_backend="patch",
-            expected_preprocessing_backend="gpu_patch",
-            notes="Validates #206 — xgboost onehot registered in GPU_SUPPORT_REGISTRY.",
-        ),
-        ValidationCase(
-            case_id="regression_xgboost_patch_onehot_kbins",
-            template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
-            model_family="xgboost",
-            numeric_preprocessor="kbins",
-            categorical_preprocessor="onehot",
-            gpu_backend="patch",
-            expected_preprocessing_backend="gpu_patch",
-            notes="Validates #206 — xgboost onehot registered in GPU_SUPPORT_REGISTRY.",
-        ),
+        # #206 xgboost+onehot cases intentionally omitted: registry entries will be removed
+        # in #209 (sparse CSR / XGBoost GPU incompatibility).
     ]
 
 


### PR DESCRIPTION
## Summary

- Fixes `_build_case_config` to write `experiment.candidates` (list) instead of `experiment.candidate` (singular), matching the schema change from #200 — without this fix every case failed with a Pydantic validation error
- Resolves `uv` as a full path via `shutil.which` + `~/.local/bin` fallback, fixing execution on the GPU target host where `uv` is not on the subprocess `PATH`
- Adds 3 smoke cases for #205 (`logistic_regression`, `ridge`, `elasticnet` with `onehot` categorical), all verified passing on the GPU host (NVIDIA L4, CUDA 12.8, cuml 26.2.0)

## Verification

GPU host run 2026-03-16:

| Case | GPU backend | Preprocessing | CV score | Status |
| --- | --- | --- | --- | --- |
| binary_logistic_native_onehot_standardize | gpu_native | gpu_cuml | 0.6944 | ✅ passed |
| regression_ridge_native_onehot_kbins | gpu_native | gpu_cuml | 0.0042 | ✅ passed |
| regression_elasticnet_native_onehot_median | gpu_native | gpu_cuml | 0.0236 | ✅ passed |

#206 xgboost+onehot combos were tested and found broken (sparse CSR / XGBoost GPU incompatibility). Tracked separately in #209 — those cases are excluded from the harness until #209 is resolved.

Closes #205