### PR TITLE
Remove experiment.submit config and make submission behavior CLI-driven

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -77,8 +77,6 @@ Required top-level sections: `competition`, `experiment`.
 | `runtime.compute_target` | no | `auto` (default), `cpu`, or `gpu` |
 | `runtime.gpu_backend` | no | `auto` (default), `patch`, or `native`; advanced override |
 | `candidates` | yes | one or more candidate entries (see below) |
-| `submit.enabled` | no | |
-| `submit.message_prefix` | no | |
 
 `train` drains `experiment.candidates` in order unless narrowed with `--candidate-id` or `--index`. `submit --index <n>` uses a 1-based index into this list.
 
@@ -126,11 +124,14 @@ Hard-invalid: `categorical_preprocessor: native` with any `model_family` other t
 | `uv run python main.py train --candidate-id <id>` | train one candidate by ID |
 | `uv run python main.py train --index <n>` | train one candidate by 1-based index |
 | `uv run python main.py train --skip-existing` | skip candidates that already exist in MLflow |
-| `uv run python main.py submit --candidate-id <id>` | submit a candidate by ID |
-| `uv run python main.py submit --index <n>` | submit a candidate by 1-based index |
+| `uv run python main.py submit` | dry-run validation for the first configured candidate |
+| `uv run python main.py submit --candidate-id <id>` | dry-run validation for a candidate by ID |
+| `uv run python main.py submit --index <n>` | dry-run validation for a candidate by 1-based index |
+| `uv run python main.py submit --candidate-id <id> --execute` | real Kaggle submission |
+| `uv run python main.py submit --candidate-id <id> --execute --message-prefix <prefix>` | real Kaggle submission with a description prefix |
 | `uv run python main.py refresh-submissions` | refresh Kaggle submission scores onto MLflow runs |
 
-The default pipeline no longer auto-submits; `submit` requires an explicit selector.
+The default pipeline stops after `train`; `submit` is always a separate explicit command. Without `--execute`, `submit` performs dry-run validation only.
 
 ### Utility Scripts
 
@@ -147,7 +148,7 @@ The default pipeline no longer auto-submits; `submit` requires an explicit selec
 - **prepare**: fetches if needed, materializes the competition context in memory, and writes EDA reports under `reports/<competition_slug>/`.
 - **eda**: writes EDA reports only.
 - **train**: trains all configured candidates sequentially by default, loading one shared dataset context per invocation. Use `--candidate-id` or `--index` to train one configured candidate. Model candidates stage artifacts in a temp bundle and upload to MLflow. Blend candidates download their base candidates from MLflow, materialize blended predictions, then upload the blended candidate run.
-- **submit**: downloads the candidate from MLflow, validates `test_predictions.csv` against `sample_submission.csv`, and when `experiment.submit.enabled=true` submits to Kaggle and records the submission event on the candidate run.
+- **submit**: downloads the candidate from MLflow and validates `test_predictions.csv` against `sample_submission.csv`. With `--execute`, submits to Kaggle and records the submission event on the candidate run. Without `--execute`, performs dry-run validation only.
 - **refresh-submissions**: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and appends new score observations onto matching candidate runs.
 
 ## Outputs
@@ -193,7 +194,7 @@ Suggested checks:
 - Trigger one intentionally failing candidate and confirm the run is marked failed but still has `logs/runtime.log`.
 - Rerun the same candidate config and confirm a hard-fail on duplicate `candidate_id`.
 - Train a blend candidate and confirm it downloads base candidates from MLflow.
-- Run `uv run python main.py submit --index 1` with `submit.enabled: false` and confirm dry-run validation succeeds.
+- Run `uv run python main.py submit --index 1` and confirm dry-run validation succeeds.
 - Run `uv run python main.py refresh-submissions` after a real submission and confirm MLflow metrics update.
 
 ### Current Limits

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -75,7 +75,3 @@ experiment:
     #   weights:
     #     - 0.5
     #     - 0.5
-
-  submit:
-    enabled: false
-    # message_prefix: s5e12-baseline

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -63,7 +63,3 @@ experiment:
     #   weights:
     #     - 0.5
     #     - 0.5
-
-  submit:
-    enabled: false
-    # message_prefix: s5e10-baseline

--- a/src/tabular_shenanigans/cli.py
+++ b/src/tabular_shenanigans/cli.py
@@ -50,8 +50,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fetch Kaggle submission outcomes for candidate runs tracked in MLflow.",
     )
 
