### PR TITLE
Support native categorical preprocessing for RealMLP

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -101,7 +101,7 @@ Deprecated: `experiment.candidate` (singular) is still accepted as a one-entry l
 - optional `optimization`
   - logistic regression Optuna trials fix `solver="saga"` and `max_iter=1000`, tune `C`, `tol`, `class_weight`, and `l1_ratio`
 
-Hard-invalid: `categorical_preprocessor: native` with any `model_family` other than `catboost`.
+Hard-invalid: `categorical_preprocessor: native` with any `model_family` other than `catboost` or `realmlp`.
 
 **Blend candidate:**
 - `candidate_type: blend`
@@ -183,7 +183,9 @@ candidate=<candidate_id> | submit=<submission_event_id> | <metric>=<value>
 - `compute_target: auto` picks the best registered GPU implementation per model/preprocessing tuple, falling back to CPU when nothing is registered.
 - `compute_target: gpu` requires a registered GPU implementation and fails fast otherwise.
 - `extra_trees` and `hist_gradient_boosting` always fall back to CPU; no GPU backend is registered.
-- `realmlp` uses the standard CPU preprocessing path and can still train on PyTorch CUDA internally when model routing resolves `compute_target` to GPU.
+- `realmlp` can use `categorical_preprocessor: native` or the existing non-native preprocessors.
+- Native RealMLP keeps repository numeric preprocessing (`median`, `standardize`, or `kbins`) and passes raw categorical columns plus categorical metadata into the upstream estimator.
+- `realmlp` still uses the standard CPU preprocessing path and can train on PyTorch CUDA internally when model routing resolves `compute_target` to GPU.
 - Mixed `gpu_patch` and non-`gpu_patch` batches are rejected because RAPIDS hook installation is process-global; split with `train --index <n>`.
 - GPU preprocessing can resolve independently from model routing; hybrid CPU-model + GPU-preprocessing cases coerce outputs back to CPU before fit.
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -260,6 +260,7 @@ Current `compute_target: auto` routing on supported Linux NVIDIA hosts:
 | `lightgbm` | `gpu_native` | `onehot` keeps the existing sparse CSR boundary; the model trains through the explicit CUDA adapter |
 | `xgboost` | `gpu_native` for `frequency + median\|standardize`; `gpu_patch` for the remaining registered `ordinal`/`frequency` tuples; CPU fallback otherwise | sparse GPU-native inputs remain unsupported |
 | `catboost` | `gpu_native` for `categorical_preprocessor: native`; CPU fallback otherwise | preprocessing stays on `cpu_native_frame` |
+| `realmlp` | `cpu` backend with `compute_target=gpu` semantics for all registered tuples, including `categorical_preprocessor: native` | preprocessing stays on CPU; the estimator still receives `device="cuda"` when runtime routing resolves to GPU |
 | `ridge`, `elasticnet` | `gpu_native` for `frequency + median\|standardize`; CPU fallback otherwise | explicit cuML regressors stay on dense inputs only |
 | `random_forest` | `gpu_native` for `onehot + median\|standardize\|kbins` and `frequency + median\|standardize`; CPU fallback otherwise | explicit cuML random forest stays on dense inputs only |
 | `extra_trees`, `hist_gradient_boosting` | CPU fallback | intentional fallback because no maintained official GPU backend is registered |
@@ -320,6 +321,13 @@ Current preprocessing selection on GPU hosts:
 
 - `gpu_native` for `categorical_preprocessor: native` only; uses CatBoost's own GPU mode, not the RAPIDS patch layer.
 - Preprocessing stays on `cpu_native_frame`.
+
+### RealMLP Native Categorical Path
+
+- `realmlp` now accepts `categorical_preprocessor: native` in both binary and regression configs.
+- Native RealMLP uses the existing `cpu_native_frame` preprocessing backend: repository numeric preprocessing still runs first, while categorical columns stay as raw pandas object/string columns.
+- During fold-local fit, the runtime passes `cat_col_names` so the upstream `RealMLP_TD_*` estimators can distinguish native categorical columns.
+- Existing non-native RealMLP paths (`onehot`, `ordinal`, `frequency`) are unchanged.
 
 ### GPU Preprocessing
 

