### PR TITLE
Split MLflow tracking and add screening stage

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -55,6 +55,8 @@ Tracked example configs:
 
 Required top-level sections: `competition`, `experiment`.
 
+Optional top-level section: `screening`.
+
 #### `competition`
 
 | Key | Required | Values / Notes |
@@ -84,6 +86,8 @@ Required top-level sections: `competition`, `experiment`.
 
 `train` drains `experiment.candidates` in order unless narrowed with `--candidate-id` or `--index`. `submit --index <n>` uses a 1-based index into this list.
 
+`screening` evaluates `screening.candidates` in order and prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
+
 Deprecated: `experiment.candidate` (singular) is still accepted as a one-entry list and emits a deprecation notice.
 
 #### Candidate Shapes
@@ -109,7 +113,19 @@ Hard-invalid: representations with `native` categorical preprocessor and any `mo
 `candidate_id` is derived automatically:
 - model: `<model_registry_key>-<representation_id>-<hash8>`
 - blend: `blend__<hash8>`
-- rerunning the same spec derives the same ID and hard-fails only when a canonical completed run for that `candidate_id` already exists in MLflow
+- the same logical model candidate keeps the same `candidate_id` across screening and canonical evaluation
+- rerunning the same canonical candidate hard-fails only when a canonical completed run for that `candidate_id` already exists in MLflow
+- schema v4 changes the candidate-id fingerprint inputs versus older experiments; existing schema-v3 MLflow data is archival and does not share IDs with new runs
+
+#### `screening`
+
+| Key | Required | Notes |
+| --- | --- | --- |
+| `cv.n_splits` | no | defaults to `2` |
+| `cv.shuffle` | no | defaults to `true` |
+| `cv.random_state` | no | defaults to `42` |
+| `promote_top_k` | no | defaults to `3`; must be `<= len(screening.candidates)` |
+| `candidates` | yes | model candidates only; same shape as `experiment.candidates` model entries |
 
 ## Commands
 
@@ -123,6 +139,9 @@ Hard-invalid: representations with `native` categorical preprocessor and any `mo
 | `uv run python main.py prepare` | fetch if needed, materialize context in memory, write EDA reports |
 | `uv run python main.py eda` | write EDA reports only |
 | `uv run python main.py train` | train all configured candidates sequentially |
+| `uv run python main.py screening` | run all configured screening candidates sequentially |
+| `uv run python main.py screening --candidate-id <id>` | screen one candidate by configured screening candidate ID |
+| `uv run python main.py screening --index <n>` | screen one candidate by 1-based screening index |
 | `uv run python main.py train --candidate-id <id>` | train one candidate by ID |
 | `uv run python main.py train --index <n>` | train one candidate by 1-based index |
 | `uv run python main.py train --skip-existing` | skip candidates that already exist in MLflow |
@@ -149,9 +168,10 @@ The default pipeline stops after `train`; `submit` is always a separate explicit
 - **fetch**: ensures the competition zip is present locally.
 - **prepare**: fetches if needed, materializes the competition context in memory, and writes EDA reports under `reports/<competition_slug>/`.
 - **eda**: writes EDA reports only.
-- **train**: trains all configured candidates sequentially by default, loading one shared dataset context per invocation. Use `--candidate-id` or `--index` to train one configured candidate. Model candidates stage artifacts in a temp bundle and upload to MLflow. Blend candidates download their base candidates from MLflow, materialize blended predictions, then upload the blended candidate run.
-- **submit**: downloads the candidate from MLflow and validates `test_predictions.csv` against `sample_submission.csv`. With `--execute`, submits to Kaggle and records the submission event on the candidate run. Without `--execute`, performs dry-run validation only.
-- **refresh-submissions**: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and can recover missing MLflow submission events from `candidate=<candidate_id>` metadata before appending score observations.
+- **screening**: runs model-only screening candidates under `screening.cv`, writes screening runs to the screening MLflow experiment, and prints a promotion snippet for the top-ranked candidates.
+- **train**: trains canonical candidates sequentially by default, loading one shared dataset context per invocation. Use `--candidate-id` or `--index` to train one configured candidate. Model candidates stage artifacts in a temp bundle and upload to the candidates MLflow experiment. Blend candidates download their base candidates from the candidates experiment, materialize blended predictions, then upload the canonical candidate run.
+- **submit**: downloads the canonical candidate from MLflow and validates `test_predictions.csv` against `sample_submission.csv`. With `--execute`, submits to Kaggle and records the submission event on a submission run in the submissions MLflow experiment. Without `--execute`, performs dry-run validation only.
+- **refresh-submissions**: scans Kaggle submission history, matches `submit=<submission_event_id>` descriptions, and updates submission runs in the submissions experiment.
 
 ## Outputs
 
@@ -163,10 +183,16 @@ The default pipeline stops after `train`; `submit` is always a separate explicit
 
 ### MLflow
 
-- One MLflow experiment per `competition.slug`.
-- One canonical top-level MLflow run per `candidate_id`.
-- Failed or incomplete retry attempts may coexist as non-canonical top-level runs for the same `candidate_id`.
-- There are no stage-specific MLflow runs for `prepare`, `submit`, or `refresh-submissions`.
+- Three MLflow experiments per `competition.slug`:
+  - `<competition_slug>__screening`
+  - `<competition_slug>__candidates`
+  - `<competition_slug>__submissions`
+- Screening runs live only in the screening experiment.
+- Re-screening the same logical candidate is allowed and creates another screening run; screening runs are exploratory, not canonical.
+- One canonical top-level candidate run per `candidate_id` lives in the candidates experiment.
+- Submission event runs live in the submissions experiment.
+- Failed or incomplete retry attempts may coexist as non-canonical top-level runs for the same canonical `candidate_id`.
+- There are no stage-specific MLflow runs for `prepare` or `refresh-submissions`.
 - There is no local canonical `artifacts/` workflow.
 
 Real Kaggle submissions use auto-generated messages:
@@ -195,13 +221,15 @@ Preferred competitions for manual testing:
 - `playground-series-s5e10`: regression smoke test
 
 Suggested checks:
-- Run `uv run python main.py train` and confirm one MLflow run appears per configured candidate.
+- Run `uv run python main.py screening` and confirm one MLflow run appears per configured screening candidate in `<competition_slug>__screening`.
+- Run `uv run python main.py train` and confirm one MLflow run appears per configured canonical candidate in `<competition_slug>__candidates`.
 - Inspect a candidate run and confirm `logs/`, `candidate/`, `config/`, and `context/` artifacts exist.
 - Trigger one intentionally failing candidate and confirm the run is marked failed but still has `logs/runtime.log`.
 - Rerun the same candidate config after a failed attempt and confirm training retries without manual MLflow cleanup.
 - Train a blend candidate and confirm it downloads base candidates from MLflow.
 - Run `uv run python main.py submit --index 1` and confirm dry-run validation succeeds.
-- Run `uv run python main.py refresh-submissions` after a real submission and confirm MLflow metrics update, including recovery when the post-submit MLflow write was interrupted.
+- Run `uv run python main.py submit --index 1 --execute` and confirm a submission run appears in `<competition_slug>__submissions` while the canonical candidate run remains unchanged.
+- Run `uv run python main.py refresh-submissions` after a real submission and confirm submission-run metrics update, including recovery when the original submission-run write was interrupted.
 
 ### Current Limits
 

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -7,7 +7,7 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 ## System Flow
 
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train candidates before importing the runtime stack, install RAPIDS hooks only when the selected train batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the full `experiment.candidates` contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -24,23 +24,27 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
     - `context/competition.json`
     - `context/folds.csv`
     - `candidate/*`
-15. Create one MLflow run attempt for the candidate and upload the staged bundle.
-16. Treat only a `FINISHED` MLflow run with the full candidate artifact contract as the canonical run for that `candidate_id`.
-17. For real Kaggle submissions, download the explicitly selected candidate from MLflow, validate `test_predictions.csv` against `sample_submission.csv`, submit `submission.csv`, and append submission history artifacts back onto that same candidate run.
-18. For submission refresh, scan Kaggle submissions once, match `submit=<submission_event_id>` descriptions, recover missing submission events from `candidate=<candidate_id>` metadata when needed, and update candidate-run submission history plus scoreboard metrics in place.
+15. For screening, create one screening MLflow run attempt in `<competition_slug>__screening` and upload the staged bundle.
+16. For canonical training, create one canonical candidate MLflow run attempt in `<competition_slug>__candidates` and upload the staged bundle.
+17. Treat only a `FINISHED` canonical candidate run with the full candidate artifact contract as the canonical run for that `candidate_id`.
+18. For real Kaggle submissions, download the explicitly selected canonical candidate from MLflow, validate `test_predictions.csv` against `sample_submission.csv`, submit `submission.csv`, and create a submission run in `<competition_slug>__submissions`.
+19. For submission refresh, scan Kaggle submissions once, match `submit=<submission_event_id>` descriptions, recover missing submission runs from `candidate=<candidate_id>` metadata when needed, and update submission-run history plus scoreboard metrics in place.
 
 ## Runtime Invariants
 
 - MLflow is required. The runtime does not support a no-tracking mode.
 - Candidate state is canonical in MLflow, not on local disk.
-- A completed run with the full candidate artifact contract is canonical for a `candidate_id`.
+- A completed run with the full candidate artifact contract is canonical for a `candidate_id` only in the candidates experiment.
 - Failed or incomplete candidate attempts are non-canonical and may remain in MLflow until cleaned up.
-- Starting a new attempt while another run for the same `candidate_id` is still active is a hard error.
+- Starting a new canonical attempt while another canonical run for the same `candidate_id` is still active is a hard error.
 - `prepare` is not a persisted source of truth anymore.
-- `train` and `blend` must produce exactly one canonical candidate run keyed by `candidate_id`.
+- `screening` writes non-canonical screening runs into the screening experiment.
+- Re-screening the same logical candidate is expected behavior and creates another screening run; screening runs are exploratory history, not canonical state.
+- `train` and `blend` must produce exactly one canonical candidate run keyed by `candidate_id` in the candidates experiment.
 - Candidate runs should upload `logs/runtime.log` on both success and failure once the run exists.
 - `submit` resolves candidates from MLflow, not from local artifact directories.
-- `refresh-submissions` updates existing candidate runs and does not create standalone tracking runs.
+- `submit` and `refresh-submissions` must not mutate canonical candidate runs.
+- `refresh-submissions` updates existing submission runs and may recover missing submission runs.
 - Untuned model candidates use upstream library estimator defaults for all hyperparameters. The repo sets only runtime and task-contract params: determinism (`random_state`/`random_seed`), parallelism (`n_jobs`/`thread_count`), logging/file-writing controls (`verbosity`, `verbose`, `allow_writing_files`), problem-definition params (`objective`, `eval_metric`, `loss_function`), and GPU routing. Users who want a stronger untuned baseline should set `model_params` explicitly or enable optimization.
 - Representation steps must be deterministic and schema-preserving across train/test. All steps fit per fold inside the CV loop.
 - Binary probability blends require matching saved class metadata across all base candidates.
@@ -51,10 +55,12 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 ## Canonical Storage Model
 
 - MLflow is the canonical experiment store.
