### PR TITLE
Remove redundant DataFrame copies in feature recipe path

### DIFF
--- a/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
+++ b/src/tabular_shenanigans/feature_recipes/playground_series_s6e3.py
@@ -144,7 +144,7 @@ def _automatic_payment_flag(series: pd.Series) -> pd.Series:
 
 
 def _transform_v1_frame(frame: pd.DataFrame) -> pd.DataFrame:
-    transformed = frame.copy()
+    transformed = frame
 
     tenure = transformed["tenure"].astype(float)
     monthly_charges = transformed["MonthlyCharges"].astype(float)

--- a/src/tabular_shenanigans/feature_recipes/registry.py
+++ b/src/tabular_shenanigans/feature_recipes/registry.py
@@ -15,7 +15,7 @@ def _identity_recipe(
     x_train_raw: pd.DataFrame,
     x_test_raw: pd.DataFrame,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    return x_train_raw.copy(), x_test_raw.copy()
+    return x_train_raw, x_test_raw
 
 
 FEATURE_RECIPE_REGISTRY = {


### PR DESCRIPTION
## Summary
- Remove redundant `.copy()` in `_identity_recipe` — already receives owned frames from `apply_feature_recipe()`
- Remove redundant `.copy()` in `_transform_v1_frame` — all v1/v2/v3/ablation transforms chain through this, and the caller already copied
- Defensive ownership boundary in `apply_feature_recipe()` is preserved unchanged

Closes #109

## Test plan
- [ ] Run a full pipeline pass with `fr0` (identity) to confirm no mutation of raw frames
- [ ] Run a full pipeline pass with `fr1`–`fr3` to confirm feature engineering produces identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)