### PR TITLE
Make optimization mode presence-based and remove optimization.enabled

### DIFF
--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -53,12 +53,12 @@ experiment:
       #   tol: 0.001
       #   l1_ratio: 0.0
       #   class_weight: balanced
-      optimization:
-        enabled: false
-        # method: optuna
-        # n_trials: 25
-        # timeout_seconds: 3600
-        # random_state: 42
+      # To enable optimization, replace model_params with an optimization block:
+      # optimization:
+      #   method: optuna
+      #   n_trials: 25
+      #   timeout_seconds: 3600
+      #   random_state: 42
 
     - candidate_type: model
       feature_recipe_id: fr0
@@ -66,8 +66,6 @@ experiment:
       numeric_preprocessor: median
       categorical_preprocessor: ordinal
       model_params: {}
-      optimization:
-        enabled: false
 
     # Optional blend candidate shape:
     # - candidate_type: blend

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -41,12 +41,12 @@ experiment:
       numeric_preprocessor: standardize
       categorical_preprocessor: onehot
       model_params: {}
-      optimization:
-        enabled: false
-        # method: optuna
-        # n_trials: 25
-        # timeout_seconds: 3600
-        # random_state: 42
+      # To enable optimization, replace model_params with an optimization block:
+      # optimization:
+      #   method: optuna
+      #   n_trials: 25
+      #   timeout_seconds: 3600
+      #   random_state: 42
 
     - candidate_type: model
       feature_recipe_id: fr0
@@ -54,8 +54,6 @@ experiment:
       numeric_preprocessor: median
       categorical_preprocessor: ordinal
       model_params: {}
-      optimization:
-        enabled: false
 
     # Optional blend candidate shape:
     # - candidate_type: blend

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -102,7 +102,7 @@ Each candidate run is named with `candidate_id`.
   - `model_family`
   - `model_registry_key`
   - `model__*` for resolved model params
-  - `opt__*` for optimization settings
+  - `opt__*` for optimization settings (logged only when optimization block is present)
 - blend candidates:
   - `blend__base_candidate_ids_json`
   - `blend__configured_weights_json`

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -64,7 +64,6 @@ class CompetitionConfig(BaseModel):
 class CandidateOptimizationConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = False
     method: Literal["optuna"] = "optuna"
     n_trials: int | None = Field(default=None, ge=1)
     timeout_seconds: int | None = Field(default=None, ge=1)
@@ -94,7 +93,7 @@ class ModelCandidateConfig(BaseCandidateConfig):
         "xgboost",
     ]
     model_params: dict[str, object] = Field(default_factory=dict)
-    optimization: CandidateOptimizationConfig = Field(default_factory=CandidateOptimizationConfig)
+    optimization: CandidateOptimizationConfig | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -108,10 +107,10 @@ class ModelCandidateConfig(BaseCandidateConfig):
 
     @model_validator(mode="after")
     def validate_model_candidate(self) -> "ModelCandidateConfig":
-        if self.model_params and self.optimization.enabled:
+        if self.model_params and self.optimization is not None:
             raise ValueError(
-                "The current runtime does not support combining candidate.model_params "
-                "with enabled candidate.optimization."
+                "candidate.model_params and candidate.optimization are mutually exclusive. "
+                "Use model_params for fixed training or optimization for tuning, not both."
             )
 
         if self.numeric_preprocessor is None or self.categorical_preprocessor is None:
@@ -295,8 +294,8 @@ class AppConfig(BaseModel):
                         model_id=resolved_model_registry_key,
                         parameter_overrides=candidate.model_params,
                     )
-                    optimization = candidate.optimization
-                    if optimization.enabled:
+                    if candidate.optimization is not None:
+                        optimization = candidate.optimization
                         if optimization.n_trials is None and optimization.timeout_seconds is None:
                             raise ValueError(
                                 "At least one candidate.optimization stopping condition is required. "
@@ -497,8 +496,8 @@ class AppConfig(BaseModel):
         competition = self.competition
         candidate = self.get_candidate(candidate_index)
         if isinstance(candidate, ModelCandidateConfig):
-            optimization_payload: dict[str, object] = {"enabled": False}
-            if candidate.optimization.enabled:
+            optimization_payload: dict[str, object] | None = None
+            if candidate.optimization is not None:
                 optimization_payload = candidate.optimization.model_dump(mode="python")
             runtime_execution_context = self.runtime_execution_context_for_index(candidate_index)
             preprocessing_execution_plan = self.preprocessing_execution_plan_for_index(candidate_index)

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -255,15 +255,15 @@ def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dic
             for key, value in model_params.items():
                 params[f"model__{key}"] = value
         optimization = candidate.optimization
-        params.update(
-            {
-                "opt__enabled": optimization.enabled,
-                "opt__method": optimization.method,
-                "opt__n_trials": optimization.n_trials,
-                "opt__timeout_seconds": optimization.timeout_seconds,
-                "opt__random_state": optimization.random_state,
-            }
-        )
+        if optimization is not None:
+            params.update(
+                {
+                    "opt__method": optimization.method,
+                    "opt__n_trials": optimization.n_trials,
+                    "opt__timeout_seconds": optimization.timeout_seconds,
+                    "opt__random_state": optimization.random_state,
+                }
+            )
         return params
 
     params["blend__base_candidate_ids_json"] = candidate.base_candidate_ids

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -336,7 +336,6 @@ def run_training_workflow(
 
             return run_blend_training(config=config, dataset_context=dataset_context)
 
-        optimization = config.experiment.candidate.optimization
         candidate = config.experiment.candidate
         candidate_run = create_candidate_run(
             config=config,
@@ -358,7 +357,7 @@ def run_training_workflow(
                         mlflow_run_id=candidate_run.run_id,
                     )
                     try:
-                        if not optimization.enabled:
+                        if candidate.optimization is None:
                             run_training(
                                 config=config,
                                 dataset_context=dataset_context,

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -126,8 +126,8 @@ def run_optimization(
     competition = config.competition
     candidate = config.experiment.candidate
     optimization = candidate.optimization
-    if not optimization.enabled:
-        raise ValueError("Optimization requires candidate.optimization.enabled=true in config.yaml.")
+    if optimization is None:
+        raise ValueError("Optimization requires a candidate.optimization block in config.yaml.")
 
     task_type = competition.task_type
     primary_metric = competition.primary_metric


### PR DESCRIPTION
## Summary
- Remove `optimization.enabled` from the schema; optimization mode is now selected by the presence of the `optimization` block
- Missing `optimization` block = fixed-training mode (`model_params` allowed)
- Present `optimization` block = optimization mode (`model_params` forbidden)
- `opt__*` MLflow params are only logged when optimization is active

Closes #137

## Test plan
- [x] Config with `optimization` block (no `enabled`) loads and activates optimization mode
- [x] Config without `optimization` block loads as fixed training with `model_params`
- [x] Config with both `model_params` and `optimization` fails fast with clear error
- [x] Config with legacy `enabled` field fails fast (pydantic `extra="forbid"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)