-- One MLflow experiment per `competition.slug`.
-- One canonical top-level MLflow run per `candidate_id`.
-- Failed or incomplete retry attempts may coexist as non-canonical top-level runs for the same `candidate_id`.
-- There are no stage-specific MLflow runs.
+- Three MLflow experiments per `competition.slug`: screening, candidates, submissions.
+- One canonical top-level MLflow candidate run per `candidate_id` in the candidates experiment.
+- Screening runs live in the screening experiment and are not canonical.
+- Submission runs live in the submissions experiment and track leaderboard events independently of candidate runs.
+- Tracking schema v4 changes candidate-id derivation versus archival schema-v3 data; existing experiments should be treated as read-only history rather than mixed with new runs.
+- Failed or incomplete retry attempts may coexist as non-canonical top-level runs for the same canonical `candidate_id`.
 - There are no local canonical candidate directories or local submission ledgers.
 
 Local persistent filesystem usage is limited to:
@@ -68,8 +74,19 @@ Each candidate run is named with `candidate_id`.
 
 ### Tags
 
-- `run_kind=candidate`
-- `tracking_schema_version=3`
+### Screening Runs
+
+Screening runs use:
+- `run_kind=screening`
+- `tracking_schema_version=4`
+
+Screening runs use the same candidate artifact bundle contract as canonical model candidates, but they live in the screening experiment and are not used for canonical lookup or submissions.
+
+### Candidate Runs
+
+Canonical candidate runs use:
+- `run_kind=canonical`
+- `tracking_schema_version=4`
 - `competition_slug`
 - `candidate_id`
 - `candidate_type`
@@ -119,13 +136,6 @@ Each candidate run is named with `candidate_id`.
 - `fit_wall_seconds`
 - `optimization_best_value` when present
 - `optimization_trial_count` when present
-- submission metrics when submission history exists:
-  - `submit_count`
-  - `latest_public_score`
-  - `best_public_score`
-  - `latest_private_score`
-  - `best_private_score`
-
 ### Artifacts
 
 Every candidate run stores:
@@ -145,15 +155,9 @@ Optional candidate artifacts:
 - `candidate/optimization_trials.csv`
 - `candidate/optimization_best_params.json`
 
-Submission artifacts on the same candidate run:
-- `submissions/history.json`
-- `submissions/<submission_event_id>/event.json`
-- `submissions/<submission_event_id>/submission.csv`
-- `submissions/<submission_event_id>/observations.json`
-
 ### Optimization Trial Child Runs
 
-Optuna-backed model candidates also create nested MLflow child runs named `trial_<n>` with `run_kind=optimization_trial`.
+Optuna-backed canonical model candidates also create nested MLflow child runs named `trial_<n>` with `run_kind=optimization_trial`.
 
 Trial child-run tags:
 - `run_kind=optimization_trial`
@@ -161,6 +165,42 @@ Trial child-run tags:
 - `candidate_id`
 - `model_family`
 - `trial_state`, transitioning from `RUNNING` to `COMPLETE` or `FAIL`
+
+### Submission Runs
+
+Submission runs use:
+- `run_kind=submission`
+- `tracking_schema_version=4`
+- `candidate_id`
+- `candidate_type`
+- `submission_event_id`
+- `representation_id`
+- `model_registry_key`
+
+Submission run params include:
+- `candidate_id`
+- `candidate_type`
+- `config_fingerprint`
+- `representation_id`
+- `model_registry_key`
+- `estimator_name`
+- `cv_metric_name`
+- `cv_metric_mean`
+- `cv_metric_std`
+- `submission_file_name`
+
+Submission run metrics:
+- `submit_count`
+- `latest_public_score`
+- `best_public_score`
+- `latest_private_score`
+- `best_private_score`
+
+Submission run artifacts:
+- `submissions/history.json`
+- `submissions/event.json`
+- `submissions/submission.csv`
+- `submissions/observations.json`
 
 Trial child-run params:
 - `trial_number`
@@ -206,17 +246,17 @@ Validation rules:
 Real Kaggle submissions:
 - generate one `submission_event_id`
 - use description format `candidate=<candidate_id> | submit=<submission_event_id> | <metric>=<value>`
-- append the event into `submissions/history.json` on the candidate run
-- upload `submission.csv` under `submissions/<submission_event_id>/`
-- attempt an immediate refresh without creating a separate run
+- create one submission run in the submissions experiment
+- write `submissions/history.json`, `submissions/event.json`, and `submissions/submission.csv` on that submission run
+- attempt an immediate refresh against that submission run
 
 Refresh behavior:
 - scan Kaggle submissions once
 - extract `submission_event_id` from the Kaggle description
-- match it to candidate-run submission history
-- when `submission_event_id` is missing from MLflow history but the Kaggle description includes `candidate=<candidate_id>`, recover the submission event onto that canonical candidate run
+- match it to submission-run history
+- when `submission_event_id` is missing from MLflow history but the Kaggle description includes `candidate=<candidate_id>`, recover the submission event into a new submission run linked to that canonical candidate
 - append only new observations
-- update candidate-run score metrics in place
+- update submission-run score metrics in place
 
 ## Candidate Manifest Contract
 

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -30,7 +30,7 @@ def _parse_bootstrap_cli_selection(argv: list[str] | None) -> BootstrapCliSelect
     if not argv:
         return BootstrapCliSelection(stage=None, candidate_index=None, candidate_id_requested=False)
 
-    known_stages = {"fetch", "prepare", "eda", "train", "submit", "refresh-submissions"}
+    known_stages = {"fetch", "prepare", "eda", "train", "screening", "submit", "refresh-submissions"}
     stage = argv[0] if argv[0] in known_stages else None
     option_argv = argv[1:] if stage is not None else argv
     index_value = _extract_option_value(option_argv, "--index")
@@ -44,35 +44,41 @@ def _parse_bootstrap_cli_selection(argv: list[str] | None) -> BootstrapCliSelect
 
 
 def _stage_uses_training_runtime(stage: str | None) -> bool:
-    return stage in {None, "train"}
+    return stage in {None, "train", "screening"}
 
 
 def _resolve_selected_candidate_indices(
     runtime_config,
     selection: BootstrapCliSelection,
 ) -> tuple[int, ...]:
+    configured_candidates = (
+        runtime_config.screening_candidates
+        if selection.stage == "screening"
+        else runtime_config.experiment_candidates
+    )
     if selection.candidate_index is not None:
         resolved_index = selection.candidate_index - 1
-        if resolved_index < 0 or resolved_index >= len(runtime_config.candidates):
+        if resolved_index < 0 or resolved_index >= len(configured_candidates):
             raise ValueError(
-                f"--index must be between 1 and {len(runtime_config.candidates)}. "
+                f"--index must be between 1 and {len(configured_candidates)}. "
                 f"Got {selection.candidate_index}."
             )
         return (resolved_index,)
-    return tuple(range(len(runtime_config.candidates)))
+    return tuple(range(len(configured_candidates)))
 
 
 def _raise_mixed_patch_runtime_error(selection: BootstrapCliSelection) -> None:
+    stage_name = "screening" if selection.stage == "screening" else "train"
     if selection.candidate_id_requested:
         raise RuntimeError(
             "This config mixes gpu_patch candidates with non-gpu_patch candidates. "
-            "Bootstrap happens before --candidate-id can be resolved safely, so this train invocation cannot "
+            f"Bootstrap happens before --candidate-id can be resolved safely, so this {stage_name} invocation cannot "
             "install RAPIDS hooks without risking the wrong process-wide runtime. "
-            "Use `uv run python main.py train --index <n>` or split the batch."
+            f"Use `uv run python main.py {stage_name} --index <n>` or split the batch."
         )
     raise RuntimeError(
-        "Batch train cannot mix gpu_patch candidates with non-gpu_patch candidates in one process because "
-        "RAPIDS hook installation is process-global. Split the run with `uv run python main.py train --index <n>` "
+        "Batch execution cannot mix gpu_patch candidates with non-gpu_patch candidates in one process because "
+        f"RAPIDS hook installation is process-global. Split the run with `uv run python main.py {stage_name} --index <n>` "
         "or separate invocations."
     )
 
@@ -102,9 +108,14 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
     capabilities = detect_runtime_capabilities()
     from tabular_shenanigans.representations.registry import REPRESENTATION_REGISTRY
 
+    configured_candidates = (
+        runtime_config.screening_candidates
+        if selection.stage == "screening"
+        else runtime_config.experiment_candidates
+    )
     selected_model_contexts = []
     for candidate_index in selected_candidate_indices:
-        candidate = runtime_config.candidates[candidate_index]
+        candidate = configured_candidates[candidate_index]
         if (
             candidate.candidate_type != "model"
             or candidate.model_family is None

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -16,7 +16,8 @@ class BootstrapRuntimeConfig:
     compute_target: str = "auto"
     gpu_backend: str = "auto"
     task_type: str | None = None
-    candidates: tuple[BootstrapCandidateRuntimeConfig, ...] = ()
+    experiment_candidates: tuple[BootstrapCandidateRuntimeConfig, ...] = ()
+    screening_candidates: tuple[BootstrapCandidateRuntimeConfig, ...] = ()
 
 
 def _validate_compute_target(value: object) -> str:
@@ -61,6 +62,14 @@ def _coerce_bootstrap_candidate(candidate: object) -> BootstrapCandidateRuntimeC
     )
 
 
+def _coerce_bootstrap_candidate_list(candidates: object, field_name: str) -> list[BootstrapCandidateRuntimeConfig]:
+    if candidates is None:
+        return []
+    if not isinstance(candidates, list):
+        raise ValueError(f"{field_name} must be a list when provided.")
+    return [_coerce_bootstrap_candidate(candidate_item) for candidate_item in candidates]
+
+
 def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> BootstrapRuntimeConfig:
     config_path = Path(path)
 
@@ -95,21 +104,28 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
         raise ValueError("Use either experiment.candidate or experiment.candidates, not both.")
     if candidate is not None and not isinstance(candidate, dict):
         raise ValueError("experiment.candidate must be a mapping when provided.")
-    if candidates is not None and not isinstance(candidates, list):
-        raise ValueError("experiment.candidates must be a list when provided.")
     competition = raw_data.get("competition")
     if competition is not None and not isinstance(competition, dict):
         raise ValueError("competition must be a mapping when provided.")
+    screening = raw_data.get("screening")
+    if screening is not None and not isinstance(screening, dict):
+        raise ValueError("screening must be a mapping when provided.")
 
-    candidate_list: list[BootstrapCandidateRuntimeConfig] = []
+    experiment_candidate_list: list[BootstrapCandidateRuntimeConfig] = []
     if candidates is not None:
-        candidate_list = [_coerce_bootstrap_candidate(candidate_item) for candidate_item in candidates]
+        experiment_candidate_list = _coerce_bootstrap_candidate_list(candidates, "experiment.candidates")
     elif candidate is not None:
-        candidate_list = [_coerce_bootstrap_candidate(candidate)]
+        experiment_candidate_list = [_coerce_bootstrap_candidate(candidate)]
+
+    screening_candidate_list = _coerce_bootstrap_candidate_list(
+        None if screening is None else screening.get("candidates"),
+        "screening.candidates",
+    )
 
     return BootstrapRuntimeConfig(
         compute_target=_validate_compute_target(None if runtime is None else runtime.get("compute_target")),
         gpu_backend=_validate_gpu_backend(None if runtime is None else runtime.get("gpu_backend")),
         task_type=None if competition is None else competition.get("task_type"),
-        candidates=tuple(candidate_list),
+        experiment_candidates=tuple(experiment_candidate_list),
+        screening_candidates=tuple(screening_candidate_list),
     )

--- a/src/tabular_shenanigans/cli.py
+++ b/src/tabular_shenanigans/cli.py
@@ -7,6 +7,11 @@ from tabular_shenanigans.competition import prepare_competition
 from tabular_shenanigans.config import AppConfig, load_config
 from tabular_shenanigans.data import fetch_competition_data, load_competition_dataset_context
 from tabular_shenanigans.eda import run_eda
