### PR TITLE
Make training and submission lifecycle resilient to partial MLflow failures

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -107,7 +107,7 @@ Hard-invalid: `categorical_preprocessor: native` with any `model_family` other t
 `candidate_id` is derived automatically:
 - model: `<feature_recipe_id>--<preprocessing_scheme_id>--<model_registry_key>--<hash8>`
 - blend: `blend__<hash8>`
-- rerunning the same spec derives the same ID and hard-fails if that run already exists in MLflow
+- rerunning the same spec derives the same ID and hard-fails only when a canonical completed run for that `candidate_id` already exists in MLflow
 
 ## Commands
 
@@ -149,7 +149,7 @@ The default pipeline stops after `train`; `submit` is always a separate explicit
 - **eda**: writes EDA reports only.
 - **train**: trains all configured candidates sequentially by default, loading one shared dataset context per invocation. Use `--candidate-id` or `--index` to train one configured candidate. Model candidates stage artifacts in a temp bundle and upload to MLflow. Blend candidates download their base candidates from MLflow, materialize blended predictions, then upload the blended candidate run.
 - **submit**: downloads the candidate from MLflow and validates `test_predictions.csv` against `sample_submission.csv`. With `--execute`, submits to Kaggle and records the submission event on the candidate run. Without `--execute`, performs dry-run validation only.
-- **refresh-submissions**: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and appends new score observations onto matching candidate runs.
+- **refresh-submissions**: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and can recover missing MLflow submission events from `candidate=<candidate_id>` metadata before appending score observations.
 
 ## Outputs
 
@@ -162,7 +162,8 @@ The default pipeline stops after `train`; `submit` is always a separate explicit
 ### MLflow
 
 - One MLflow experiment per `competition.slug`.
-- One top-level MLflow run per `candidate_id`.
+- One canonical top-level MLflow run per `candidate_id`.
+- Failed or incomplete retry attempts may coexist as non-canonical top-level runs for the same `candidate_id`.
 - There are no stage-specific MLflow runs for `prepare`, `submit`, or `refresh-submissions`.
 - There is no local canonical `artifacts/` workflow.
 
@@ -192,14 +193,14 @@ Suggested checks:
 - Run `uv run python main.py train` and confirm one MLflow run appears per configured candidate.
 - Inspect a candidate run and confirm `logs/`, `candidate/`, `config/`, and `context/` artifacts exist.
 - Trigger one intentionally failing candidate and confirm the run is marked failed but still has `logs/runtime.log`.
-- Rerun the same candidate config and confirm a hard-fail on duplicate `candidate_id`.
+- Rerun the same candidate config after a failed attempt and confirm training retries without manual MLflow cleanup.
 - Train a blend candidate and confirm it downloads base candidates from MLflow.
 - Run `uv run python main.py submit --index 1` and confirm dry-run validation succeeds.
-- Run `uv run python main.py refresh-submissions` after a real submission and confirm MLflow metrics update.
+- Run `uv run python main.py refresh-submissions` after a real submission and confirm MLflow metrics update, including recovery when the post-submit MLflow write was interrupted.
 
 ### Current Limits
 
 - Kaggle authentication must be preconfigured.
 - RAPIDS acceleration is Linux-only; macOS stays on CPU.
 - LightGBM GPU routing requires a CUDA-enabled source build.
-- Candidate lookup is keyed by derived `candidate_id`; reusing the same spec without deleting the existing run is a hard error.
+- Candidate lookup is keyed by derived `candidate_id`; reusing the same spec while a canonical completed run already exists is a hard error.

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -24,17 +24,20 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
     - `context/competition.json`
     - `context/folds.csv`
     - `candidate/*`