--- a/src/tabular_shenanigans/_model_builders.py
+++ b/src/tabular_shenanigans/_model_builders.py
@@ -829,6 +829,19 @@ def build_realmlp_classifier(
     return RealMLP_TD_Classifier(**params), params
 
 
+def build_realmlp_fit_kwargs(
+    x_train_processed: object,
+    numeric_columns: list[str],
+    categorical_columns: list[str],
+) -> dict[str, object]:
+    del numeric_columns
+    if not categorical_columns:
+        return {}
+    if not isinstance(x_train_processed, pd.DataFrame):
+        raise ValueError("RealMLP native preprocessing must produce a pandas DataFrame.")
+    return {"cat_col_names": list(categorical_columns)}
+
+
 def build_lightgbm_regressor(
     random_state: int,
     parameter_overrides: dict[str, object] | None = None,
@@ -1008,18 +1021,37 @@ def build_hist_gradient_boosting_tuning_space(trial: object) -> dict[str, object
     }
 
 
-def build_realmlp_tuning_space(trial: object) -> dict[str, object]:
-    return {
-        "n_epochs": trial.suggest_int("n_epochs", 50, 500, step=50),
+def build_realmlp_tuning_space(
+    trial: object,
+    task_type: str | None = None,
+) -> dict[str, object]:
+    params: dict[str, object] = {
+        "act": trial.suggest_categorical("act", ["relu", "selu", "mish"]),
         "batch_size": trial.suggest_categorical("batch_size", [128, 256, 512]),
-        "lr": trial.suggest_float("lr", 1e-4, 1e-2, log=True),
-        "hidden_sizes": trial.suggest_categorical(
-            "hidden_sizes",
-            [[128], [256], [128, 128], [256, 128]],
-        ),
-        "p_drop": trial.suggest_float("p_drop", 0.0, 0.5),
-        "wd": trial.suggest_float("wd", 1e-6, 1e-2, log=True),
+        "hidden_width": trial.suggest_categorical("hidden_width", [64, 128, 192, 256, 384]),
+        "lr": trial.suggest_float("lr", 3e-5, 3e-2, log=True),
+        "lr_sched": trial.suggest_categorical("lr_sched", ["constant", "coslog4"]),
+        "n_epochs": trial.suggest_int("n_epochs", 100, 600, step=50),
+        "n_hidden_layers": trial.suggest_int("n_hidden_layers", 1, 4),
+        "p_drop": trial.suggest_float("p_drop", 0.0, 0.4),
+        "p_drop_sched": trial.suggest_categorical("p_drop_sched", ["constant", "flat_cos"]),
+        "use_early_stopping": trial.suggest_categorical("use_early_stopping", [True, False]),
+        "wd": trial.suggest_float("wd", 1e-7, 3e-2, log=True),
+        "wd_sched": trial.suggest_categorical("wd_sched", ["constant", "flat_cos"]),
     }
+    if params["use_early_stopping"]:
+        params["early_stopping_additive_patience"] = trial.suggest_int(
+            "early_stopping_additive_patience", 10, 40, step=5
+        )
+        params["early_stopping_multiplicative_patience"] = trial.suggest_float(
+            "early_stopping_multiplicative_patience", 1.0, 3.0
+        )
+    if task_type == "binary":
+        params["use_ls"] = trial.suggest_categorical("use_ls", [True, False])
+        if params["use_ls"]:
+            params["ls_eps"] = trial.suggest_float("ls_eps", 1e-3, 0.2, log=True)
+            params["ls_eps_sched"] = trial.suggest_categorical("ls_eps_sched", ["constant", "flat_cos"])
+    return params
 
 
 def build_knn_tuning_space(trial: object) -> dict[str, object]:

--- a/src/tabular_shenanigans/_model_registry.py
+++ b/src/tabular_shenanigans/_model_registry.py
@@ -21,6 +21,7 @@ from tabular_shenanigans._model_builders import (
     build_naive_bayes_classifier,
     build_naive_bayes_tuning_space,
     build_realmlp_classifier,
+    build_realmlp_fit_kwargs,
     build_realmlp_regressor,
     build_realmlp_tuning_space,
     build_random_forest_classifier,
@@ -150,11 +151,18 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_id="realmlp",
             model_name="RealMLP_TD_Regressor",
             builder=build_realmlp_regressor,
+            fit_kwargs_builder=build_realmlp_fit_kwargs,
             tuning_space_builder=build_realmlp_tuning_space,
+            supports_native_categorical_preprocessing=True,
             gpu_routing_rules=(
                 gpu_routing_rule(
                     numeric_preprocessors=ALL_NUMERIC_PREPROCESSORS,
                     categorical_preprocessors=ALL_NON_NATIVE_CATEGORICAL_PREPROCESSORS,
+                    gpu_backends=(CPU_GPU_BACKEND,),
+                ),
+                gpu_routing_rule(
+                    numeric_preprocessors=ALL_NUMERIC_PREPROCESSORS,
+                    categorical_preprocessors=("native",),
                     gpu_backends=(CPU_GPU_BACKEND,),
                 ),
             ),
@@ -278,11 +286,18 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_id="realmlp",
             model_name="RealMLP_TD_Classifier",
             builder=build_realmlp_classifier,
+            fit_kwargs_builder=build_realmlp_fit_kwargs,
             tuning_space_builder=build_realmlp_tuning_space,
+            supports_native_categorical_preprocessing=True,
             gpu_routing_rules=(
                 gpu_routing_rule(
                     numeric_preprocessors=ALL_NUMERIC_PREPROCESSORS,
                     categorical_preprocessors=ALL_NON_NATIVE_CATEGORICAL_PREPROCESSORS,
+                    gpu_backends=(CPU_GPU_BACKEND,),
+                ),
+                gpu_routing_rule(
+                    numeric_preprocessors=ALL_NUMERIC_PREPROCESSORS,
+                    categorical_preprocessors=("native",),
                     gpu_backends=(CPU_GPU_BACKEND,),
                 ),
             ),
@@ -426,9 +441,15 @@ def validate_model_preprocessing_compatibility(
         return
     if model_definition.supports_native_categorical_preprocessing:
         return
+    native_model_families = sorted(
+        candidate_model_id
+        for candidate_model_id, candidate_definition in get_task_model_registry(task_type).items()
+        if candidate_definition.supports_native_categorical_preprocessing
+    )
     raise ValueError(
         f"Model family '{model_definition.model_id}' does not support "
-        "categorical_preprocessor='native'. Use model_family='catboost' for native categorical handling."
+        "categorical_preprocessor='native'. "
+        f"Supported native categorical model families: {native_model_families}."
     )
 
 
@@ -491,6 +512,8 @@ def build_tuning_space(task_type: str, model_id: str, trial: object) -> dict[str
             f"Model id '{model_definition.model_id}' does not support tuning for task_type '{task_type}'. "
             f"Supported tunable model_ids: {supported_model_ids}"
         )
+    if model_definition.model_id == "realmlp":
+        return model_definition.tuning_space_builder(trial, task_type=task_type)
     return model_definition.tuning_space_builder(trial)
 
 


### PR DESCRIPTION
## Summary
- allow RealMLP to use `categorical_preprocessor: native` and pass native categorical metadata through fit
- expand the repo-owned RealMLP Optuna tuning space with layer-width, activation, schedule, early-stopping, and binary label-smoothing knobs
- update operator and technical docs for the new RealMLP preprocessing/runtime contract

## Manual verification
- `uv run python -m compileall src`
- targeted `uv run python` smoke script covering config validation, native binary RealMLP fit/predict, native regression RealMLP fit/predict, legacy non-native RealMLP fit/predict, and simulated Linux GPU routing resolution for native RealMLP
- full Kaggle/MLflow smoke runs not executed in this environment

Closes #252