+from tabular_shenanigans.screening import (
+    ScreeningBatchSummary,
+    print_screening_batch_summary,
+    run_screening_batch,
+)
 from tabular_shenanigans.submit import run_submission, run_submission_refresh
 from tabular_shenanigans.training_orchestration import (
     TrainingBatchSummary,
@@ -43,6 +48,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--skip-existing",
         action="store_true",
         help="Skip configured candidates that already exist in MLflow.",
+    )
+
+    screening_parser = subparsers.add_parser("screening", help="Run screening candidates into MLflow.")
+    screening_selector_group = screening_parser.add_mutually_exclusive_group()
+    screening_selector_group.add_argument(
+        "--candidate-id",
+        help="Optional configured screening candidate_id from config.yaml. Omit to screen all configured candidates.",
+    )
+    screening_selector_group.add_argument(
+        "--index",
+        type=int,
+        help="Optional 1-based configured screening candidate index from config.yaml.",
     )
 
     subparsers.add_parser(
@@ -117,6 +134,18 @@ def _print_resolved_setup(config: AppConfig) -> None:
             candidate_config=config.with_candidate_index(candidate_index),
             candidate_index=candidate_index + 1,
         )
+    if config.screening is not None:
+        print(
+            "Resolved screening setup: "
+            f"configured_candidates={config.screening_candidate_count}, "
+            f"folds={config.screening.cv.n_splits}, "
+            f"promote_top_k={config.screening.promote_top_k}"
+        )
+        for candidate_index in range(config.screening_candidate_count):
+            _print_candidate_setup(
+                candidate_config=config.with_screening_candidate_index(candidate_index),
+                candidate_index=candidate_index + 1,
+            )
 
 
 def _ensure_data_ready(config: AppConfig) -> Path:
