### PR TITLE
Register xgboost+onehot as gpu_native (#218)

### DIFF
--- a/scripts/validate_gpu_target_matrix.py
+++ b/scripts/validate_gpu_target_matrix.py
@@ -252,26 +252,26 @@ def _default_cases() -> list[ValidationCase]:
             expected_preprocessing_backend="gpu_cuml",
             notes="Validates #205 — elasticnet onehot registered in GPU_SUPPORT_REGISTRY.",
         ),
-        # #206/#209: xgboost+onehot on gpu_patch — densified to dense_array, routed through gpu_cuml preprocessing.
+        # #218: xgboost+onehot promoted to gpu_native — densified to dense_array via gpu_cuml preprocessing.
         ValidationCase(
-            case_id="binary_xgboost_patch_onehot_standardize",
+            case_id="binary_xgboost_native_onehot_standardize",
             template_config_path=DEFAULT_BINARY_TEMPLATE_PATH,
             model_family="xgboost",
             numeric_preprocessor="standardize",
             categorical_preprocessor="onehot",
-            gpu_backend="patch",
+            gpu_backend="native",
             expected_preprocessing_backend="gpu_cuml",
-            notes="Validates #209 — xgboost onehot on gpu_patch densified to dense_array via gpu_cuml preprocessing.",
+            notes="Validates #218 — xgboost onehot registered as gpu_native; densified to dense_array via gpu_cuml preprocessing.",
         ),
         ValidationCase(
-            case_id="regression_xgboost_patch_onehot_kbins",
+            case_id="regression_xgboost_native_onehot_kbins",
             template_config_path=DEFAULT_REGRESSION_TEMPLATE_PATH,
             model_family="xgboost",
             numeric_preprocessor="kbins",
             categorical_preprocessor="onehot",
-            gpu_backend="patch",
+            gpu_backend="native",
             expected_preprocessing_backend="gpu_cuml",
-            notes="Validates #209 — xgboost onehot on gpu_patch densified to dense_array via gpu_cuml preprocessing.",
+            notes="Validates #218 — xgboost onehot registered as gpu_native; densified to dense_array via gpu_cuml preprocessing.",
         ),
         # #212: frequency + kbins on gpu_native
         ValidationCase(

--- a/src/tabular_shenanigans/execution_routing.py
+++ b/src/tabular_shenanigans/execution_routing.py
@@ -194,7 +194,7 @@ def _build_gpu_support_registry() -> dict[tuple[str, str, str, str], tuple[str, 
         model_family="xgboost",
         numeric_preprocessors=("median", "standardize", "kbins"),
         categorical_preprocessors=("onehot",),
-        gpu_paths=(PATCH_GPU_BACKEND,),
+        gpu_paths=(NATIVE_GPU_BACKEND,),
     )
     _register_model_paths(
         registry,


### PR DESCRIPTION
## Summary

- Changes `xgboost + {median,standardize,kbins} + onehot` registry entry from `PATCH_GPU_BACKEND` to `NATIVE_GPU_BACKEND`
- `GPU_SUPPORT_REGISTRY` now contains zero `PATCH_GPU_BACKEND` entries
- Updates the two validation cases (`binary_xgboost_patch_onehot_standardize`, `regression_xgboost_patch_onehot_kbins`) to `gpu_backend="native"` with updated case IDs

## Verification

No implementation changes needed — `GpuCumlDensePreprocessor` already handles onehot+dense_array for all numeric preprocessors, and XGBoost trains with `device="cuda"` natively. Validation harness cases updated to reflect the promotion.

Closes #218