-    submit_parser = subparsers.add_parser("submit", help="Prepare or submit from an MLflow candidate run.")
-    submit_selector_group = submit_parser.add_mutually_exclusive_group(required=True)
+    submit_parser = subparsers.add_parser("submit", help="Validate or submit a candidate to Kaggle.")
+    submit_selector_group = submit_parser.add_mutually_exclusive_group()
     submit_selector_group.add_argument(
         "--candidate-id",
         help="Existing candidate_id in the current competition MLflow experiment.",
@@ -59,7 +59,16 @@ def build_parser() -> argparse.ArgumentParser:
     submit_selector_group.add_argument(
         "--index",
         type=int,
-        help="1-based configured candidate index from config.yaml.",
+        help="1-based configured candidate index from config.yaml. Defaults to 1 when no selector is given.",
+    )
+    submit_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute a real Kaggle submission. Without this flag, submit performs dry-run validation only.",
+    )
+    submit_parser.add_argument(
+        "--message-prefix",
+        help="Optional prefix for the Kaggle submission description. Only used with --execute.",
     )
 
     return parser
@@ -186,8 +195,9 @@ def _resolve_submit_candidate_id(
     if candidate_id is not None:
         return candidate_id
 
+    effective_index = index if index is not None else 1
     selected_candidate_indices = config.resolve_candidate_indices(
-        index=index,
+        index=effective_index,
         require_explicit=True,
     )
     return config.with_candidate_index(selected_candidate_indices[0]).resolved_candidate_id
@@ -197,6 +207,8 @@ def _run_submit_stage(
     config: AppConfig,
     candidate_id: str | None = None,
     index: int | None = None,
+    execute: bool = False,
+    message_prefix: str | None = None,
 ):
     resolved_candidate_id = _resolve_submit_candidate_id(
         config=config,
@@ -207,6 +219,8 @@ def _run_submit_stage(
     submission_result = run_submission(
         config=config,
         candidate_id=resolved_candidate_id,
+        execute=execute,
+        message_prefix=message_prefix,
     )
     print(
         "Submission stage complete: "
@@ -300,6 +314,8 @@ def main(argv: list[str] | None = None) -> None:
             config=config,
             candidate_id=args.candidate_id,
             index=args.index,
+            execute=args.execute,
+            message_prefix=args.message_prefix,
         )
         return
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -192,13 +192,6 @@ ExperimentCandidateConfig = Annotated[
 ]
 
 
-class ExperimentSubmitConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    enabled: bool = False
-    message_prefix: str | None = None
-
-
 class ExperimentTrackingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -217,7 +210,6 @@ class ExperimentConfig(BaseModel):
 
     candidates: list[ExperimentCandidateConfig] = Field(min_length=1)
     runtime: ExperimentRuntimeConfig = Field(default_factory=ExperimentRuntimeConfig)
-    submit: ExperimentSubmitConfig = Field(default_factory=ExperimentSubmitConfig)
     tracking: ExperimentTrackingConfig = Field(default_factory=ExperimentTrackingConfig)
     active_candidate_index: int = Field(default=0, exclude=True, repr=False, ge=0)
     legacy_candidate_contract_used: bool = Field(default=False, exclude=True, repr=False)

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -340,9 +340,9 @@ def _build_submission_event(
 def run_submission(
     config: AppConfig,
     candidate_id: str,
+    execute: bool = False,
+    message_prefix: str | None = None,
 ) -> SubmissionRunResult:
-    submit_config = config.experiment.submit
-
     with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-submit-") as temp_dir:
         temp_root = Path(temp_dir)
         submission_context = _load_submission_context(
@@ -355,12 +355,12 @@ def run_submission(
             output_dir=temp_root,
         )
 
-        if submit_config.enabled:
+        if execute:
             submission_event_id = make_submission_event_id()
             submission_message = _build_submission_message_from_context(
                 submission_context,
                 submission_event_id=submission_event_id,
-                submit_message_prefix=submit_config.message_prefix,
+                submit_message_prefix=message_prefix,
             )
             completed = subprocess.run(
                 [


### PR DESCRIPTION
## Summary
- Removed `experiment.submit` (`enabled`, `message_prefix`) from config schema, example configs, and `config.yaml`
- Submission behavior is now fully CLI-driven: `--execute` flag opts in to real Kaggle submission, `--message-prefix` sets the description prefix
- Without `--execute`, `submit` performs dry-run validation only (the safe default)
- Candidate selector (`--candidate-id` / `--index`) is now optional; defaults to first configured candidate when omitted

Closes #141

## Test plan
- [ ] Run `uv run python main.py submit` and confirm dry-run validation for the first configured candidate
- [ ] Run `uv run python main.py submit --candidate-id <id>` and confirm dry-run validation
- [ ] Run `uv run python main.py submit --candidate-id <id> --execute` and confirm real Kaggle submission
- [ ] Run `uv run python main.py submit --candidate-id <id> --execute --message-prefix test` and confirm prefix appears in Kaggle description
- [ ] Confirm `config.yaml` with an `experiment.submit` section is rejected by validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)