@@ -185,6 +214,31 @@ def _run_train_stage(
     return batch_summary
 
 
+def _run_screening_stage(
+    config: AppConfig,
+    dataset_context=None,
+    candidate_id: str | None = None,
+    index: int | None = None,
+) -> ScreeningBatchSummary:
+    if config.screening is None:
+        raise ValueError("screening is not configured in config.yaml.")
+    if dataset_context is None:
+        _ensure_data_ready(config)
+        dataset_context = _load_shared_dataset_context(config)
+    batch_summary = run_screening_batch(
+        config=config,
+        dataset_context=dataset_context,
+        candidate_id=candidate_id,
+        index=index,
+    )
+    print_screening_batch_summary(config=config, summary=batch_summary)
+    if batch_summary.failed_count > 0:
+        raise RuntimeError(
+            f"{batch_summary.failed_count} candidate(s) failed during screening. See the batch summary above."
+        )
+    return batch_summary
+
+
 def _resolve_submit_candidate_id(
     config: AppConfig,
     candidate_id: str | None = None,
@@ -223,9 +277,11 @@ def _run_submit_stage(
     print(
         "Submission stage complete: "
         f"candidate_id={submission_result.candidate_id}, "
-        f"mlflow_run_id={submission_result.candidate_run_id}, "
+        f"candidate_run_id={submission_result.candidate_run_id}, "
         f"status={submission_result.submission_status}"
     )
+    if submission_result.submission_run_id is not None:
+        print(f"Submission MLflow run: {submission_result.submission_run_id}")
     if submission_result.submission_event_id is not None:
         print(f"Submission event recorded: {submission_result.submission_event_id}")
     if submission_result.submission_artifact_path is not None:
@@ -300,6 +356,14 @@ def main(argv: list[str] | None = None) -> None:
             candidate_id=args.candidate_id,
             index=args.index,
             skip_existing=args.skip_existing,
+        )
+        return
+
+    if args.stage == "screening":
+        _run_screening_stage(
+            config=config,
+            candidate_id=args.candidate_id,
+            index=args.index,
         )
         return
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -29,6 +29,18 @@ class ConfigError(ValueError):
     pass
 
 
+def _competition_identity_fingerprint_payload(competition: "CompetitionConfig") -> dict[str, object]:
+    return {
+        "slug": competition.slug,
+        "task_type": competition.task_type,
+        "primary_metric": competition.primary_metric,
+        "id_column": competition.id_column,
+        "label_column": competition.label_column,
+        "features": competition.features.model_dump(mode="python"),
+        "positive_label": competition.positive_label,
+    }
+
+
 class CompetitionCvConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -57,6 +69,35 @@ class CompetitionConfig(BaseModel):
     label_column: str | None = None
     cv: CompetitionCvConfig = Field(default_factory=CompetitionCvConfig)
     features: CompetitionFeaturesConfig = Field(default_factory=CompetitionFeaturesConfig)
+
+
+class ScreeningConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidates: list["ModelCandidateConfig"] = Field(min_length=1)
+    cv: CompetitionCvConfig = Field(
+        default_factory=lambda: CompetitionCvConfig(n_splits=2, shuffle=True, random_state=42)
+    )
+    promote_top_k: int = Field(default=3, ge=1)
+    active_candidate_index: int = Field(default=0, exclude=True, repr=False, ge=0)
+
+    @property
+    def candidate(self) -> "ModelCandidateConfig":
+        return self.candidates[self.active_candidate_index]
+
+    @model_validator(mode="after")
+    def validate_active_candidate_index(self) -> "ScreeningConfig":
+        if self.active_candidate_index >= len(self.candidates):
+            raise ValueError(
+                "screening.active_candidate_index must reference a configured candidate. "
+                f"Got {self.active_candidate_index} for {len(self.candidates)} candidates."
+            )
+        if self.promote_top_k > len(self.candidates):
+            raise ValueError(
+                "screening.promote_top_k cannot exceed the number of screening candidates. "
+                f"Got promote_top_k={self.promote_top_k} for {len(self.candidates)} candidates."
+            )
+        return self
 
 
 class CandidateOptimizationConfig(BaseModel):
@@ -210,6 +251,12 @@ class AppConfig(BaseModel):
 
     competition: CompetitionConfig
     experiment: ExperimentConfig
+    screening: ScreeningConfig | None = None
+    active_run_stage: Literal["canonical", "screening"] = Field(
+        default="canonical",
+        exclude=True,
+        repr=False,
+    )
 
     @model_validator(mode="after")
     def validate_config(self) -> "AppConfig":
@@ -282,6 +329,61 @@ class AppConfig(BaseModel):
                 "Configured candidates must derive distinct candidate_id values. "
                 f"Duplicates: {duplicate_summary}"
             )
+
+        if self.screening is not None:
+            resolved_screening_candidate_ids: dict[str, list[int]] = {}
+            for candidate_index, candidate in enumerate(self.screening.candidates, start=1):
+                try:
+                    candidate.representation_id = resolve_representation_id(candidate.representation_id)
+                    representation_definition = get_representation_definition(candidate.representation_id)
+                    resolved_model_registry_key = self.resolve_screening_model_registry_key_for_index(
+                        candidate_index - 1
+                    )
+                    validate_model_preprocessing_compatibility(
+                        task_type=competition.task_type,
+                        model_id=resolved_model_registry_key,
+                        categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
+                    )
+                    validate_model_parameter_overrides(
+                        task_type=competition.task_type,
+                        model_id=resolved_model_registry_key,
+                        parameter_overrides=candidate.model_params,
+                    )
+                    if candidate.optimization is not None:
+                        optimization = candidate.optimization
+                        if optimization.n_trials is None and optimization.timeout_seconds is None:
+                            raise ValueError(
+                                "At least one screening candidate.optimization stopping condition is required. "
+                                "Set screening candidate.optimization.n_trials or "
+                                "screening candidate.optimization.timeout_seconds."
+                            )
+                        if not is_model_tunable(competition.task_type, resolved_model_registry_key):
+                            supported_tunable_model_families = get_tunable_model_ids(competition.task_type)
+                            raise ValueError(
+                                f"Configured screening model_family '{candidate.model_family}' does not support "
+                                f"optimization for task_type '{competition.task_type}'. Supported tunable model "
+                                f"families: {supported_tunable_model_families}"
+                            )
+                except ValueError as exc:
+                    raise ValueError(f"screening.candidates[{candidate_index}] is invalid: {exc}") from exc
+
+                resolved_candidate_id = self.resolve_screening_candidate_id_for_index(candidate_index - 1)
+                resolved_screening_candidate_ids.setdefault(resolved_candidate_id, []).append(candidate_index)
+
+            duplicate_screening_candidate_ids = {
+                candidate_id: candidate_indices
+                for candidate_id, candidate_indices in resolved_screening_candidate_ids.items()
+                if len(candidate_indices) > 1
+            }
+            if duplicate_screening_candidate_ids:
+                duplicate_summary = "; ".join(
+                    f"{candidate_id} at screening candidates {candidate_indices}"
+                    for candidate_id, candidate_indices in sorted(duplicate_screening_candidate_ids.items())
+                )
+                raise ValueError(
+                    "Configured screening candidates must derive distinct candidate_id values. "
+                    f"Duplicates: {duplicate_summary}"
+                )
         return self
 
     @property
@@ -297,6 +399,12 @@ class AppConfig(BaseModel):
         return len(self.experiment.candidates)
 
     @property
+    def screening_candidate_count(self) -> int:
+        if self.screening is None:
+            return 0
+        return len(self.screening.candidates)
+
+    @property
     def active_candidate_index(self) -> int:
         return self.experiment.active_candidate_index
 
@@ -309,6 +417,13 @@ class AppConfig(BaseModel):
             return self.experiment.candidate
         return self.experiment.candidates[candidate_index]
 
+    def get_screening_candidate(self, candidate_index: int | None = None) -> ModelCandidateConfig:
+        if self.screening is None:
+            raise ValueError("screening is not configured in config.yaml.")
+        if candidate_index is None:
+            return self.screening.candidate
+        return self.screening.candidates[candidate_index]
+
     def with_candidate_index(self, candidate_index: int) -> "AppConfig":
         if candidate_index < 0 or candidate_index >= self.candidate_count:
             raise ValueError(
@@ -316,6 +431,22 @@ class AppConfig(BaseModel):
             )
         copied_config = self.model_copy(deep=True)
         copied_config.experiment.active_candidate_index = candidate_index
+        return copied_config
+
+    def with_screening_candidate_index(self, candidate_index: int) -> "AppConfig":
+        if self.screening is None:
+            raise ValueError("screening is not configured in config.yaml.")
+        if candidate_index < 0 or candidate_index >= self.screening_candidate_count:
+            raise ValueError(
+                f"Screening candidate index must be between 0 and {self.screening_candidate_count - 1}. "
+                f"Got {candidate_index}."
+            )
+        copied_config = self.model_copy(deep=True)
+        copied_config.screening.active_candidate_index = candidate_index
+        copied_config.experiment.candidates = [copied_config.screening.candidate]
+        copied_config.experiment.active_candidate_index = 0
+        copied_config.competition.cv = copied_config.screening.cv.model_copy(deep=True)
+        copied_config.active_run_stage = "screening"
         return copied_config
 
     def resolve_candidate_indices(
@@ -349,10 +480,50 @@ class AppConfig(BaseModel):
 
         return list(range(self.candidate_count))
 
+    def resolve_screening_candidate_indices(
+        self,
+        candidate_id: str | None = None,
+        index: int | None = None,
+        require_explicit: bool = False,
+    ) -> list[int]:
+        if self.screening is None:
+            raise ValueError("screening is not configured in config.yaml.")
+        if candidate_id is not None and index is not None:
+            raise ValueError("Use either --candidate-id or --index, not both.")
+
+        if index is not None:
+            resolved_index = index - 1
+            if resolved_index < 0 or resolved_index >= self.screening_candidate_count:
+                raise ValueError(
+                    f"--index must be between 1 and {self.screening_candidate_count}. Got {index}."
+                )
+            return [resolved_index]
+
+        if candidate_id is not None:
+            configured_candidate_ids = self.configured_screening_candidate_ids
+            try:
+                return [configured_candidate_ids.index(candidate_id)]
+            except ValueError as exc:
+                raise ValueError(
+                    f"Configured screening candidate_id '{candidate_id}' was not found in config.yaml."
+                ) from exc
+
+        if require_explicit:
+            raise ValueError("Select a configured screening candidate with --candidate-id or --index.")
+
+        return list(range(self.screening_candidate_count))
+
     def resolve_model_registry_key_for_index(self, candidate_index: int | None = None) -> str:
         candidate = self.get_candidate(candidate_index)
         if not isinstance(candidate, ModelCandidateConfig):
             raise ValueError("resolved_model_registry_key is only available for model candidates.")
+        return resolve_candidate_model_id(
+            task_type=self.competition.task_type,
+            model_family=candidate.model_family,
+        )
+
+    def resolve_screening_model_registry_key_for_index(self, candidate_index: int | None = None) -> str:
+        candidate = self.get_screening_candidate(candidate_index)
         return resolve_candidate_model_id(
             task_type=self.competition.task_type,
             model_family=candidate.model_family,
@@ -454,30 +625,14 @@ class AppConfig(BaseModel):
             optimization_payload: dict[str, object] | None = None
             if candidate.optimization is not None:
                 optimization_payload = candidate.optimization.model_dump(mode="python")
-            runtime_execution_context = self.runtime_execution_context_for_index(candidate_index)
-            preprocessing_execution_plan = self.preprocessing_execution_plan_for_index(candidate_index)
             fingerprint_payload = {
-                "competition": {
-                    "task_type": competition.task_type,
-                    "primary_metric": competition.primary_metric,
-                    "cv": competition.cv.model_dump(mode="python"),
-                    "features": competition.features.model_dump(mode="python"),
-                    "positive_label": competition.positive_label,
-                },
+                "competition": _competition_identity_fingerprint_payload(competition),
                 "candidate": {
                     "representation_id": candidate.representation_id,
                     "model_family": candidate.model_family,
                     "model_registry_key": self.resolve_model_registry_key_for_index(candidate_index),
                     "model_params": candidate.model_params,
                     "optimization": optimization_payload,
-                },
-                "runtime": {
-                    "compute_target": self.experiment.runtime.compute_target,
-                    "gpu_backend": self.experiment.runtime.gpu_backend,
-                    "resolved_compute_target": runtime_execution_context.resolved_compute_target,
-                    "resolved_gpu_backend": runtime_execution_context.resolved_gpu_backend,
-                    "acceleration_backend": runtime_execution_context.acceleration_backend,
-                    "preprocessing_backend": preprocessing_execution_plan.preprocessing_backend,
                 },
             }
             return build_model_candidate_id(
@@ -488,12 +643,7 @@ class AppConfig(BaseModel):
 
         normalized_weights = self.resolve_blend_weights_for_index(candidate_index)
         fingerprint_payload = {
-            "competition": {
-                "task_type": competition.task_type,
-                "primary_metric": competition.primary_metric,
-                "cv": competition.cv.model_dump(mode="python"),
-                "features": competition.features.model_dump(mode="python"),
-            },
+            "competition": _competition_identity_fingerprint_payload(competition),
             "components": [
                 {
                     "candidate_id": component_candidate_id,
@@ -508,6 +658,28 @@ class AppConfig(BaseModel):
         return build_blend_candidate_id(
             base_candidate_ids=candidate.base_candidate_ids,
             normalized_weights=normalized_weights,
+            fingerprint_payload=fingerprint_payload,
+        )
+
+    def resolve_screening_candidate_id_for_index(self, candidate_index: int | None = None) -> str:
+        competition = self.competition
+        candidate = self.get_screening_candidate(candidate_index)
+        optimization_payload: dict[str, object] | None = None
+        if candidate.optimization is not None:
+            optimization_payload = candidate.optimization.model_dump(mode="python")
+        fingerprint_payload = {
+            "competition": _competition_identity_fingerprint_payload(competition),
+            "candidate": {
+                "representation_id": candidate.representation_id,
+                "model_family": candidate.model_family,
+                "model_registry_key": self.resolve_screening_model_registry_key_for_index(candidate_index),
+                "model_params": candidate.model_params,
+                "optimization": optimization_payload,
+            },
+        }
+        return build_model_candidate_id(
+            model_registry_key=self.resolve_screening_model_registry_key_for_index(candidate_index),
+            representation_id=candidate.representation_id,
             fingerprint_payload=fingerprint_payload,
         )
 
@@ -530,6 +702,19 @@ class AppConfig(BaseModel):
     @property
     def resolved_candidate_id(self) -> str:
         return self.resolve_candidate_id_for_index()
+
+    @property
+    def configured_screening_candidate_ids(self) -> list[str]:
+        return [
+            self.resolve_screening_candidate_id_for_index(candidate_index)
+            for candidate_index in range(self.screening_candidate_count)
+        ]
+
+    @property
+    def resolved_screening_candidate_id(self) -> str:
+        if self.screening is None:
+            raise ValueError("screening is not configured in config.yaml.")
+        return self.resolve_screening_candidate_id_for_index(self.screening.active_candidate_index)
 
 
 def load_config(path: str = "config.yaml") -> AppConfig:

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -4,7 +4,7 @@ import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from tabular_shenanigans.candidate_artifacts import (
     CANDIDATE_ARTIFACT_DIRNAME,
@@ -14,11 +14,15 @@ from tabular_shenanigans.candidate_artifacts import (
     load_candidate_manifest,
 )
 from tabular_shenanigans.config import AppConfig
-from tabular_shenanigans.submission_history import CandidateSubmissionHistory
+from tabular_shenanigans.submission_history import CandidateSubmissionHistory, SubmissionEvent
 
-TRACKING_SCHEMA_VERSION = "3"
-RUN_KIND_CANDIDATE = "candidate"
+TRACKING_SCHEMA_VERSION = "4"
+RUN_KIND_SCREENING = "screening"
+RUN_KIND_CANONICAL = "canonical"
+RUN_KIND_SUBMISSION = "submission"
+RUN_KIND_OPTIMIZATION_TRIAL = "optimization_trial"
 SUBMISSION_HISTORY_ARTIFACT_PATH = "submissions/history.json"
+SUBMISSION_EVENT_ARTIFACT_PATH = "submissions/event.json"
 CANDIDATE_BUNDLE_REQUIRED_ARTIFACT_PATHS = (
     "logs/runtime.log",
     "config/runtime_config.json",
@@ -31,6 +35,7 @@ CANDIDATE_BUNDLE_REQUIRED_ARTIFACT_PATHS = (
 )
 CANDIDATE_BUNDLE_ROOT_PATHS = ("logs", "config", "context", "candidate")
 ACTIVE_MLFLOW_RUN_STATUSES = {"RUNNING", "SCHEDULED"}
+ExperimentRole = Literal["screening", "candidates", "submissions"]
 
 
 @dataclass(frozen=True)
@@ -38,6 +43,7 @@ class CandidateRunRef:
     run_id: str
     experiment_id: str
     candidate_id: str
+    run_kind: str
 
 
 @dataclass(frozen=True)
@@ -53,6 +59,14 @@ class DownloadedCandidateBundle:
 class TrialRunRef:
     run_id: str
     trial_number: int
+
+
+@dataclass(frozen=True)
+class SubmissionRunRef:
+    run_id: str
+    experiment_id: str
+    candidate_id: str
+    submission_event_id: str
 
 
 @dataclass(frozen=True)
@@ -103,11 +117,27 @@ def _client(config: AppConfig):
     return mlflow.tracking.MlflowClient()
 
 
-def _experiment_id(config: AppConfig) -> str:
+def _experiment_name(config: AppConfig, role: ExperimentRole) -> str:
+    return f"{config.competition.slug}__{role}"
+
+
+def _experiment_id(config: AppConfig, role: ExperimentRole) -> str:
     mlflow = _load_mlflow()
     mlflow.set_tracking_uri(config.experiment.tracking.tracking_uri)
-    experiment = mlflow.set_experiment(config.competition.slug)
+    experiment = mlflow.set_experiment(_experiment_name(config, role))
     return experiment.experiment_id
+
+
+def _training_experiment_role(config: AppConfig) -> ExperimentRole:
+    if config.active_run_stage == "screening":
+        return "screening"
+    return "candidates"
+
+
+def _training_run_kind(config: AppConfig) -> str:
+    if config.active_run_stage == "screening":
+        return RUN_KIND_SCREENING
+    return RUN_KIND_CANONICAL
 
 
 def _git_output(args: list[str]) -> str | None:
@@ -161,21 +191,29 @@ def _log_metrics(client, run_id: str, metrics: dict[str, float | int | None]) ->
         client.log_metric(run_id, key, float(value))
 
 
-def _candidate_search_filter(candidate_id: str) -> str:
+def _candidate_search_filter(candidate_id: str, run_kind: str) -> str:
     return (
-        f"tags.run_kind = '{RUN_KIND_CANDIDATE}' "
+        f"tags.run_kind = '{run_kind}' "
         f"and tags.candidate_id = '{candidate_id}'"
     )
+
+
+def _submission_run_search_filter() -> str:
+    return f"tags.run_kind = '{RUN_KIND_SUBMISSION}'"
 
 
 def _candidate_run_ref_from_run(run) -> CandidateRunRef:
     candidate_id = run.data.tags.get("candidate_id")
     if candidate_id is None:
         raise ValueError(f"Candidate run {run.info.run_id} is missing tag 'candidate_id'.")
+    run_kind = run.data.tags.get("run_kind")
+    if run_kind is None:
+        raise ValueError(f"Candidate run {run.info.run_id} is missing tag 'run_kind'.")
     return CandidateRunRef(
         run_id=run.info.run_id,
         experiment_id=run.info.experiment_id,
         candidate_id=str(candidate_id),
+        run_kind=str(run_kind),
     )
 
 
@@ -226,11 +264,7 @@ def _required_candidate_artifact_paths(manifest: Mapping[str, object] | None = N
     return required_paths
 
 
-def _assess_candidate_run(
-    client,
-    run,
-    destination_dir: Path,
-) -> CandidateRunAssessment:
+def _assess_candidate_run(client, run, destination_dir: Path) -> CandidateRunAssessment:
     run_ref = _candidate_run_ref_from_run(run)
     artifact_paths = _collect_candidate_bundle_artifact_paths(client, run_ref.run_id)
     required_paths = _required_candidate_artifact_paths()
@@ -277,11 +311,7 @@ def _candidate_run_guidance(lookup: CandidateRunLookup) -> str:
     return "Retry training to create a fresh canonical run or repair/delete the broken runs."
 
 
-def _build_candidate_lookup_from_runs(
-    candidate_id: str,
-    client,
-    runs: list[Any],
-) -> CandidateRunLookup:
+def _build_candidate_lookup_from_runs(candidate_id: str, client, runs: list[Any]) -> CandidateRunLookup:
     with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-candidate-lookup-") as temp_dir:
         temp_root = Path(temp_dir)
         assessments = tuple(
@@ -310,10 +340,10 @@ def _build_candidate_lookup_from_runs(
 
 def _candidate_run_lookup(config: AppConfig, candidate_id: str) -> CandidateRunLookup:
     client = _client(config)
-    experiment_id = _experiment_id(config)
+    experiment_id = _experiment_id(config, "candidates")
     runs = client.search_runs(
         experiment_ids=[experiment_id],
-        filter_string=_candidate_search_filter(candidate_id),
+        filter_string=_candidate_search_filter(candidate_id, RUN_KIND_CANONICAL),
         max_results=100,
     )
     return _build_candidate_lookup_from_runs(
@@ -327,7 +357,7 @@ def find_candidate_run(config: AppConfig, candidate_id: str) -> CandidateRunRef:
     lookup = _candidate_run_lookup(config=config, candidate_id=candidate_id)
     if not lookup.matching_runs:
         raise ValueError(
-            f"Candidate '{candidate_id}' was not found in MLflow experiment '{config.competition.slug}'."
+            f"Candidate '{candidate_id}' was not found in MLflow experiment '{_experiment_name(config, 'candidates')}'."
         )
     if lookup.canonical_run is None:
         matching_runs = "; ".join(_format_candidate_run_assessment(assessment) for assessment in lookup.matching_runs)
@@ -371,7 +401,7 @@ def candidate_run_exists(config: AppConfig, candidate_id: str) -> bool:
 def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: str) -> dict[str, object]:
     runtime_execution_context = config.runtime_execution_context
     tags: dict[str, object] = {
-        "run_kind": RUN_KIND_CANDIDATE,
+        "run_kind": _training_run_kind(config),
         "tracking_schema_version": TRACKING_SCHEMA_VERSION,
         "competition_slug": config.competition.slug,
         "candidate_id": candidate_id,
@@ -390,14 +420,12 @@ def _base_candidate_tags(config: AppConfig, candidate_id: str, candidate_type: s
     return tags
 
 
-def create_candidate_run(
-    config: AppConfig,
-    candidate_id: str,
-    candidate_type: str,
-) -> CandidateRunRef:
-    ensure_candidate_run_absent(config=config, candidate_id=candidate_id)
+def create_candidate_run(config: AppConfig, candidate_id: str, candidate_type: str) -> CandidateRunRef:
+    if config.active_run_stage != "screening":
+        ensure_candidate_run_absent(config=config, candidate_id=candidate_id)
     client = _client(config)
-    experiment_id = _experiment_id(config)
+    role = _training_experiment_role(config)
+    experiment_id = _experiment_id(config, role)
     run = client.create_run(
         experiment_id=experiment_id,
         tags=_base_candidate_tags(config=config, candidate_id=candidate_id, candidate_type=candidate_type),
@@ -407,14 +435,11 @@ def create_candidate_run(
         run_id=run.info.run_id,
         experiment_id=experiment_id,
         candidate_id=candidate_id,
+        run_kind=_training_run_kind(config),
     )
 
 
-def terminate_run(
-    config: AppConfig,
-    run_id: str,
-    status: str,
-) -> None:
+def terminate_run(config: AppConfig, run_id: str, status: str) -> None:
     _client(config).set_terminated(run_id=run_id, status=status)
 
 
@@ -467,7 +492,8 @@ def _candidate_run_params(config: AppConfig, manifest: dict[str, object]) -> dic
 
 
 def _candidate_run_tags(config: AppConfig, manifest: dict[str, object]) -> dict[str, object]:
-    tags = {
+    return {
+        "run_kind": _training_run_kind(config),
         "competition_slug": manifest.get("competition_slug"),
         "candidate_id": manifest.get("candidate_id"),
         "candidate_type": manifest.get("candidate_type"),
@@ -475,7 +501,6 @@ def _candidate_run_tags(config: AppConfig, manifest: dict[str, object]) -> dict[
         "primary_metric": manifest.get("primary_metric"),
         "config_fingerprint": manifest.get("config_fingerprint"),
     }
-    return tags
 
 
 def _candidate_run_metrics(
@@ -513,30 +538,6 @@ def _candidate_run_metrics(
     return metrics
 
 
-def _trial_run_context_params(
-    config: AppConfig,
-    trial_number: int,
-    hyperparams: dict[str, object],
-    representation_id: str,
-    model_family: str,
-    model_registry_key: str,
-    preprocessing_backend: str,
-) -> dict[str, object]:
-    runtime_execution_context = config.runtime_execution_context
-    params: dict[str, object] = {
-        "trial_number": trial_number,
-        "representation_id": representation_id,
-        "model_family": model_family,
-        "model_registry_key": model_registry_key,
-        "runtime__resolved_compute_target": runtime_execution_context.resolved_compute_target,
-        "runtime__resolved_gpu_backend": runtime_execution_context.resolved_gpu_backend,
-        "runtime__preprocessing_backend": preprocessing_backend,
-    }
-    for key, value in hyperparams.items():
-        params[f"hp__{key}"] = value
-    return params
-
-
 def create_trial_run(
     config: AppConfig,
     candidate_run: CandidateRunRef,
@@ -552,7 +553,8 @@ def create_trial_run(
         experiment_id=candidate_run.experiment_id,
         run_name=f"trial_{trial_number}",
         tags={
-            "run_kind": "optimization_trial",
+            "run_kind": RUN_KIND_OPTIMIZATION_TRIAL,
+            "tracking_schema_version": TRACKING_SCHEMA_VERSION,
             "mlflow.parentRunId": candidate_run.run_id,
             "candidate_id": candidate_run.candidate_id,
             "model_family": model_family,
@@ -563,15 +565,16 @@ def create_trial_run(
     _log_params(
         client,
         trial_run_id,
-        _trial_run_context_params(
-            config=config,
-            trial_number=trial_number,
-            hyperparams=hyperparams,
-            representation_id=representation_id,
-            model_family=model_family,
-            model_registry_key=model_registry_key,
-            preprocessing_backend=preprocessing_backend,
-        ),
+        {
+            "trial_number": trial_number,
+            "representation_id": representation_id,
+            "model_family": model_family,
+            "model_registry_key": model_registry_key,
+            "runtime__resolved_compute_target": config.runtime_execution_context.resolved_compute_target,
+            "runtime__resolved_gpu_backend": config.runtime_execution_context.resolved_gpu_backend,
+            "runtime__preprocessing_backend": preprocessing_backend,
+            **{f"hp__{key}": value for key, value in hyperparams.items()},
+        },
     )
     return TrialRunRef(run_id=trial_run_id, trial_number=trial_number)
 
@@ -583,14 +586,15 @@ def finalize_trial_run(
     cv_score_mean: float | None,
     cv_score_std: float | None,
     duration_seconds: float | None,
-    trial_state: str,  # "COMPLETE" | "FAIL"
+    trial_state: str,
 ) -> None:
     client = _client(config)
     if isinstance(model_params, dict):
-        params: dict[str, object] = {}
-        for key, value in model_params.items():
-            params[f"mp__{key}"] = value
-        _log_params(client, trial_run.run_id, params)
+        _log_params(
+            client,
+            trial_run.run_id,
+            {f"mp__{key}": value for key, value in model_params.items()},
+        )
     _log_metrics(
         client,
         trial_run.run_id,
@@ -634,25 +638,15 @@ def log_candidate_run(
     )
 
 
-def upload_run_log(
-    config: AppConfig,
-    run_id: str,
-    log_path: Path,
-    artifact_dir: str = "logs",
-) -> None:
+def upload_run_log(config: AppConfig, run_id: str, log_path: Path, artifact_dir: str = "logs") -> None:
     if not log_path.exists():
         raise ValueError(f"Runtime log artifact does not exist: {log_path}")
     _client(config).log_artifact(run_id, str(log_path), artifact_dir)
 
 
-def download_candidate_manifest(
-    config: AppConfig,
-    run_id: str,
-    destination_dir: Path,
-) -> dict[str, object]:
-    client = _client(config)
+def download_candidate_manifest(config: AppConfig, run_id: str, destination_dir: Path) -> dict[str, object]:
     return _download_json_artifact(
-        client=client,
+        client=_client(config),
         run_id=run_id,
         artifact_path=f"{CANDIDATE_ARTIFACT_DIRNAME}/{CANDIDATE_MANIFEST_FILENAME}",
         destination_dir=destination_dir,
@@ -688,11 +682,7 @@ def _validate_downloaded_candidate_artifact_dir(
         )
 
 
-def download_candidate_bundle(
-    config: AppConfig,
-    candidate_id: str,
-    destination_dir: Path,
-) -> DownloadedCandidateBundle:
+def download_candidate_bundle(config: AppConfig, candidate_id: str, destination_dir: Path) -> DownloadedCandidateBundle:
     candidate_run = find_candidate_run(config=config, candidate_id=candidate_id)
     client = _client(config)
     candidate_dir_path = Path(
@@ -718,11 +708,74 @@ def download_candidate_bundle(
     )
 
 
-def download_submission_history(
-    config: AppConfig,
-    run_id: str,
-    destination_dir: Path,
-) -> CandidateSubmissionHistory:
+def create_submission_run(config: AppConfig, submission_event: SubmissionEvent) -> SubmissionRunRef:
+    client = _client(config)
+    experiment_id = _experiment_id(config, "submissions")
+    run = client.create_run(
+        experiment_id=experiment_id,
+        run_name=submission_event.submission_event_id,
+        tags={
+            "run_kind": RUN_KIND_SUBMISSION,
+            "tracking_schema_version": TRACKING_SCHEMA_VERSION,
+            "competition_slug": submission_event.competition_slug,
+            "candidate_id": submission_event.candidate_id,
+            "candidate_type": submission_event.candidate_type,
+            "submission_event_id": submission_event.submission_event_id,
+            "representation_id": submission_event.representation_id,
+            "model_registry_key": submission_event.model_registry_key,
+            **_git_metadata(),
+        },
+    )
+    _log_params(
+        client,
+        run.info.run_id,
+        {
+            "candidate_id": submission_event.candidate_id,
+            "candidate_type": submission_event.candidate_type,
+            "config_fingerprint": submission_event.config_fingerprint,
+            "representation_id": submission_event.representation_id,
+            "model_registry_key": submission_event.model_registry_key,
+            "estimator_name": submission_event.estimator_name,
+            "cv_metric_name": submission_event.cv_metric_name,
+            "cv_metric_mean": submission_event.cv_metric_mean,
+            "cv_metric_std": submission_event.cv_metric_std,
+            "submission_file_name": submission_event.submission_file_name,
+        },
+    )
+    return SubmissionRunRef(
+        run_id=run.info.run_id,
+        experiment_id=experiment_id,
+        candidate_id=submission_event.candidate_id,
+        submission_event_id=submission_event.submission_event_id,
+    )
+
+
+def list_submission_runs(config: AppConfig) -> list[SubmissionRunRef]:
+    client = _client(config)
+    experiment_id = _experiment_id(config, "submissions")
+    runs = client.search_runs(
+        experiment_ids=[experiment_id],
+        filter_string=_submission_run_search_filter(),
+        max_results=1000,
+    )
+    results: list[SubmissionRunRef] = []
+    for run in runs:
+        candidate_id = run.data.tags.get("candidate_id")
+        submission_event_id = run.data.tags.get("submission_event_id")
+        if candidate_id is None or submission_event_id is None:
+            continue
+        results.append(
+            SubmissionRunRef(
+                run_id=run.info.run_id,
+                experiment_id=run.info.experiment_id,
+                candidate_id=str(candidate_id),
+                submission_event_id=str(submission_event_id),
+            )
+        )
+    return results
+
+
+def download_submission_history(config: AppConfig, run_id: str, destination_dir: Path) -> CandidateSubmissionHistory:
     client = _client(config)
     artifact_entries = client.list_artifacts(run_id, "submissions")
     if not any(entry.path == SUBMISSION_HISTORY_ARTIFACT_PATH for entry in artifact_entries):
@@ -745,6 +798,11 @@ def upload_submission_history(
     updated_submission_event_ids: list[str] | None = None,
     submission_csv_paths: Mapping[str, Path] | None = None,
 ) -> None:
+    if updated_submission_event_ids is not None and len(updated_submission_event_ids) > 1:
+        raise ValueError(
+            "Submission runs support exactly one submission event per MLflow run. "
+            f"Got updated_submission_event_ids={updated_submission_event_ids}."
+        )
     client = _client(config)
     with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-submission-history-") as temp_dir:
         temp_root = Path(temp_dir)
@@ -758,43 +816,33 @@ def upload_submission_history(
             return
 
         for submission_event_id in updated_submission_event_ids:
-            event_dir = submissions_dir / submission_event_id
-            event_dir.mkdir(parents=True, exist_ok=True)
-            if submission_csv_paths is not None and submission_event_id in submission_csv_paths:
-                client.log_artifact(
-                    run_id,
-                    str(submission_csv_paths[submission_event_id]),
-                    f"submissions/{submission_event_id}",
-                )
             event = history.get_event(submission_event_id)
             if event is None:
                 raise ValueError(f"Submission history is missing event '{submission_event_id}'.")
-            event_path = event_dir / "event.json"
+            if submission_csv_paths is not None and submission_event_id in submission_csv_paths:
+                client.log_artifact(run_id, str(submission_csv_paths[submission_event_id]), "submissions")
+            event_path = submissions_dir / "event.json"
             event_path.write_text(json.dumps(json_ready(event.to_dict()), indent=2, sort_keys=True), encoding="utf-8")
-            client.log_artifact(run_id, str(event_path), f"submissions/{submission_event_id}")
-            observations_path = event_dir / "observations.json"
+            client.log_artifact(run_id, str(event_path), "submissions")
+            observations_path = submissions_dir / "observations.json"
             event_observations = [observation.to_dict() for observation in history.get_observations(submission_event_id)]
             observations_path.write_text(
                 json.dumps(json_ready(event_observations), indent=2, sort_keys=True),
                 encoding="utf-8",
             )
-            client.log_artifact(run_id, str(observations_path), f"submissions/{submission_event_id}")
+            client.log_artifact(run_id, str(observations_path), "submissions")
 
 
-def update_submission_metrics(
-    config: AppConfig,
-    run_id: str,
-    score_metrics: dict[str, float | int | None],
-) -> None:
+def update_submission_metrics(config: AppConfig, run_id: str, score_metrics: dict[str, float | int | None]) -> None:
     _log_metrics(_client(config), run_id, score_metrics)
 
 
 def search_candidate_runs(config: AppConfig) -> list[CandidateRunRef]:
     client = _client(config)
-    experiment_id = _experiment_id(config)
+    experiment_id = _experiment_id(config, "candidates")
     runs = client.search_runs(
         experiment_ids=[experiment_id],
-        filter_string=f"tags.run_kind = '{RUN_KIND_CANDIDATE}'",
+        filter_string=f"tags.run_kind = '{RUN_KIND_CANONICAL}'",
         max_results=1000,
     )
     runs_by_candidate_id: dict[str, list[Any]] = {}

--- a/src/tabular_shenanigans/screening.py
+++ b/src/tabular_shenanigans/screening.py
@@ -1,0 +1,206 @@
+from pathlib import Path
+import time
+import tempfile
+import traceback
+from dataclasses import dataclass
+from typing import Literal
+
+import yaml
+
+from tabular_shenanigans.config import AppConfig
+from tabular_shenanigans.cv import is_higher_better
+from tabular_shenanigans.data import CompetitionDatasetContext
+from tabular_shenanigans.mlflow_store import download_candidate_manifest
+from tabular_shenanigans.train import run_training_workflow
+
+
+@dataclass(frozen=True)
+class ScreeningBatchResult:
+    candidate_index: int
+    candidate_id: str
+    status: Literal["screened", "failed"]
+    run_id: str | None
+    wall_seconds: float
+    metric_mean: float | None = None
+    metric_std: float | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ScreeningBatchSummary:
+    results: list[ScreeningBatchResult]
+
+    @property
+    def total_candidates(self) -> int:
+        return len(self.results)
+
+    @property
+    def screened_count(self) -> int:
+        return sum(result.status == "screened" for result in self.results)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(result.status == "failed" for result in self.results)
+
+
+def _metric_from_manifest(manifest: dict[str, object]) -> tuple[float, float]:
+    cv_summary = manifest.get("cv_summary")
+    if not isinstance(cv_summary, dict):
+        raise ValueError("Candidate manifest cv_summary must be a mapping.")
+    return float(cv_summary["metric_mean"]), float(cv_summary["metric_std"])
+
+
+def _print_screening_promotion_snippet(config: AppConfig, summary: ScreeningBatchSummary) -> None:
+    if config.screening is None:
+        raise ValueError("screening is not configured in config.yaml.")
+    successful_results = [result for result in summary.results if result.status == "screened"]
+    if not successful_results:
+        print("Screening promotion summary skipped: no successful screening runs.")
+        return
+
+    reverse_sort = is_higher_better(config.competition.primary_metric)
+    ranked_results = sorted(
+        successful_results,
+        key=lambda result: result.metric_mean if result.metric_mean is not None else float("-inf"),
+        reverse=reverse_sort,
+    )
+    top_results = ranked_results[: min(config.screening.promote_top_k, len(ranked_results))]
+
+    print("Screening ranking:")
+    for rank, result in enumerate(top_results, start=1):
+        print(
+            f"  [{rank}] candidate_index={result.candidate_index}, "
+            f"candidate_id={result.candidate_id}, "
+            f"{config.competition.primary_metric}={result.metric_mean:.6f}, "
+            f"std={result.metric_std:.6f}, "
+            f"mlflow_run_id={result.run_id}"
+        )
+
+    promoted_candidates = [
+        config.get_screening_candidate(result.candidate_index - 1).model_dump(mode="python", exclude_none=True)
+        for result in top_results
+    ]
+    snippet = yaml.safe_dump(
+        {"experiment": {"candidates": promoted_candidates}},
+        sort_keys=False,
+        default_flow_style=False,
+    ).strip()
+    print("Suggested canonical candidate snippet:")
+    print(snippet)
+
+
+def run_screening_batch(
+    config: AppConfig,
+    dataset_context: CompetitionDatasetContext,
+    candidate_id: str | None = None,
+    index: int | None = None,
+) -> ScreeningBatchSummary:
+    if config.screening is None:
+        raise ValueError("screening is not configured in config.yaml.")
+
+    selected_candidate_indices = config.resolve_screening_candidate_indices(
+        candidate_id=candidate_id,
+        index=index,
+        require_explicit=False,
+    )
+    print(
+        "Screening batch starting: "
+        f"selected_candidates={len(selected_candidate_indices)}, "
+        f"configured_candidates={config.screening_candidate_count}, "
+        f"promote_top_k={config.screening.promote_top_k}"
+    )
+
+    results: list[ScreeningBatchResult] = []
+    for batch_position, candidate_index in enumerate(selected_candidate_indices, start=1):
+        screening_config = config.with_screening_candidate_index(candidate_index)
+        resolved_candidate_id = screening_config.resolved_candidate_id
+        print(
+            f"[{batch_position}/{len(selected_candidate_indices)}] "
+            f"screening_candidate_index={candidate_index + 1}, "
+            f"candidate_id={resolved_candidate_id}"
+        )
+
+        started = time.perf_counter()
+        try:
+            candidate_run = run_training_workflow(
+                config=screening_config,
+                dataset_context=dataset_context,
+            )
+            with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-screening-manifest-") as temp_dir:
+                manifest = download_candidate_manifest(
+                    config=screening_config,
+                    run_id=candidate_run.run_id,
+                    destination_dir=Path(temp_dir),
+                )
+            metric_mean, metric_std = _metric_from_manifest(manifest)
+        except Exception as exc:
+            wall_seconds = time.perf_counter() - started
+            print(
+                "Screening candidate failed: "
+                f"candidate_index={candidate_index + 1}, "
+                f"candidate_id={resolved_candidate_id}, "
+                f"error={exc}"
+            )
+            traceback.print_exc()
+            results.append(
+                ScreeningBatchResult(
+                    candidate_index=candidate_index + 1,
+                    candidate_id=resolved_candidate_id,
+                    status="failed",
+                    run_id=None,
+                    wall_seconds=wall_seconds,
+                    error=str(exc),
+                )
+            )
+            continue
+
+        wall_seconds = time.perf_counter() - started
+        print(
+            "Screening candidate complete: "
+            f"candidate_index={candidate_index + 1}, "
+            f"candidate_id={resolved_candidate_id}, "
+            f"mlflow_run_id={candidate_run.run_id}, "
+            f"{config.competition.primary_metric}={metric_mean:.6f}, "
+            f"wall_seconds={wall_seconds:.2f}"
+        )
+        results.append(
+            ScreeningBatchResult(
+                candidate_index=candidate_index + 1,
+                candidate_id=resolved_candidate_id,
+                status="screened",
+                run_id=candidate_run.run_id,
+                wall_seconds=wall_seconds,
+                metric_mean=metric_mean,
+                metric_std=metric_std,
+            )
+        )
+
+    return ScreeningBatchSummary(results=results)
+
+
+def print_screening_batch_summary(config: AppConfig, summary: ScreeningBatchSummary) -> None:
+    print(
+        "Screening batch summary: "
+        f"total={summary.total_candidates}, "
+        f"screened={summary.screened_count}, "
+        f"failed={summary.failed_count}"
+    )
+    for result in summary.results:
+        summary_line = (
+            f"candidate_index={result.candidate_index}, "
+            f"candidate_id={result.candidate_id}, "
+            f"status={result.status}, "
+            f"wall_seconds={result.wall_seconds:.2f}"
+        )
+        if result.metric_mean is not None and result.metric_std is not None:
+            summary_line = (
+                f"{summary_line}, "
+                f"{config.competition.primary_metric}={result.metric_mean:.6f}, "
+                f"std={result.metric_std:.6f}"
+            )
+        if result.run_id is not None:
+            summary_line = f"{summary_line}, mlflow_run_id={result.run_id}"
+        if result.error is not None:
+            summary_line = f"{summary_line}, error={result.error}"
+        print(summary_line)
+    _print_screening_promotion_snippet(config=config, summary=summary)

--- a/src/tabular_shenanigans/submit.py
+++ b/src/tabular_shenanigans/submit.py
@@ -14,9 +14,13 @@ from tabular_shenanigans.data import (
 )
 from tabular_shenanigans.mlflow_store import (
     CandidateRunRef,
+    SubmissionRunRef,
+    create_submission_run,
     download_candidate_bundle,
     download_submission_history,
+    list_submission_runs,
     search_candidate_runs,
+    terminate_run,
     update_submission_metrics,
     upload_submission_history,
 )
@@ -59,6 +63,7 @@ class SubmissionContext:
 class SubmissionRunResult:
     candidate_id: str
     candidate_run_id: str
+    submission_run_id: str | None
     submission_status: str
     submission_message: str
     submission_event_id: str | None
@@ -113,6 +118,7 @@ def _load_submission_context(
             run_id=downloaded_bundle.run_id,
             experiment_id=downloaded_bundle.experiment_id,
             candidate_id=candidate_id,
+            run_kind="canonical",
         ),
         candidate_id=str(_require_manifest_value(candidate_manifest, "candidate_id")),
         candidate_type=str(_require_manifest_value(candidate_manifest, "candidate_type")),
@@ -407,11 +413,6 @@ def run_submission(
                 print(completed.stderr.strip())
             submit_response_message = _collect_submit_response_message(completed)
 
-            history = download_submission_history(
-                config=config,
-                run_id=submission_context.candidate_run.run_id,
-                destination_dir=temp_root / "history",
-            )
             submission_event = _build_submission_event(
                 submission_context=submission_context,
                 submission_event_id=submission_event_id,
@@ -419,22 +420,31 @@ def run_submission(
                 submit_message=submission_message,
                 submit_response_message=submit_response_message,
             )
-            history = history.with_submission_event(submission_event)
-            upload_submission_history(
+            submission_run = create_submission_run(
                 config=config,
-                run_id=submission_context.candidate_run.run_id,
-                history=history,
-                updated_submission_event_ids=[submission_event_id],
-                submission_csv_paths={submission_event_id: submission_path},
+                submission_event=submission_event,
             )
-            update_submission_metrics(
-                config=config,
-                run_id=submission_context.candidate_run.run_id,
-                score_metrics=build_submission_score_metrics(
-                    primary_metric=submission_context.primary_metric,
+            submission_run_status = "FAILED"
+            try:
+                history = CandidateSubmissionHistory.empty().with_submission_event(submission_event)
+                upload_submission_history(
+                    config=config,
+                    run_id=submission_run.run_id,
                     history=history,
-                ),
-            )
+                    updated_submission_event_ids=[submission_event_id],
+                    submission_csv_paths={submission_event_id: submission_path},
+                )
+                update_submission_metrics(
+                    config=config,
+                    run_id=submission_run.run_id,
+                    score_metrics=build_submission_score_metrics(
+                        primary_metric=submission_context.primary_metric,
+                        history=history,
+                    ),
+                )
+                submission_run_status = "FINISHED"
+            finally:
+                terminate_run(config=config, run_id=submission_run.run_id, status=submission_run_status)
 
             immediate_refresh_error = None
             try:
@@ -456,10 +466,11 @@ def run_submission(
             return SubmissionRunResult(
                 candidate_id=submission_context.candidate_id,
                 candidate_run_id=submission_context.candidate_run.run_id,
+                submission_run_id=submission_run.run_id,
                 submission_status="submitted",
                 submission_message=submission_message,
                 submission_event_id=submission_event_id,
-                submission_artifact_path=f"submissions/{submission_event_id}/submission.csv",
+                submission_artifact_path="submissions/submission.csv",
                 submission_refresh_result=submission_refresh_result,
                 immediate_refresh_error=immediate_refresh_error,
             )
@@ -468,6 +479,7 @@ def run_submission(
         return SubmissionRunResult(
             candidate_id=submission_context.candidate_id,
             candidate_run_id=submission_context.candidate_run.run_id,
+            submission_run_id=None,
             submission_status="prepared",
             submission_message="",
             submission_event_id=None,
@@ -483,104 +495,107 @@ def run_submission_refresh(
     observation_source: str = "manual_refresh",
 ) -> SubmissionRefreshResult:
     candidate_runs = search_candidate_runs(config)
-    tracked_candidate_count = 0
+    submission_runs = list_submission_runs(config)
     tracked_submission_event_count = 0
     matched_submission_event_ids: set[str] = set()
-    updated_candidate_count = 0
     appended_observation_count = 0
     scanned_remote_submission_count = 0
+    tracked_candidate_ids: set[str] = set()
+    updated_candidate_ids: set[str] = set()
 
     histories_by_run_id: dict[str, CandidateSubmissionHistory] = {}
-    event_to_candidate_run: dict[str, CandidateRunRef] = {}
+    event_to_submission_run: dict[str, SubmissionRunRef] = {}
     candidate_run_by_candidate_id: dict[str, CandidateRunRef] = {}
     submission_contexts_by_run_id: dict[str, SubmissionContext] = {}
+    created_submission_run_ids: set[str] = set()
+    finished_submission_run_ids: set[str] = set()
 
-    with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-refresh-submissions-") as temp_dir:
-        temp_root = Path(temp_dir)
-        for candidate_run in candidate_runs:
-            if target_candidate_ids is not None and candidate_run.candidate_id not in target_candidate_ids:
-                continue
-            candidate_run_by_candidate_id[candidate_run.candidate_id] = candidate_run
-            history = download_submission_history(
-                config=config,
-                run_id=candidate_run.run_id,
-                destination_dir=temp_root / candidate_run.candidate_id,
-            )
-            histories_by_run_id[candidate_run.run_id] = history
-            relevant_event_ids = {
-                event.submission_event_id
-                for event in history.events
-                if target_submission_event_ids is None or event.submission_event_id in target_submission_event_ids
-            }
-            if relevant_event_ids:
-                tracked_candidate_count += 1
-                tracked_submission_event_count += len(relevant_event_ids)
-            for submission_event_id in relevant_event_ids:
-                if submission_event_id in event_to_candidate_run:
-                    existing_candidate_id = event_to_candidate_run[submission_event_id].candidate_id
-                    raise ValueError(
-                        "Submission event ids must be unique across candidate runs. "
-                        f"Event '{submission_event_id}' was found under candidates "
-                        f"'{existing_candidate_id}' and '{candidate_run.candidate_id}'."
-                    )
-                event_to_candidate_run[submission_event_id] = candidate_run
-
-        if not histories_by_run_id:
-            return SubmissionRefreshResult(
-                competition_slug=config.competition.slug,
-                tracked_candidate_count=tracked_candidate_count,
-                tracked_submission_event_count=tracked_submission_event_count,
-                matched_submission_event_count=0,
-                updated_candidate_count=0,
-                appended_observation_count=0,
-                scanned_remote_submission_count=0,
-                observation_source=observation_source,
-            )
-
-        observations_by_run_id: dict[str, list[SubmissionScoreObservation]] = {}
-        updated_submission_event_ids_by_run_id: dict[str, set[str]] = {}
-        for remote_submission in iter_kaggle_submissions(config.competition.slug):
-            scanned_remote_submission_count += 1
-            submission_event_id = extract_submission_event_id(remote_submission.kaggle_description)
-            if submission_event_id is None:
-                continue
-            if target_submission_event_ids is not None and submission_event_id not in target_submission_event_ids:
-                continue
-
-            candidate_id = extract_candidate_id(remote_submission.kaggle_description)
-            candidate_run = event_to_candidate_run.get(submission_event_id)
-            if candidate_run is not None:
-                if target_candidate_ids is not None and candidate_run.candidate_id not in target_candidate_ids:
+    try:
+        with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-refresh-submissions-") as temp_dir:
+            temp_root = Path(temp_dir)
+            for candidate_run in candidate_runs:
+                candidate_run_by_candidate_id[candidate_run.candidate_id] = candidate_run
+            for submission_run in submission_runs:
+                if target_candidate_ids is not None and submission_run.candidate_id not in target_candidate_ids:
                     continue
-                if candidate_id is not None and candidate_id != candidate_run.candidate_id:
-                    raise ValueError(
-                        "Kaggle submission metadata did not match the tracked MLflow candidate. "
-                        f"submission_event_id={submission_event_id}, "
-                        f"kaggle_candidate_id={candidate_id}, "
-                        f"tracked_candidate_id={candidate_run.candidate_id}"
-                    )
-            else:
-                if target_candidate_ids is not None and candidate_id not in target_candidate_ids:
+                history = download_submission_history(
+                    config=config,
+                    run_id=submission_run.run_id,
+                    destination_dir=temp_root / submission_run.candidate_id / submission_run.submission_event_id,
+                )
+                histories_by_run_id[submission_run.run_id] = history
+                relevant_event_ids = {
+                    event.submission_event_id
+                    for event in history.events
+                    if target_submission_event_ids is None or event.submission_event_id in target_submission_event_ids
+                }
+                if relevant_event_ids:
+                    tracked_candidate_ids.add(submission_run.candidate_id)
+                    tracked_submission_event_count += len(relevant_event_ids)
+                for submission_event_id in relevant_event_ids:
+                    if submission_event_id in event_to_submission_run:
+                        existing_candidate_id = event_to_submission_run[submission_event_id].candidate_id
+                        raise ValueError(
+                            "Submission event ids must be unique across submission runs. "
+                            f"Event '{submission_event_id}' was found under candidates "
+                            f"'{existing_candidate_id}' and '{submission_run.candidate_id}'."
+                        )
+                    event_to_submission_run[submission_event_id] = submission_run
+
+            if not candidate_run_by_candidate_id and not histories_by_run_id:
+                return SubmissionRefreshResult(
+                    competition_slug=config.competition.slug,
+                    tracked_candidate_count=len(tracked_candidate_ids),
+                    tracked_submission_event_count=tracked_submission_event_count,
+                    matched_submission_event_count=0,
+                    updated_candidate_count=0,
+                    appended_observation_count=0,
+                    scanned_remote_submission_count=0,
+                    observation_source=observation_source,
+                )
+
+            observations_by_run_id: dict[str, list[SubmissionScoreObservation]] = {}
+            updated_submission_event_ids_by_run_id: dict[str, set[str]] = {}
+            for remote_submission in iter_kaggle_submissions(config.competition.slug):
+                scanned_remote_submission_count += 1
+                submission_event_id = extract_submission_event_id(remote_submission.kaggle_description)
+                if submission_event_id is None:
                     continue
-                if candidate_id is None:
-                    print(
-                        "Submission refresh could not recover orphaned Kaggle submission: "
-                        f"submission_event_id={submission_event_id}, "
-                        "reason=missing_candidate_id_in_kaggle_description"
-                    )
-                    continue
-                candidate_run = candidate_run_by_candidate_id.get(candidate_id)
-                if candidate_run is None:
-                    print(
-                        "Submission refresh could not recover orphaned Kaggle submission: "
-                        f"candidate_id={candidate_id}, "
-                        f"submission_event_id={submission_event_id}, "
-                        "reason=no_canonical_candidate_run"
-                    )
+                if target_submission_event_ids is not None and submission_event_id not in target_submission_event_ids:
                     continue
 
-                history = histories_by_run_id[candidate_run.run_id]
-                if history.get_event(submission_event_id) is None:
+                candidate_id = extract_candidate_id(remote_submission.kaggle_description)
+                submission_run = event_to_submission_run.get(submission_event_id)
+                if submission_run is not None:
+                    if target_candidate_ids is not None and submission_run.candidate_id not in target_candidate_ids:
+                        continue
+                    if candidate_id is not None and candidate_id != submission_run.candidate_id:
+                        raise ValueError(
+                            "Kaggle submission metadata did not match the tracked MLflow candidate. "
+                            f"submission_event_id={submission_event_id}, "
+                            f"kaggle_candidate_id={candidate_id}, "
+                            f"tracked_candidate_id={submission_run.candidate_id}"
+                        )
+                else:
+                    if target_candidate_ids is not None and candidate_id not in target_candidate_ids:
+                        continue
+                    if candidate_id is None:
+                        print(
+                            "Submission refresh could not recover orphaned Kaggle submission: "
+                            f"submission_event_id={submission_event_id}, "
+                            "reason=missing_candidate_id_in_kaggle_description"
+                        )
+                        continue
+                    candidate_run = candidate_run_by_candidate_id.get(candidate_id)
+                    if candidate_run is None:
+                        print(
+                            "Submission refresh could not recover orphaned Kaggle submission: "
+                            f"candidate_id={candidate_id}, "
+                            f"submission_event_id={submission_event_id}, "
+                            "reason=no_canonical_candidate_run"
+                        )
+                        continue
+
                     submission_context = submission_contexts_by_run_id.get(candidate_run.run_id)
                     if submission_context is None:
                         submission_context = _load_submission_context(
@@ -590,75 +605,94 @@ def run_submission_refresh(
                         )
                         submission_contexts_by_run_id[candidate_run.run_id] = submission_context
 
-                    history = history.with_submission_event(
-                        _build_recovered_submission_event(
-                            submission_context=submission_context,
-                            submission_event_id=submission_event_id,
-                            kaggle_submitted_at=remote_submission.kaggle_submitted_at,
-                            kaggle_file_name=remote_submission.kaggle_file_name,
-                            kaggle_description=remote_submission.kaggle_description,
-                        )
+                    submission_event = _build_recovered_submission_event(
+                        submission_context=submission_context,
+                        submission_event_id=submission_event_id,
+                        kaggle_submitted_at=remote_submission.kaggle_submitted_at,
+                        kaggle_file_name=remote_submission.kaggle_file_name,
+                        kaggle_description=remote_submission.kaggle_description,
                     )
-                    histories_by_run_id[candidate_run.run_id] = history
-                    event_to_candidate_run[submission_event_id] = candidate_run
-                    updated_submission_event_ids_by_run_id.setdefault(candidate_run.run_id, set()).add(
+                    submission_run = create_submission_run(
+                        config=config,
+                        submission_event=submission_event,
+                    )
+                    created_submission_run_ids.add(submission_run.run_id)
+                    history = CandidateSubmissionHistory.empty().with_submission_event(submission_event)
+                    histories_by_run_id[submission_run.run_id] = history
+                    event_to_submission_run[submission_event_id] = submission_run
+                    updated_submission_event_ids_by_run_id.setdefault(submission_run.run_id, set()).add(
                         submission_event_id
                     )
                     print(
-                        "Recovered orphaned Kaggle submission onto candidate run: "
+                        "Recovered orphaned Kaggle submission onto submission run: "
                         f"candidate_id={candidate_run.candidate_id}, "
                         f"submission_event_id={submission_event_id}, "
-                        f"mlflow_run_id={candidate_run.run_id}"
+                        f"mlflow_run_id={submission_run.run_id}"
                     )
 
-            matched_submission_event_ids.add(submission_event_id)
-            observations_by_run_id.setdefault(candidate_run.run_id, []).append(
-                SubmissionScoreObservation(
-                    observed_at_utc=utc_now_iso(),
-                    submission_event_id=submission_event_id,
-                    kaggle_submitted_at=remote_submission.kaggle_submitted_at,
-                    kaggle_file_name=remote_submission.kaggle_file_name,
-                    kaggle_description=remote_submission.kaggle_description,
-                    kaggle_status=remote_submission.kaggle_status,
-                    public_score=remote_submission.public_score,
-                    private_score=remote_submission.private_score,
-                    observation_source=observation_source,
+                if submission_run is None:
+                    raise RuntimeError(
+                        f"Submission run resolution failed for submission_event_id={submission_event_id}."
+                    )
+
+                matched_submission_event_ids.add(submission_event_id)
+                observations_by_run_id.setdefault(submission_run.run_id, []).append(
+                    SubmissionScoreObservation(
+                        observed_at_utc=utc_now_iso(),
+                        submission_event_id=submission_event_id,
+                        kaggle_submitted_at=remote_submission.kaggle_submitted_at,
+                        kaggle_file_name=remote_submission.kaggle_file_name,
+                        kaggle_description=remote_submission.kaggle_description,
+                        kaggle_status=remote_submission.kaggle_status,
+                        public_score=remote_submission.public_score,
+                        private_score=remote_submission.private_score,
+                        observation_source=observation_source,
+                    )
                 )
-            )
-            updated_submission_event_ids_by_run_id.setdefault(candidate_run.run_id, set()).add(submission_event_id)
+                updated_submission_event_ids_by_run_id.setdefault(submission_run.run_id, set()).add(
+                    submission_event_id
+                )
 
-        for run_id, history in histories_by_run_id.items():
-            observations = observations_by_run_id.get(run_id, [])
-            updated_history, appended_count = history.with_submission_observations(observations)
-            updated_submission_event_ids = sorted(updated_submission_event_ids_by_run_id.get(run_id, set()))
-            if appended_count == 0 and not updated_submission_event_ids:
-                continue
+            for run_id, history in histories_by_run_id.items():
+                observations = observations_by_run_id.get(run_id, [])
+                updated_history, appended_count = history.with_submission_observations(observations)
+                updated_submission_event_ids = sorted(updated_submission_event_ids_by_run_id.get(run_id, set()))
+                if appended_count == 0 and not updated_submission_event_ids:
+                    continue
 
-            upload_submission_history(
-                config=config,
-                run_id=run_id,
-                history=updated_history,
-                updated_submission_event_ids=updated_submission_event_ids,
-            )
-            update_submission_metrics(
-                config=config,
-                run_id=run_id,
-                score_metrics=build_submission_score_metrics(
-                    primary_metric=config.competition.primary_metric,
+                upload_submission_history(
+                    config=config,
+                    run_id=run_id,
                     history=updated_history,
-                ),
-            )
-            histories_by_run_id[run_id] = updated_history
-            updated_candidate_count += 1
-            appended_observation_count += appended_count
+                    updated_submission_event_ids=updated_submission_event_ids,
+                )
+                update_submission_metrics(
+                    config=config,
+                    run_id=run_id,
+                    score_metrics=build_submission_score_metrics(
+                        primary_metric=config.competition.primary_metric,
+                        history=updated_history,
+                    ),
+                )
+                histories_by_run_id[run_id] = updated_history
+                candidate_id = updated_history.events[0].candidate_id if updated_history.events else None
+                if candidate_id is not None:
+                    updated_candidate_ids.add(candidate_id)
+                if run_id in created_submission_run_ids:
+                    terminate_run(config=config, run_id=run_id, status="FINISHED")
+                    finished_submission_run_ids.add(run_id)
+                appended_observation_count += appended_count
 
-    return SubmissionRefreshResult(
-        competition_slug=config.competition.slug,
-        tracked_candidate_count=tracked_candidate_count,
-        tracked_submission_event_count=tracked_submission_event_count,
-        matched_submission_event_count=len(matched_submission_event_ids),
-        updated_candidate_count=updated_candidate_count,
-        appended_observation_count=appended_observation_count,
-        scanned_remote_submission_count=scanned_remote_submission_count,
-        observation_source=observation_source,
-    )
+        return SubmissionRefreshResult(
+            competition_slug=config.competition.slug,
+            tracked_candidate_count=len(tracked_candidate_ids),
+            tracked_submission_event_count=tracked_submission_event_count,
+            matched_submission_event_count=len(matched_submission_event_ids),
+            updated_candidate_count=len(updated_candidate_ids),
+            appended_observation_count=appended_observation_count,
+            scanned_remote_submission_count=scanned_remote_submission_count,
+            observation_source=observation_source,
+        )
+    finally:
+        for run_id in sorted(created_submission_run_ids - finished_submission_run_ids):
+            terminate_run(config=config, run_id=run_id, status="FAILED")

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -257,8 +257,9 @@ def run_training(
     )
     fit_wall_seconds = time.perf_counter() - evaluation_started
     model_result = evaluation_artifacts.model_result
+    stage_label = "Screening" if config.active_run_stage == "screening" else "Training"
     print(
-        f"Training candidate: {candidate_id} | "
+        f"{stage_label} candidate: {candidate_id} | "
         f"representation={candidate.representation_id} | "
         f"estimator={model_result.estimator_name} | "
         f"features={training_context.x_train_features.shape[1]} | "
@@ -345,7 +346,7 @@ def run_training_workflow(
             try:
                 with capture_runtime_log(log_path):
                     emit_runtime_log_header(
-                        stage_name="train",
+                        stage_name="screening" if config.active_run_stage == "screening" else "train",
                         competition_slug=competition.slug,
                         candidate_id=candidate_run.candidate_id,
                         mlflow_run_id=candidate_run.run_id,

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -153,16 +153,18 @@ def run_optimization(
 
     def objective(trial: optuna.Trial) -> float:
         parameter_overrides = build_tuning_space(task_type, tuning_model_spec.model_registry_key, trial)
-        trial_run = create_trial_run(
-            config=config,
-            candidate_run=candidate_run,
-            trial_number=trial.number,
-            hyperparams=parameter_overrides,
-            representation_id=training_context.representation_id,
-            model_family=config.experiment.candidate.model_family,
-            model_registry_key=tuning_model_spec.model_registry_key,
-            preprocessing_backend=training_context.preprocessing_backend,
-        )
+        trial_run = None
+        if config.active_run_stage != "screening":
+            trial_run = create_trial_run(
+                config=config,
+                candidate_run=candidate_run,
+                trial_number=trial.number,
+                hyperparams=parameter_overrides,
+                representation_id=training_context.representation_id,
+                model_family=config.experiment.candidate.model_family,
+                model_registry_key=tuning_model_spec.model_registry_key,
+                preprocessing_backend=training_context.preprocessing_backend,
+            )
         trial_start = time.time()
         try:
             cv_evaluation = score_model_spec(
@@ -176,15 +178,16 @@ def run_optimization(
                 cv_random_state=competition.cv.random_state,
             )
         except Exception:
-            finalize_trial_run(
-                config=config,
-                trial_run=trial_run,
-                model_params=None,
-                cv_score_mean=None,
-                cv_score_std=None,
-                duration_seconds=time.time() - trial_start,
-                trial_state="FAIL",
-            )
+            if trial_run is not None:
+                finalize_trial_run(
+                    config=config,
+                    trial_run=trial_run,
+                    model_params=None,
+                    cv_score_mean=None,
+                    cv_score_std=None,
+                    duration_seconds=time.time() - trial_start,
+                    trial_state="FAIL",
+                )
             raise
         duration_seconds = time.time() - trial_start
         metric_mean = cv_evaluation.model_result.cv_summary.metric_mean
@@ -192,15 +195,16 @@ def run_optimization(
         trial.set_user_attr("metric_std", metric_std)
         trial.set_user_attr("parameter_overrides", json_ready(parameter_overrides))
         trial.set_user_attr("model_params", json_ready(cv_evaluation.model_result.model_params))
-        finalize_trial_run(
-            config=config,
-            trial_run=trial_run,
-            model_params=cv_evaluation.model_result.model_params,
-            cv_score_mean=metric_mean,
-            cv_score_std=metric_std,
-            duration_seconds=duration_seconds,
-            trial_state="COMPLETE",
-        )
+        if trial_run is not None:
+            finalize_trial_run(
+                config=config,
+                trial_run=trial_run,
+                model_params=cv_evaluation.model_result.model_params,
+                cv_score_mean=metric_mean,
+                cv_score_std=metric_std,
+                duration_seconds=duration_seconds,
+                trial_state="COMPLETE",
+            )
         print(
             f"Trial {trial.number}: {primary_metric}={metric_mean:.6f} "
             f"(std={metric_std:.6f}) params={parameter_overrides}"


### PR DESCRIPTION
## Summary
- split MLflow tracking into per-competition screening, candidates, and submissions experiments with schema v4
- add an explicit model-only `screening` stage with its own config block and promotion snippet output
- move submission history and leaderboard tracking onto dedicated submission runs so canonical candidate runs stay immutable

## Verification
- `uv run python -m compileall src`
- verified CLI parser support for `screening`
- verified synthetic config loads with screening and preserves candidate ID stability across screening vs canonical CV settings

## Breaking change
- schema v4 changes candidate ID derivation versus schema v3 archival experiments
- existing schema-v3 MLflow data should be treated as read-only history and not mixed with new v4 runs

Closes #256