-15. Create one MLflow run for the candidate and upload the staged bundle.
-16. For real Kaggle submissions, download the explicitly selected candidate from MLflow, validate `test_predictions.csv` against `sample_submission.csv`, submit `submission.csv`, and append submission history artifacts back onto that same candidate run.
-17. For submission refresh, scan Kaggle submissions once, match `submit=<submission_event_id>` descriptions, and update candidate-run submission history plus scoreboard metrics in place.
+15. Create one MLflow run attempt for the candidate and upload the staged bundle.
+16. Treat only a `FINISHED` MLflow run with the full candidate artifact contract as the canonical run for that `candidate_id`.
+17. For real Kaggle submissions, download the explicitly selected candidate from MLflow, validate `test_predictions.csv` against `sample_submission.csv`, submit `submission.csv`, and append submission history artifacts back onto that same candidate run.
+18. For submission refresh, scan Kaggle submissions once, match `submit=<submission_event_id>` descriptions, recover missing submission events from `candidate=<candidate_id>` metadata when needed, and update candidate-run submission history plus scoreboard metrics in place.
 
 ## Runtime Invariants
 
 - MLflow is required. The runtime does not support a no-tracking mode.
 - Candidate state is canonical in MLflow, not on local disk.
-- Reusing an existing derived `candidate_id` within a competition experiment is a hard error.
+- A completed run with the full candidate artifact contract is canonical for a `candidate_id`.
+- Failed or incomplete candidate attempts are non-canonical and may remain in MLflow until cleaned up.
+- Starting a new attempt while another run for the same `candidate_id` is still active is a hard error.
 - `prepare` is not a persisted source of truth anymore.
-- `train` and `blend` must produce exactly one candidate run keyed by `candidate_id`.
+- `train` and `blend` must produce exactly one canonical candidate run keyed by `candidate_id`.
 - Candidate runs should upload `logs/runtime.log` on both success and failure once the run exists.
 - `submit` resolves candidates from MLflow, not from local artifact directories.
 - `refresh-submissions` updates existing candidate runs and does not create standalone tracking runs.
@@ -49,7 +52,8 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 
 - MLflow is the canonical experiment store.
 - One MLflow experiment per `competition.slug`.
-- One top-level MLflow run per `candidate_id`.
+- One canonical top-level MLflow run per `candidate_id`.
+- Failed or incomplete retry attempts may coexist as non-canonical top-level runs for the same `candidate_id`.
 - There are no stage-specific MLflow runs.
 - There are no local canonical candidate directories or local submission ledgers.
 
@@ -186,6 +190,7 @@ Refresh behavior:
 - scan Kaggle submissions once
 - extract `submission_event_id` from the Kaggle description
 - match it to candidate-run submission history
+- when `submission_event_id` is missing from MLflow history but the Kaggle description includes `candidate=<candidate_id>`, recover the submission event onto that canonical candidate run
 - append only new observations
 - update candidate-run score metrics in place
 

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from tabular_shenanigans.candidate_artifacts import (
     CANDIDATE_ARTIFACT_DIRNAME,
+    CANDIDATE_MANIFEST_FILENAME,
     CONTEXT_ARTIFACT_DIRNAME,
     json_ready,
     load_candidate_manifest,
@@ -18,6 +19,18 @@ from tabular_shenanigans.submission_history import CandidateSubmissionHistory
 TRACKING_SCHEMA_VERSION = "3"
 RUN_KIND_CANDIDATE = "candidate"
 SUBMISSION_HISTORY_ARTIFACT_PATH = "submissions/history.json"
+CANDIDATE_BUNDLE_REQUIRED_ARTIFACT_PATHS = (
+    "logs/runtime.log",
+    "config/runtime_config.json",
+    "context/competition.json",
+    "context/folds.csv",
+    "candidate/candidate.json",
+    "candidate/fold_metrics.csv",
+    "candidate/oof_predictions.csv",
+    "candidate/test_predictions.csv",
+)
+CANDIDATE_BUNDLE_ROOT_PATHS = ("logs", "config", "context", "candidate")
+ACTIVE_MLFLOW_RUN_STATUSES = {"RUNNING", "SCHEDULED"}
 
 
 @dataclass(frozen=True)
@@ -34,6 +47,37 @@ class DownloadedCandidateBundle:
     candidate_id: str
     candidate_artifact_dir: Path
     manifest: dict[str, object]
+
+
+@dataclass(frozen=True)
+class CandidateRunAssessment:
+    run_ref: CandidateRunRef
+    run_status: str
+    missing_artifact_paths: tuple[str, ...]
+    bundle_error: str | None
+
+    @property
+    def is_canonical(self) -> bool:
+        return (
+            self.run_status == "FINISHED"
+            and not self.missing_artifact_paths
+            and self.bundle_error is None
+        )
+
+    @property
+    def is_active(self) -> bool:
+        return self.run_status in ACTIVE_MLFLOW_RUN_STATUSES
+
+
+@dataclass(frozen=True)
+class CandidateRunLookup:
+    candidate_id: str
+    matching_runs: tuple[CandidateRunAssessment, ...]
+    canonical_run: CandidateRunRef | None
+
+    @property
+    def has_active_runs(self) -> bool:
+        return any(run.is_active for run in self.matching_runs)
 
 
 def _load_mlflow():
@@ -118,56 +162,204 @@ def _candidate_search_filter(candidate_id: str) -> str:
     )
 
 
