### PR TITLE
Remove repo-owned hyperparameter defaults from untuned model builders (#140)

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -38,6 +38,7 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 - Candidate runs should upload `logs/runtime.log` on both success and failure once the run exists.
 - `submit` resolves candidates from MLflow, not from local artifact directories.
 - `refresh-submissions` updates existing candidate runs and does not create standalone tracking runs.
+- Untuned model candidates use upstream library estimator defaults for all hyperparameters. The repo sets only runtime and task-contract params: determinism (`random_state`/`random_seed`), parallelism (`n_jobs`/`thread_count`), logging/file-writing controls (`verbosity`, `verbose`, `allow_writing_files`), problem-definition params (`objective`, `eval_metric`, `loss_function`), and GPU routing. Users who want a stronger untuned baseline should set `model_params` explicitly or enable optimization.
 - Feature recipes must be deterministic, leakage-safe, and schema-preserving across train/test.
 - Binary probability blends require matching saved class metadata across all base candidates.
 - Binary `accuracy` blends require the saved probability sidecar and current probability-average blend rule metadata across all base candidates.
@@ -319,7 +320,7 @@ Current preprocessing selection on GPU hosts:
 - [eda.py](/src/tabular_shenanigans/eda.py): local EDA report generation.
 - [feature_recipes](/src/tabular_shenanigans/feature_recipes): deterministic feature recipes such as `fr0`, `fr1`, `fr2`, `fr3`, and the `fr2_ablate_*`/`fr3_ablate_*` grouped ablation variants used for `s6e3` recipe studies.
 - [model_evaluation.py](/src/tabular_shenanigans/model_evaluation.py): shared prepared training context, reusable CV evaluation logic for train/tune, and fold-stage runtime profiling for benchmark checkpoints.
-- [models.py](/src/tabular_shenanigans/models.py): model registry, capability checks, estimator construction, and tuning space definitions.
+- [models.py](/src/tabular_shenanigans/models.py): model registry, capability checks, estimator construction (runtime/task-contract params only; hyperparameter defaults are upstream), and tuning space definitions.
 - [preprocess.py](/src/tabular_shenanigans/preprocess.py): raw feature-frame preparation and split preprocessing components.
 - [cv.py](/src/tabular_shenanigans/cv.py): splitters and task-aware metric scoring.
 - [train.py](/src/tabular_shenanigans/train.py): model training workflow, candidate manifest construction, temp bundle staging, MLflow candidate logging, and training-stage runtime profiling capture.

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -613,7 +613,7 @@ def _build_random_forest_regressor(
         )
         return SingleTargetRegressionAdapter(estimator_class(**params)), params
 
-    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
+    params = _merge_model_params({"n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return RandomForestRegressor(**params), params
 
 
@@ -621,7 +621,7 @@ def _build_extra_trees_regressor(
     random_state: int,
     parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[ExtraTreesRegressor, dict[str, object]]:
-    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
+    params = _merge_model_params({"n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return ExtraTreesRegressor(**params), params
 
 
@@ -630,12 +630,7 @@ def _build_hist_gradient_boosting_regressor(
     parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[HistGradientBoostingRegressor, dict[str, object]]:
     params = _merge_model_params(
-        {
-            "early_stopping": False,
-            "learning_rate": 0.05,
-            "max_iter": 300,
-            "random_state": random_state,
-        },
+        {"random_state": random_state},
         parameter_overrides,
     )
     return HistGradientBoostingRegressor(**params), params
@@ -715,7 +710,7 @@ def _build_random_forest_classifier(
         )
         return BinaryLabelEncodingClassifier(estimator_class(**params)), params
 
-    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
+    params = _merge_model_params({"n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return RandomForestClassifier(**params), params
 
 
@@ -723,7 +718,7 @@ def _build_extra_trees_classifier(
     random_state: int,
     parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[ExtraTreesClassifier, dict[str, object]]:
-    params = _merge_model_params({"n_estimators": 500, "n_jobs": -1, "random_state": random_state}, parameter_overrides)
+    params = _merge_model_params({"n_jobs": -1, "random_state": random_state}, parameter_overrides)
     return ExtraTreesClassifier(**params), params
 
 
@@ -732,12 +727,7 @@ def _build_hist_gradient_boosting_classifier(
     parameter_overrides: dict[str, object] | None = None,
 ) -> tuple[HistGradientBoostingClassifier, dict[str, object]]:
     params = _merge_model_params(
-        {
-            "early_stopping": False,
-            "learning_rate": 0.05,
-            "max_iter": 300,
-            "random_state": random_state,
-        },
+        {"random_state": random_state},
         parameter_overrides,
     )
     return HistGradientBoostingClassifier(**params), params
@@ -757,12 +747,8 @@ def _build_lightgbm_regressor(
 
     runtime_execution_context = get_runtime_execution_context()
     params = {
-        "colsample_bytree": 0.8,
-        "learning_rate": 0.05,
-        "n_estimators": 500,
         "n_jobs": -1,
         "random_state": random_state,
-        "subsample": 0.8,
         "verbosity": -1,
         **_resolve_booster_runtime_defaults("lightgbm"),
     }
@@ -788,12 +774,8 @@ def _build_lightgbm_classifier(
 
     runtime_execution_context = get_runtime_execution_context()
     params = {
-        "colsample_bytree": 0.8,
-        "learning_rate": 0.05,
-        "n_estimators": 500,
         "n_jobs": -1,
         "random_state": random_state,
-        "subsample": 0.8,
         "verbosity": -1,
         **_resolve_booster_runtime_defaults("lightgbm"),
     }
@@ -819,9 +801,6 @@ def _build_catboost_regressor(
 
     params = {
         "allow_writing_files": False,
-        "depth": 6,
-        "iterations": 500,
-        "learning_rate": 0.05,
         "loss_function": "RMSE",
         "random_seed": random_state,
         "thread_count": -1,
@@ -846,9 +825,6 @@ def _build_catboost_classifier(
 
     params = {
         "allow_writing_files": False,
-        "depth": 6,
-        "iterations": 500,
-        "learning_rate": 0.05,
         "loss_function": "Logloss",
         "random_seed": random_state,
         "thread_count": -1,
@@ -872,15 +848,10 @@ def _build_xgboost_regressor(
         ) from exc
 
     params = {
-        "colsample_bytree": 0.8,
         "eval_metric": "rmse",
-        "learning_rate": 0.05,
-        "max_depth": 6,
-        "n_estimators": 500,
         "n_jobs": -1,
         "objective": "reg:squarederror",
         "random_state": random_state,
-        "subsample": 0.8,
         "tree_method": "hist",
         **_resolve_booster_runtime_defaults("xgboost"),
     }
@@ -901,15 +872,10 @@ def _build_xgboost_classifier(
         ) from exc
 
     params = {
-        "colsample_bytree": 0.8,
         "eval_metric": "logloss",
-        "learning_rate": 0.05,
-        "max_depth": 6,
-        "n_estimators": 500,
         "n_jobs": -1,
         "objective": "binary:logistic",
         "random_state": random_state,
-        "subsample": 0.8,
         "tree_method": "hist",
         **_resolve_booster_runtime_defaults("xgboost"),
     }


### PR DESCRIPTION
## Summary
- Remove repo-owned hyperparameter opinions (n_estimators, learning_rate, max_depth, depth, iterations, early_stopping, colsample_bytree, subsample) from all non-logistic model builders in `models.py`
- Retain only runtime/task-contract params: determinism, parallelism, logging/file-writing controls, problem-definition, and GPU routing
- Document in TECHNICAL_GUIDE.md that untuned candidates use upstream library estimator defaults

## Notable behavior change
`HistGradientBoosting` shifts from `early_stopping=False` to sklearn default `early_stopping="auto"` — intentional runtime-contract shift per issue discussion.

## Not changed
- LogisticRegression defaults (`solver="saga"`, `max_iter=1000`) — out of scope per issue
- Tuning spaces — all removed params are already explicitly searched during optimization

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)