### PR TITLE
Log every Optuna trial as a nested MLflow run

### DIFF
--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -318,6 +318,48 @@ def _candidate_run_metrics(
     return metrics
 
 
+def log_trial_run(
+    config: AppConfig,
+    candidate_run: CandidateRunRef,
+    trial_number: int,
+    model_family: str,
+    hyperparams: dict[str, object],
+    model_params: dict[str, object] | None,
+    cv_score_mean: float | None,
+    cv_score_std: float | None,
+    duration_seconds: float | None,
+    trial_state: str,  # "COMPLETE" | "FAIL"
+) -> None:
+    client = _client(config)
+    run = client.create_run(
+        experiment_id=candidate_run.experiment_id,
+        run_name=f"trial_{trial_number}",
+        tags={
+            "run_kind": "optimization_trial",
+            "mlflow.parentRunId": candidate_run.run_id,
+            "candidate_id": candidate_run.candidate_id,
+            "trial_state": trial_state,
+            "model_family": model_family,
+        },
+    )
+    trial_run_id = run.info.run_id
+    params: dict[str, object] = {"trial_number": trial_number}
+    for key, value in hyperparams.items():
+        params[f"hp__{key}"] = value
+    if isinstance(model_params, dict):
+        for key, value in model_params.items():
+            params[f"mp__{key}"] = value
+    _log_params(client, trial_run_id, params)
+    if trial_state == "COMPLETE":
+        _log_metrics(client, trial_run_id, {
+            "cv_score_mean": cv_score_mean,
+            "cv_score_std": cv_score_std,
+            "duration_seconds": duration_seconds,
+        })
+    status = "FINISHED" if trial_state == "COMPLETE" else "FAILED"
+    client.set_terminated(trial_run_id, status=status)
+
+
 def log_candidate_run(
     config: AppConfig,
     candidate_run: CandidateRunRef,

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -375,6 +375,7 @@ def run_training_workflow(
                             optimization_result = run_optimization(
                                 config=config,
                                 dataset_context=dataset_context,
+                                candidate_run=candidate_run,
                                 prepared_training_context=prepared_training_context,
                             )
                             run_training(

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -1,4 +1,5 @@
 import json
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -15,6 +16,7 @@ from tabular_shenanigans.model_evaluation import (
     build_prepared_training_context,
     score_model_spec,
 )
+from tabular_shenanigans.mlflow_store import CandidateRunRef, log_trial_run
 from tabular_shenanigans.models import build_tuning_space, get_model_definition
 
 
@@ -115,6 +117,7 @@ def _build_optimization_summary(
 def run_optimization(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
+    candidate_run: CandidateRunRef,
     prepared_training_context: PreparedTrainingContext | None = None,
 ) -> OptimizationResult:
     if not config.is_model_candidate:
@@ -152,21 +155,50 @@ def run_optimization(
 
     def objective(trial: optuna.Trial) -> float:
         parameter_overrides = build_tuning_space(task_type, tuning_model_spec.model_registry_key, trial)
-        cv_evaluation = score_model_spec(
-            task_type=task_type,
-            primary_metric=primary_metric,
-            model_spec=TrainingModelSpec(
-                model_registry_key=tuning_model_spec.model_registry_key,
-                parameter_overrides=parameter_overrides,
-            ),
-            training_context=training_context,
-            cv_random_state=competition.cv.random_state,
-        )
+        trial_start = time.time()
+        try:
+            cv_evaluation = score_model_spec(
+                task_type=task_type,
+                primary_metric=primary_metric,
+                model_spec=TrainingModelSpec(
+                    model_registry_key=tuning_model_spec.model_registry_key,
+                    parameter_overrides=parameter_overrides,
+                ),
+                training_context=training_context,
+                cv_random_state=competition.cv.random_state,
+            )
+        except Exception:
+            log_trial_run(
+                config=config,
+                candidate_run=candidate_run,
+                trial_number=trial.number,
+                model_family=tuning_model_spec.model_registry_key,
+                hyperparams=parameter_overrides,
+                model_params=None,
+                cv_score_mean=None,
+                cv_score_std=None,
+                duration_seconds=time.time() - trial_start,
+                trial_state="FAIL",
+            )
+            raise
+        duration_seconds = time.time() - trial_start
         metric_mean = cv_evaluation.model_result.cv_summary.metric_mean
         metric_std = cv_evaluation.model_result.cv_summary.metric_std
         trial.set_user_attr("metric_std", metric_std)
         trial.set_user_attr("parameter_overrides", json_ready(parameter_overrides))
         trial.set_user_attr("model_params", json_ready(cv_evaluation.model_result.model_params))
+        log_trial_run(
+            config=config,
+            candidate_run=candidate_run,
+            trial_number=trial.number,
+            model_family=tuning_model_spec.model_registry_key,
+            hyperparams=parameter_overrides,
+            model_params=cv_evaluation.model_result.model_params,
+            cv_score_mean=metric_mean,
+            cv_score_std=metric_std,
+            duration_seconds=duration_seconds,
+            trial_state="COMPLETE",
+        )
         print(
             f"Trial {trial.number}: {primary_metric}={metric_mean:.6f} "
             f"(std={metric_std:.6f}) params={parameter_overrides}"


### PR DESCRIPTION
## Summary
- Adds `log_trial_run()` to `mlflow_store.py` — creates a nested child run under the parent candidate run via the `mlflow.parentRunId` tag
- Modifies `run_optimization()` in `tune.py` to accept the parent `CandidateRunRef` and call `log_trial_run()` inside `objective()` after each trial
- Failed trials (exception in `score_model_spec`) are logged with `trial_state=FAIL` and `FAILED` MLflow run status before re-raising; successful trials get `COMPLETE` / `FINISHED`
- Each child run logs: `hp__*` params (sampled hyperparameters), `mp__*` params (resolved model params), `trial_number`, plus `cv_score_mean`, `cv_score_std`, `duration_seconds` metrics, and `run_kind`, `candidate_id`, `trial_state`, `model_family` tags

## Verification
- Run any optimization candidate (`candidate.optimization.enabled: true`)
- In MLflow UI, expand the candidate run — trial child runs should appear nested underneath, visible while the study is in progress
- Each trial run should show correct hyperparams, CV score, and duration
- Parent candidate run still holds the full study artifacts and final best-candidate metrics unchanged

Closes #143