-def find_candidate_run(config: AppConfig, candidate_id: str) -> CandidateRunRef:
-    client = _client(config)
-    experiment_id = _experiment_id(config)
-    runs = client.search_runs(
-        experiment_ids=[experiment_id],
-        filter_string=_candidate_search_filter(candidate_id),
-        max_results=10,
-    )
-    if not runs:
-        raise ValueError(
-            f"Candidate '{candidate_id}' was not found in MLflow experiment '{config.competition.slug}'."
-        )
-    if len(runs) > 1:
-        run_ids = [run.info.run_id for run in runs]
-        raise ValueError(
-            "Candidate id must map to exactly one MLflow run. "
-            f"Candidate '{candidate_id}' matched runs: {run_ids}"
-        )
-    run = runs[0]
+def _candidate_run_ref_from_run(run) -> CandidateRunRef:
+    candidate_id = run.data.tags.get("candidate_id")
+    if candidate_id is None:
+        raise ValueError(f"Candidate run {run.info.run_id} is missing tag 'candidate_id'.")
     return CandidateRunRef(
         run_id=run.info.run_id,
         experiment_id=run.info.experiment_id,
-        candidate_id=candidate_id,
+        candidate_id=str(candidate_id),
     )
 
 
-def ensure_candidate_run_absent(config: AppConfig, candidate_id: str) -> None:
+def _collect_candidate_bundle_artifact_paths(client, run_id: str) -> set[str]:
+    artifact_paths: set[str] = set()
+    pending_paths = list(CANDIDATE_BUNDLE_ROOT_PATHS)
+    visited_paths: set[str] = set()
+
+    while pending_paths:
+        current_path = pending_paths.pop()
+        if current_path in visited_paths:
+            continue
+        visited_paths.add(current_path)
+        for artifact in client.list_artifacts(run_id, current_path):
+            artifact_paths.add(artifact.path)
+            if artifact.is_dir:
+                pending_paths.append(artifact.path)
+    return artifact_paths
+
+
+def _download_json_artifact(
+    client,
+    run_id: str,
+    artifact_path: str,
+    destination_dir: Path,
+) -> dict[str, object]:
+    local_path = Path(
+        client.download_artifacts(
+            run_id=run_id,
+            path=artifact_path,
+            dst_path=str(destination_dir),
+        )
+    )
+    payload = json.loads(local_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Artifact '{artifact_path}' for run '{run_id}' must contain a JSON object.")
+    return payload
+
+
+def _required_candidate_artifact_paths(manifest: Mapping[str, object] | None = None) -> list[str]:
+    required_paths = list(CANDIDATE_BUNDLE_REQUIRED_ARTIFACT_PATHS)
+    if manifest is None:
+        return required_paths
+
+    probability_artifact_path = manifest.get("binary_accuracy_test_probability_path")
+    if probability_artifact_path is not None:
+        required_paths.append(f"{CANDIDATE_ARTIFACT_DIRNAME}/{probability_artifact_path}")
+    return required_paths
+
+
+def _assess_candidate_run(
+    client,
+    run,
+    destination_dir: Path,
+) -> CandidateRunAssessment:
+    run_ref = _candidate_run_ref_from_run(run)
+    artifact_paths = _collect_candidate_bundle_artifact_paths(client, run_ref.run_id)
+    required_paths = _required_candidate_artifact_paths()
+    bundle_error = None
+
+    manifest_artifact_path = f"{CANDIDATE_ARTIFACT_DIRNAME}/{CANDIDATE_MANIFEST_FILENAME}"
+    if manifest_artifact_path in artifact_paths:
+        try:
+            manifest = _download_json_artifact(
+                client=client,
+                run_id=run_ref.run_id,
+                artifact_path=manifest_artifact_path,
+                destination_dir=destination_dir,
+            )
+        except Exception as exc:
+            bundle_error = str(exc)
+        else:
+            required_paths = _required_candidate_artifact_paths(manifest)
+
+    missing_artifact_paths = tuple(sorted(path for path in required_paths if path not in artifact_paths))
+    return CandidateRunAssessment(
+        run_ref=run_ref,
+        run_status=str(run.info.status),
+        missing_artifact_paths=missing_artifact_paths,
+        bundle_error=bundle_error,
+    )
+
+
+def _format_candidate_run_assessment(assessment: CandidateRunAssessment) -> str:
+    parts = [
+        f"run_id={assessment.run_ref.run_id}",
+        f"status={assessment.run_status}",
+    ]
+    if assessment.missing_artifact_paths:
+        parts.append(f"missing_artifacts={list(assessment.missing_artifact_paths)}")
+    if assessment.bundle_error is not None:
+        parts.append(f"bundle_error={assessment.bundle_error}")
+    return ", ".join(parts)
+
+
+def _candidate_run_guidance(lookup: CandidateRunLookup) -> str:
+    if lookup.has_active_runs:
+        return "Wait for the active run to finish or terminate it before retrying."
+    return "Retry training to create a fresh canonical run or repair/delete the broken runs."
+
+
+def _build_candidate_lookup_from_runs(
+    candidate_id: str,
+    client,
+    runs: list[Any],
+) -> CandidateRunLookup:
+    with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-candidate-lookup-") as temp_dir:
+        temp_root = Path(temp_dir)
+        assessments = tuple(
+            _assess_candidate_run(
+                client=client,
+                run=run,
+                destination_dir=temp_root / run.info.run_id,
+            )
+            for run in runs
+        )
+
+    canonical_runs = [assessment.run_ref for assessment in assessments if assessment.is_canonical]
+    if len(canonical_runs) > 1:
+        matching_runs = "; ".join(_format_candidate_run_assessment(assessment) for assessment in assessments)
+        raise ValueError(
+            "Candidate id resolved to multiple completed MLflow runs with the required artifact bundle. "
+            f"Candidate '{candidate_id}' matched runs: {matching_runs}. Manual cleanup is required."
+        )
+
+    return CandidateRunLookup(
+        candidate_id=candidate_id,
+        matching_runs=assessments,
+        canonical_run=canonical_runs[0] if canonical_runs else None,
+    )
+
+
+def _candidate_run_lookup(config: AppConfig, candidate_id: str) -> CandidateRunLookup:
     client = _client(config)
     experiment_id = _experiment_id(config)
     runs = client.search_runs(
         experiment_ids=[experiment_id],
         filter_string=_candidate_search_filter(candidate_id),
-        max_results=1,
+        max_results=100,
     )
-    if runs:
+    return _build_candidate_lookup_from_runs(
+        candidate_id=candidate_id,
+        client=client,
+        runs=runs,
+    )
+
+
+def find_candidate_run(config: AppConfig, candidate_id: str) -> CandidateRunRef:
+    lookup = _candidate_run_lookup(config=config, candidate_id=candidate_id)
+    if not lookup.matching_runs:
+        raise ValueError(
+            f"Candidate '{candidate_id}' was not found in MLflow experiment '{config.competition.slug}'."
+        )
+    if lookup.canonical_run is None:
+        matching_runs = "; ".join(_format_candidate_run_assessment(assessment) for assessment in lookup.matching_runs)
+        raise ValueError(
+            "Candidate did not resolve to a completed MLflow run with the required artifact bundle. "
+            f"Candidate '{candidate_id}' matched runs: {matching_runs}. "
+            f"{_candidate_run_guidance(lookup)}"
+        )
+    return lookup.canonical_run
+
+
+def ensure_candidate_run_absent(config: AppConfig, candidate_id: str) -> None:
+    lookup = _candidate_run_lookup(config=config, candidate_id=candidate_id)
+    if lookup.canonical_run is not None:
         raise ValueError(
             "Candidate already exists in MLflow for this competition. "
-            f"Change the candidate config so it derives a new candidate_id or delete candidate '{candidate_id}'."
+            f"Candidate '{candidate_id}' resolved to canonical run '{lookup.canonical_run.run_id}'. "
+            "Change the candidate config so it derives a new candidate_id or delete the canonical candidate run."
+        )
+    if lookup.has_active_runs:
+        matching_runs = "; ".join(_format_candidate_run_assessment(assessment) for assessment in lookup.matching_runs)
+        raise ValueError(
+            "Candidate has an active MLflow run and cannot be retried safely yet. "
+            f"Candidate '{candidate_id}' matched runs: {matching_runs}. "
+            "Wait for the active run to finish or terminate it before retrying."
         )
 
 
 def candidate_run_exists(config: AppConfig, candidate_id: str) -> bool:
-    client = _client(config)
-    experiment_id = _experiment_id(config)
-    runs = client.search_runs(
-        experiment_ids=[experiment_id],
-        filter_string=_candidate_search_filter(candidate_id),
-        max_results=1,
-    )
-    return bool(runs)
+    lookup = _candidate_run_lookup(config=config, candidate_id=candidate_id)
+    if lookup.has_active_runs:
+        matching_runs = "; ".join(_format_candidate_run_assessment(assessment) for assessment in lookup.matching_runs)
+        raise ValueError(
+            "Candidate has an active MLflow run and cannot be resolved for --skip-existing yet. "
+            f"Candidate '{candidate_id}' matched runs: {matching_runs}. "
+            "Wait for the active run to finish or terminate it before retrying."
+        )
+    return lookup.canonical_run is not None
 
 
 def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: str) -> dict[str, object]:
@@ -400,6 +592,49 @@ def upload_run_log(
     _client(config).log_artifact(run_id, str(log_path), artifact_dir)
 
 
+def download_candidate_manifest(
+    config: AppConfig,
+    run_id: str,
+    destination_dir: Path,
+) -> dict[str, object]:
+    client = _client(config)
+    return _download_json_artifact(
+        client=client,
+        run_id=run_id,
+        artifact_path=f"{CANDIDATE_ARTIFACT_DIRNAME}/{CANDIDATE_MANIFEST_FILENAME}",
+        destination_dir=destination_dir,
+    )
+
+
+def _validate_downloaded_candidate_artifact_dir(
+    candidate_id: str,
+    run_id: str,
+    candidate_artifact_dir: Path,
+    manifest: Mapping[str, object],
+) -> None:
+    required_filenames = [
+        CANDIDATE_MANIFEST_FILENAME,
+        "fold_metrics.csv",
+        "oof_predictions.csv",
+        "test_predictions.csv",
+    ]
+    probability_artifact_path = manifest.get("binary_accuracy_test_probability_path")
+    if probability_artifact_path is not None:
+        required_filenames.append(str(probability_artifact_path))
+
+    missing_files = sorted(
+        filename
+        for filename in required_filenames
+        if not (candidate_artifact_dir / filename).exists()
+    )
+    if missing_files:
+        raise ValueError(
+            "Candidate bundle is incomplete after download. "
+            f"Candidate '{candidate_id}' resolved to run '{run_id}' but candidate artifacts were missing: "
+            f"{missing_files}"
+        )
+
+
 def download_candidate_bundle(
     config: AppConfig,
     candidate_id: str,
@@ -415,6 +650,12 @@ def download_candidate_bundle(
         )
     )
     manifest = load_candidate_manifest(candidate_artifact_dir=candidate_dir_path)
+    _validate_downloaded_candidate_artifact_dir(
+        candidate_id=candidate_id,
+        run_id=candidate_run.run_id,
+        candidate_artifact_dir=candidate_dir_path,
+        manifest=manifest,
+    )
     return DownloadedCandidateBundle(
         run_id=candidate_run.run_id,
         experiment_id=candidate_run.experiment_id,
@@ -503,11 +744,21 @@ def search_candidate_runs(config: AppConfig) -> list[CandidateRunRef]:
         filter_string=f"tags.run_kind = '{RUN_KIND_CANDIDATE}'",
         max_results=1000,
     )
-    return [
-        CandidateRunRef(
-            run_id=run.info.run_id,
-            experiment_id=run.info.experiment_id,
-            candidate_id=str(run.data.tags.get("candidate_id")),
+    runs_by_candidate_id: dict[str, list[Any]] = {}
+    for run in runs:
+        candidate_id = run.data.tags.get("candidate_id")
+        if candidate_id is None:
+            continue
+        runs_by_candidate_id.setdefault(str(candidate_id), []).append(run)
+
+    resolved_runs: list[CandidateRunRef] = []
+    for candidate_id, candidate_id_runs in sorted(runs_by_candidate_id.items()):
+        lookup = _build_candidate_lookup_from_runs(
+            candidate_id=candidate_id,
+            client=client,
+            runs=candidate_id_runs,
         )
-        for run in runs
-    ]
+        if lookup.canonical_run is None:
+            continue
+        resolved_runs.append(lookup.canonical_run)
+    return resolved_runs

--- a/src/tabular_shenanigans/submission_history.py
+++ b/src/tabular_shenanigans/submission_history.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from tabular_shenanigans.cv import is_higher_better
 
 SUBMISSION_EVENT_ID_PATTERN = re.compile(r"(?:^|\s\|\s)submit=(?P<submission_event_id>[a-z0-9_-]+)(?:\s\|\s|$)")
+CANDIDATE_ID_PATTERN = re.compile(r"(?:^|\s\|\s)candidate=(?P<candidate_id>[^|]+?)(?:\s\|\s|$)")
 
 
 @dataclass(frozen=True)
@@ -246,10 +247,18 @@ def make_submission_event_id() -> str:
 
 
 def extract_submission_event_id(kaggle_description: str) -> str | None:
-    match = SUBMISSION_EVENT_ID_PATTERN.search(kaggle_description)
-    if match is None:
+    matches = list(SUBMISSION_EVENT_ID_PATTERN.finditer(kaggle_description))
+    if not matches:
         return None
-    return match.group("submission_event_id")
+    return matches[-1].group("submission_event_id")
+
+
+def extract_candidate_id(kaggle_description: str) -> str | None:
+    matches = list(CANDIDATE_ID_PATTERN.finditer(kaggle_description))
+    if not matches:
+        return None
+    candidate_id = matches[-1].group("candidate_id").strip()
+    return candidate_id or None
 
 
 def _parse_optional_float(raw_value: object) -> float | None:

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -26,6 +26,7 @@ from tabular_shenanigans.submission_history import (
     SubmissionRefreshResult,
     SubmissionScoreObservation,
     build_submission_score_metrics,
+    extract_candidate_id,
     extract_submission_event_id,
     iter_kaggle_submissions,
     make_submission_event_id,
@@ -337,6 +338,36 @@ def _build_submission_event(
     )
 
 
+def _build_recovered_submission_event(
+    submission_context: SubmissionContext,
+    submission_event_id: str,
+    kaggle_submitted_at: str,
+    kaggle_file_name: str,
+    kaggle_description: str,
+) -> SubmissionEvent:
+    return SubmissionEvent(
+        submission_event_id=submission_event_id,
+        submitted_at_utc=kaggle_submitted_at or utc_now_iso(),
+        competition_slug=submission_context.competition_slug,
+        candidate_id=submission_context.candidate_id,
+        candidate_type=submission_context.candidate_type,
+        config_fingerprint=submission_context.config_fingerprint,
+        feature_recipe_id=submission_context.feature_recipe_id,
+        preprocessing_scheme_id=submission_context.preprocessing_scheme_id,
+        model_registry_key=submission_context.model_registry_key,
+        estimator_name=submission_context.estimator_name,
+        cv_metric_name=submission_context.cv_metric_name,
+        cv_metric_mean=submission_context.cv_metric_mean,
+        cv_metric_std=submission_context.cv_metric_std,
+        submission_file_name=kaggle_file_name or "submission.csv",
+        submit_message=kaggle_description,
+        submit_response_message=(
+            "Recovered by refresh-submissions from Kaggle metadata after the original "
+            "post-submit MLflow write did not complete."
+        ),
+    )
+
+
 def run_submission(
     config: AppConfig,
     candidate_id: str,
@@ -469,31 +500,29 @@ def run_submission_refresh(
 
     histories_by_run_id: dict[str, CandidateSubmissionHistory] = {}
     event_to_candidate_run: dict[str, CandidateRunRef] = {}
+    candidate_run_by_candidate_id: dict[str, CandidateRunRef] = {}
+    submission_contexts_by_run_id: dict[str, SubmissionContext] = {}
 
     with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-refresh-submissions-") as temp_dir:
         temp_root = Path(temp_dir)
         for candidate_run in candidate_runs:
             if target_candidate_ids is not None and candidate_run.candidate_id not in target_candidate_ids:
                 continue
+            candidate_run_by_candidate_id[candidate_run.candidate_id] = candidate_run
             history = download_submission_history(
                 config=config,
                 run_id=candidate_run.run_id,
                 destination_dir=temp_root / candidate_run.candidate_id,
             )
-            if not history.events:
-                continue
-
+            histories_by_run_id[candidate_run.run_id] = history
             relevant_event_ids = {
                 event.submission_event_id
                 for event in history.events
                 if target_submission_event_ids is None or event.submission_event_id in target_submission_event_ids
             }
-            if not relevant_event_ids:
-                continue
-
-            tracked_candidate_count += 1
-            tracked_submission_event_count += len(relevant_event_ids)
-            histories_by_run_id[candidate_run.run_id] = history
+            if relevant_event_ids:
+                tracked_candidate_count += 1
+                tracked_submission_event_count += len(relevant_event_ids)
             for submission_event_id in relevant_event_ids:
                 if submission_event_id in event_to_candidate_run:
                     existing_candidate_id = event_to_candidate_run[submission_event_id].candidate_id
@@ -504,7 +533,7 @@ def run_submission_refresh(
                     )
                 event_to_candidate_run[submission_event_id] = candidate_run
 
-        if not event_to_candidate_run:
+        if not histories_by_run_id:
             return SubmissionRefreshResult(
                 competition_slug=config.competition.slug,
                 tracked_candidate_count=tracked_candidate_count,
@@ -517,14 +546,78 @@ def run_submission_refresh(
             )
 
         observations_by_run_id: dict[str, list[SubmissionScoreObservation]] = {}
+        updated_submission_event_ids_by_run_id: dict[str, set[str]] = {}
         for remote_submission in iter_kaggle_submissions(config.competition.slug):
             scanned_remote_submission_count += 1
             submission_event_id = extract_submission_event_id(remote_submission.kaggle_description)
             if submission_event_id is None:
                 continue
-            candidate_run = event_to_candidate_run.get(submission_event_id)
-            if candidate_run is None:
+            if target_submission_event_ids is not None and submission_event_id not in target_submission_event_ids:
                 continue
+
+            candidate_id = extract_candidate_id(remote_submission.kaggle_description)
+            candidate_run = event_to_candidate_run.get(submission_event_id)
+            if candidate_run is not None:
+                if target_candidate_ids is not None and candidate_run.candidate_id not in target_candidate_ids:
+                    continue
+                if candidate_id is not None and candidate_id != candidate_run.candidate_id:
+                    raise ValueError(
+                        "Kaggle submission metadata did not match the tracked MLflow candidate. "
+                        f"submission_event_id={submission_event_id}, "
+                        f"kaggle_candidate_id={candidate_id}, "
+                        f"tracked_candidate_id={candidate_run.candidate_id}"
+                    )
+            else:
+                if target_candidate_ids is not None and candidate_id not in target_candidate_ids:
+                    continue
+                if candidate_id is None:
+                    print(
+                        "Submission refresh could not recover orphaned Kaggle submission: "
+                        f"submission_event_id={submission_event_id}, "
+                        "reason=missing_candidate_id_in_kaggle_description"
+                    )
+                    continue
+                candidate_run = candidate_run_by_candidate_id.get(candidate_id)
+                if candidate_run is None:
+                    print(
+                        "Submission refresh could not recover orphaned Kaggle submission: "
+                        f"candidate_id={candidate_id}, "
+                        f"submission_event_id={submission_event_id}, "
+                        "reason=no_canonical_candidate_run"
+                    )
+                    continue
+
+                history = histories_by_run_id[candidate_run.run_id]
+                if history.get_event(submission_event_id) is None:
+                    submission_context = submission_contexts_by_run_id.get(candidate_run.run_id)
+                    if submission_context is None:
+                        submission_context = _load_submission_context(
+                            config=config,
+                            candidate_id=candidate_run.candidate_id,
+                            destination_dir=temp_root / "recovered-events" / candidate_run.candidate_id,
+                        )
+                        submission_contexts_by_run_id[candidate_run.run_id] = submission_context
+
+                    history = history.with_submission_event(
+                        _build_recovered_submission_event(
+                            submission_context=submission_context,
+                            submission_event_id=submission_event_id,
+                            kaggle_submitted_at=remote_submission.kaggle_submitted_at,
+                            kaggle_file_name=remote_submission.kaggle_file_name,
+                            kaggle_description=remote_submission.kaggle_description,
+                        )
+                    )
+                    histories_by_run_id[candidate_run.run_id] = history
+                    event_to_candidate_run[submission_event_id] = candidate_run
+                    updated_submission_event_ids_by_run_id.setdefault(candidate_run.run_id, set()).add(
+                        submission_event_id
+                    )
+                    print(
+                        "Recovered orphaned Kaggle submission onto candidate run: "
+                        f"candidate_id={candidate_run.candidate_id}, "
+                        f"submission_event_id={submission_event_id}, "
+                        f"mlflow_run_id={candidate_run.run_id}"
+                    )
 
             matched_submission_event_ids.add(submission_event_id)
             observations_by_run_id.setdefault(candidate_run.run_id, []).append(
@@ -540,20 +633,20 @@ def run_submission_refresh(
                     observation_source=observation_source,
                 )
             )
+            updated_submission_event_ids_by_run_id.setdefault(candidate_run.run_id, set()).add(submission_event_id)
 
-        for run_id, observations in observations_by_run_id.items():
-            history = histories_by_run_id[run_id]
+        for run_id, history in histories_by_run_id.items():
+            observations = observations_by_run_id.get(run_id, [])
             updated_history, appended_count = history.with_submission_observations(observations)
-            if appended_count == 0:
+            updated_submission_event_ids = sorted(updated_submission_event_ids_by_run_id.get(run_id, set()))
+            if appended_count == 0 and not updated_submission_event_ids:
                 continue
 
             upload_submission_history(
                 config=config,
                 run_id=run_id,
                 history=updated_history,
-                updated_submission_event_ids=sorted(
-                    {observation.submission_event_id for observation in observations}
-                ),
+                updated_submission_event_ids=updated_submission_event_ids,
             )
             update_submission_metrics(
                 config=config,

--- a/src/tabular_shenanigans/training_orchestration.py
+++ b/src/tabular_shenanigans/training_orchestration.py
@@ -72,27 +72,26 @@ def run_training_batch(
             f"candidate_type={candidate.candidate_type}"
         )
 
-        if skip_existing and candidate_run_exists(candidate_config, resolved_candidate_id):
-            print(
-                "Candidate skipped: "
-                f"candidate_index={candidate_index + 1}, "
-                f"candidate_id={resolved_candidate_id}, "
-                "reason=existing_mlflow_run"
-            )
-            results.append(
-                CandidateBatchResult(
-                    candidate_index=candidate_index + 1,
-                    candidate_id=resolved_candidate_id,
-                    candidate_type=candidate.candidate_type,
-                    status="skipped",
-                    run_id=None,
-                    wall_seconds=0.0,
-                )
-            )
-            continue
-
         started = time.perf_counter()
         try:
+            if skip_existing and candidate_run_exists(candidate_config, resolved_candidate_id):
+                print(
+                    "Candidate skipped: "
+                    f"candidate_index={candidate_index + 1}, "
+                    f"candidate_id={resolved_candidate_id}, "
+                    "reason=existing_mlflow_run"
+                )
+                results.append(
+                    CandidateBatchResult(
+                        candidate_index=candidate_index + 1,
+                        candidate_id=resolved_candidate_id,
+                        candidate_type=candidate.candidate_type,
+                        status="skipped",
+                        run_id=None,
+                        wall_seconds=0.0,
+                    )
+                )
+                continue
             candidate_run = run_training_workflow(
                 config=candidate_config,
                 dataset_context=dataset_context,


### PR DESCRIPTION
## Summary
- resolve candidate runs by canonical completed bundle instead of treating any matching candidate_id as valid
- allow retries after failed or incomplete MLflow attempts while failing explicitly on active duplicate runs
- recover orphaned Kaggle submissions during refresh by reconstructing missing MLflow submission events from candidate metadata

## Verification
- uv run python -m compileall src
- targeted local MLflow verification script covering failed-only attempts, active duplicate attempts, canonical retry resolution, and orphaned submission recovery

Closes #235