### PR TITLE
Create live MLflow trial child runs

### DIFF
--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -154,6 +154,36 @@ Submission artifacts on the same candidate run:
 - `submissions/<submission_event_id>/submission.csv`
 - `submissions/<submission_event_id>/observations.json`
 
+### Optimization Trial Child Runs
+
+Optuna-backed model candidates also create nested MLflow child runs named `trial_<n>` with `run_kind=optimization_trial`.
+
+Trial child-run tags:
+- `run_kind=optimization_trial`
+- `mlflow.parentRunId=<candidate_run_id>`
+- `candidate_id`
+- `model_family`
+- `trial_state`, transitioning from `RUNNING` to `COMPLETE` or `FAIL`
+
+Trial child-run params:
+- `trial_number`
+- `feature_recipe_id`
+- `numeric_preprocessor`
+- `categorical_preprocessor`
+- `preprocessing_scheme_id`
+- `model_family`
+- `model_registry_key`
+- `runtime__resolved_compute_target`
+- `runtime__resolved_gpu_backend`
+- `runtime__preprocessing_backend`
+- `hp__*` for sampled Optuna hyperparameters
+- `mp__*` for resolved model params on completed trials
+
+Trial child-run metrics:
+- `duration_seconds`
+- `cv_score_mean` on completed trials
+- `cv_score_std` on completed trials
+
 ## Prediction Contracts
 
 - Binary `roc_auc` and `log_loss`: `test_predictions.csv` stores positive-class probabilities in `[0, 1]`.

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -50,6 +50,12 @@ class DownloadedCandidateBundle:
 
 
 @dataclass(frozen=True)
+class TrialRunRef:
+    run_id: str
+    trial_number: int
+
+
+@dataclass(frozen=True)
 class CandidateRunAssessment:
     run_ref: CandidateRunRef
     run_status: str
