### PR TITLE
Extend gpu_native_frequency preprocessor to support kbins (#212)

### DIFF
--- a/scripts/validate_gpu_target_matrix.py
+++ b/scripts/validate_gpu_target_matrix.py
@@ -254,6 +254,27 @@ def _default_cases() -> list[ValidationCase]:
         ),
         # #206 xgboost+onehot cases intentionally omitted: registry entries will be removed
         # in #209 (sparse CSR / XGBoost GPU incompatibility).
+        # #212: frequency + kbins on gpu_native
+        ValidationCase(
+            case_id="regression_ridge_native_frequency_kbins",
+            template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
+            model_family="ridge",
+            numeric_preprocessor="kbins",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates #212 — frequency+kbins on gpu_native routes to gpu_native_frequency.",
+        ),
+        ValidationCase(
+            case_id="binary_random_forest_native_frequency_kbins",
+            template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
+            model_family="random_forest",
+            numeric_preprocessor="kbins",
+            categorical_preprocessor="frequency",
+            gpu_backend="native",
+            expected_preprocessing_backend="gpu_native_frequency",
+            notes="Validates #212 — frequency+kbins on gpu_native for binary classification.",
+        ),
     ]
 
 

--- a/src/tabular_shenanigans/gpu_cuml_preprocess.py
+++ b/src/tabular_shenanigans/gpu_cuml_preprocess.py
@@ -50,7 +50,7 @@ class _ResolvedNumericGpuTransformers:
     post_imputer_transformer: object | None
 
 
-def _build_gpu_kbins_discretizer(kbins_discretizer_class: type[object]) -> object:
+def build_gpu_kbins_discretizer(kbins_discretizer_class: type[object]) -> object:
     try:
         return kbins_discretizer_class(
             n_bins=5,
@@ -68,8 +68,8 @@ def _build_gpu_kbins_discretizer(kbins_discretizer_class: type[object]) -> objec
         )
 
 
-def _fit_kbins_transformer(imputed_numeric: object, kbins_discretizer_class: type[object]) -> tuple[object, object]:
-    post_imputer_transformer = _build_gpu_kbins_discretizer(kbins_discretizer_class)
+def fit_kbins_transformer(imputed_numeric: object, kbins_discretizer_class: type[object]) -> tuple[object, object]:
+    post_imputer_transformer = build_gpu_kbins_discretizer(kbins_discretizer_class)
     try:
         transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
     except TypeError as exc:
@@ -87,7 +87,7 @@ def _fit_kbins_transformer(imputed_numeric: object, kbins_discretizer_class: typ
     return post_imputer_transformer, transformed_numeric
 
 
-def _transform_kbins_values(post_imputer_transformer: object, imputed_numeric: object) -> object:
+def transform_kbins_values(post_imputer_transformer: object, imputed_numeric: object) -> object:
     if type(post_imputer_transformer).__module__.startswith("sklearn"):
         cpu_input = imputed_numeric.to_pandas() if hasattr(imputed_numeric, "to_pandas") else imputed_numeric
         return post_imputer_transformer.transform(cpu_input)
@@ -124,7 +124,7 @@ class GpuCumlDensePreprocessor:
             post_imputer_transformer = StandardScaler()
             transformed_numeric = post_imputer_transformer.fit_transform(imputed_numeric)
         elif self.numeric_preprocessor_id == "kbins":
-            post_imputer_transformer, transformed_numeric = _fit_kbins_transformer(
+            post_imputer_transformer, transformed_numeric = fit_kbins_transformer(
                 imputed_numeric,
                 KBinsDiscretizer,
             )
@@ -174,7 +174,7 @@ class GpuCumlDensePreprocessor:
         transformed_numeric = self.numeric_transformers.imputer.transform(numeric_frame)
         if self.numeric_transformers.post_imputer_transformer is not None:
             if self.numeric_preprocessor_id == "kbins":
-                transformed_numeric = _transform_kbins_values(
+                transformed_numeric = transform_kbins_values(
                     self.numeric_transformers.post_imputer_transformer,
                     transformed_numeric,
                 )

--- a/src/tabular_shenanigans/gpu_preprocess.py
+++ b/src/tabular_shenanigans/gpu_preprocess.py
@@ -2,9 +2,10 @@ from dataclasses import dataclass
 
 import pandas as pd
 
+from tabular_shenanigans.gpu_cuml_preprocess import fit_kbins_transformer, transform_kbins_values
 from tabular_shenanigans.preprocess import ResolvedFeatureSchema
 
-SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS = frozenset({"median", "standardize"})
+SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS = frozenset({"median", "standardize", "kbins"})
 SUPPORTED_GPU_NATIVE_CATEGORICAL_PREPROCESSOR_IDS = frozenset({"frequency"})
 
 
@@ -42,6 +43,7 @@ class GpuNativeFrequencyPreprocessor:
         self.numeric_preprocessor_id = numeric_preprocessor_id
         self.numeric_statistics = _ResolvedNumericStatistics(medians={}, means={}, scales={})
         self.category_frequencies: dict[str, dict[str, float]] = {}
+        self.kbins_transformer: object | None = None
 
     def _normalize_numeric_frame(self, frame: pd.DataFrame):
         cudf = _import_cudf()
@@ -82,6 +84,22 @@ class GpuNativeFrequencyPreprocessor:
                 means[column] = mean_float
                 scales[column] = scale_float
 
+        if self.numeric_preprocessor_id == "kbins" and self.numeric_columns:
+            try:
+                from cuml.preprocessing import KBinsDiscretizer
+            except ImportError as exc:
+                raise RuntimeError(
+                    "gpu_native kbins preprocessing requires the optional GPU dependencies. "
+                    "Install them with `uv sync --extra boosters --extra gpu`."
+                ) from exc
+            cudf = _import_cudf()
+            imputed_numeric_frame = cudf.from_pandas(
+                frame.loc[:, self.numeric_columns]
+            ).astype("float64")
+            for column in self.numeric_columns:
+                imputed_numeric_frame[column] = imputed_numeric_frame[column].fillna(medians[column])
+            self.kbins_transformer, _ = fit_kbins_transformer(imputed_numeric_frame, KBinsDiscretizer)
+
         categorical_frame = self._normalize_categorical_frame(frame)
         for column in self.categorical_columns:
             value_frequencies = categorical_frame[column].value_counts(normalize=True, dropna=False)
@@ -101,6 +119,15 @@ class GpuNativeFrequencyPreprocessor:
         cudf = _import_cudf()
         if not self.numeric_columns:
             return cudf.DataFrame(index=frame.index)
+
+        if self.numeric_preprocessor_id == "kbins":
+            if self.kbins_transformer is None:
+                raise ValueError("kbins preprocessor must be fit before transform.")
+            imputed_frame = cudf.from_pandas(frame.loc[:, self.numeric_columns]).astype("float64")
+            for column in self.numeric_columns:
+                imputed_frame[column] = imputed_frame[column].fillna(self.numeric_statistics.medians[column])
+            kbins_result = transform_kbins_values(self.kbins_transformer, imputed_frame)
+            return cudf.DataFrame(kbins_result, index=frame.index)
 
         numeric_frame = self._normalize_numeric_frame(frame)
         transformed_columns: dict[str, object] = {}

--- a/src/tabular_shenanigans/preprocess_execution.py
+++ b/src/tabular_shenanigans/preprocess_execution.py
@@ -68,7 +68,7 @@ def resolve_preprocessing_execution_plan(
     if (
         gpu_available
         and categorical_preprocessor_id == "frequency"
-        and numeric_preprocessor_id in {"median", "standardize"}
+        and numeric_preprocessor_id in {"median", "standardize", "kbins"}
     ):
         return PreprocessingExecutionPlan(
             preprocessing_backend=GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND,


### PR DESCRIPTION
## Summary

- Renamed `_build_gpu_kbins_discretizer`, `_fit_kbins_transformer`, `_transform_kbins_values` to public names in `gpu_cuml_preprocess.py` — no logic changes, just importable from sibling modules
- Extended `GpuNativeFrequencyPreprocessor` in `gpu_preprocess.py`: `fit()` builds a cuML `KBinsDiscretizer` after median imputation when `numeric_preprocessor_id == "kbins"`; `_transform_numeric_frame()` applies it and wraps the result as a `cudf.DataFrame` for downstream concat
- Added `"kbins"` to `SUPPORTED_GPU_NATIVE_NUMERIC_PREPROCESSOR_IDS`
- Extended the `gpu_native_frequency` routing condition in `preprocess_execution.py` to include `"kbins"`
- Added two new `ValidationCase` entries in the harness: `regression_ridge_native_frequency_kbins` and `binary_random_forest_native_frequency_kbins`, both expecting `gpu_native_frequency`

## Verification

Routing logic verified locally (imports clean, constant set updated). GPU execution path requires a machine with cuML installed — harness cases `regression_ridge_native_frequency_kbins` and `binary_random_forest_native_frequency_kbins` are the verification targets.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)