@@ -510,18 +516,49 @@ def _candidate_run_metrics(
     return metrics
 
 
-def log_trial_run(
+def _trial_run_context_params(
+    config: AppConfig,
+    trial_number: int,
+    hyperparams: dict[str, object],
+    feature_recipe_id: str,
+    numeric_preprocessor: str,
+    categorical_preprocessor: str,
+    preprocessing_scheme_id: str,
+    model_family: str,
+    model_registry_key: str,
+    preprocessing_backend: str,
+) -> dict[str, object]:
+    runtime_execution_context = config.runtime_execution_context
+    params: dict[str, object] = {
+        "trial_number": trial_number,
+        "feature_recipe_id": feature_recipe_id,
+        "numeric_preprocessor": numeric_preprocessor,
+        "categorical_preprocessor": categorical_preprocessor,
+        "preprocessing_scheme_id": preprocessing_scheme_id,
+        "model_family": model_family,
+        "model_registry_key": model_registry_key,
+        "runtime__resolved_compute_target": runtime_execution_context.resolved_compute_target,
+        "runtime__resolved_gpu_backend": runtime_execution_context.resolved_gpu_backend,
+        "runtime__preprocessing_backend": preprocessing_backend,
+    }
+    for key, value in hyperparams.items():
+        params[f"hp__{key}"] = value
+    return params
+
+
+def create_trial_run(
     config: AppConfig,
     candidate_run: CandidateRunRef,
     trial_number: int,
-    model_family: str,
     hyperparams: dict[str, object],
-    model_params: dict[str, object] | None,
-    cv_score_mean: float | None,
-    cv_score_std: float | None,
-    duration_seconds: float | None,
-    trial_state: str,  # "COMPLETE" | "FAIL"
-) -> None:
+    feature_recipe_id: str,
+    numeric_preprocessor: str,
+    categorical_preprocessor: str,
+    preprocessing_scheme_id: str,
+    model_family: str,
+    model_registry_key: str,
+    preprocessing_backend: str,
+) -> TrialRunRef:
     client = _client(config)
     run = client.create_run(
         experiment_id=candidate_run.experiment_id,
@@ -530,26 +567,57 @@ def log_trial_run(
             "run_kind": "optimization_trial",
             "mlflow.parentRunId": candidate_run.run_id,
             "candidate_id": candidate_run.candidate_id,
-            "trial_state": trial_state,
             "model_family": model_family,
+            "trial_state": "RUNNING",
         },
     )
     trial_run_id = run.info.run_id
-    params: dict[str, object] = {"trial_number": trial_number}
-    for key, value in hyperparams.items():
-        params[f"hp__{key}"] = value
+    _log_params(
+        client,
+        trial_run_id,
+        _trial_run_context_params(
+            config=config,
+            trial_number=trial_number,
+            hyperparams=hyperparams,
+            feature_recipe_id=feature_recipe_id,
+            numeric_preprocessor=numeric_preprocessor,
+            categorical_preprocessor=categorical_preprocessor,
+            preprocessing_scheme_id=preprocessing_scheme_id,
+            model_family=model_family,
+            model_registry_key=model_registry_key,
+            preprocessing_backend=preprocessing_backend,
+        ),
+    )
+    return TrialRunRef(run_id=trial_run_id, trial_number=trial_number)
+
+
+def finalize_trial_run(
+    config: AppConfig,
+    trial_run: TrialRunRef,
+    model_params: dict[str, object] | None,
+    cv_score_mean: float | None,
+    cv_score_std: float | None,
+    duration_seconds: float | None,
+    trial_state: str,  # "COMPLETE" | "FAIL"
+) -> None:
+    client = _client(config)
     if isinstance(model_params, dict):
+        params: dict[str, object] = {}
         for key, value in model_params.items():
             params[f"mp__{key}"] = value
-    _log_params(client, trial_run_id, params)
-    if trial_state == "COMPLETE":
-        _log_metrics(client, trial_run_id, {
+        _log_params(client, trial_run.run_id, params)
+    _log_metrics(
+        client,
+        trial_run.run_id,
+        {
             "cv_score_mean": cv_score_mean,
             "cv_score_std": cv_score_std,
             "duration_seconds": duration_seconds,
-        })
+        },
+    )
+    _set_tags(client, trial_run.run_id, {"trial_state": trial_state})
     status = "FINISHED" if trial_state == "COMPLETE" else "FAILED"
-    client.set_terminated(trial_run_id, status=status)
+    client.set_terminated(trial_run.run_id, status=status)
 
 
 def log_candidate_run(

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -16,7 +16,7 @@ from tabular_shenanigans.model_evaluation import (
     build_prepared_training_context,
     score_model_spec,
 )
-from tabular_shenanigans.mlflow_store import CandidateRunRef, log_trial_run
+from tabular_shenanigans.mlflow_store import CandidateRunRef, create_trial_run, finalize_trial_run
 from tabular_shenanigans.models import build_tuning_space, get_model_definition
 
 
@@ -155,6 +155,19 @@ def run_optimization(
 
     def objective(trial: optuna.Trial) -> float:
         parameter_overrides = build_tuning_space(task_type, tuning_model_spec.model_registry_key, trial)
+        trial_run = create_trial_run(
+            config=config,
+            candidate_run=candidate_run,
+            trial_number=trial.number,
+            hyperparams=parameter_overrides,
+            feature_recipe_id=config.experiment.candidate.feature_recipe_id,
+            numeric_preprocessor=training_context.numeric_preprocessor,
+            categorical_preprocessor=training_context.categorical_preprocessor,
+            preprocessing_scheme_id=training_context.preprocessing_scheme_id,
+            model_family=config.experiment.candidate.model_family,
+            model_registry_key=tuning_model_spec.model_registry_key,
+            preprocessing_backend=training_context.preprocessing_backend,
+        )
         trial_start = time.time()
         try:
             cv_evaluation = score_model_spec(
@@ -168,12 +181,9 @@ def run_optimization(
                 cv_random_state=competition.cv.random_state,
             )
         except Exception:
-            log_trial_run(
+            finalize_trial_run(
                 config=config,
-                candidate_run=candidate_run,
-                trial_number=trial.number,
-                model_family=tuning_model_spec.model_registry_key,
-                hyperparams=parameter_overrides,
+                trial_run=trial_run,
                 model_params=None,
                 cv_score_mean=None,
                 cv_score_std=None,
@@ -187,12 +197,9 @@ def run_optimization(
         trial.set_user_attr("metric_std", metric_std)
         trial.set_user_attr("parameter_overrides", json_ready(parameter_overrides))
         trial.set_user_attr("model_params", json_ready(cv_evaluation.model_result.model_params))
-        log_trial_run(
+        finalize_trial_run(
             config=config,
-            candidate_run=candidate_run,
-            trial_number=trial.number,
-            model_family=tuning_model_spec.model_registry_key,
-            hyperparams=parameter_overrides,
+            trial_run=trial_run,
             model_params=cv_evaluation.model_result.model_params,
             cv_score_mean=metric_mean,
             cv_score_std=metric_std,


### PR DESCRIPTION
## Summary
- create Optuna trial child runs at trial start and finalize them at trial end
- mirror stable candidate context onto optimization trial rows for direct MLflow filtering
- document the optimization trial child-run schema in the technical guide

## Verification
- PYTHONPYCACHEPREFIX=/tmp python3 -m py_compile src/tabular_shenanigans/mlflow_store.py src/tabular_shenanigans/tune.py
- manual MLflow runtime verification not run in this change

Closes #233