### PR TITLE
Cross-product screening orchestration and slim submission runs

### DIFF
--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -71,3 +71,25 @@ experiment:
     #   weights:
     #     - 0.5
     #     - 0.5
+
+# Optional screening stage — evaluates the cross-product of representation_ids x model_families
+# with a cheap reduced-fold CV, then prints a promotion snippet for the top-k candidates.
+# screening:
+#   representation_ids:
+#     - standardize-onehot
+#     - median-ordinal
+#     - median-frequency
+#   model_families:
+#     - lightgbm
+#     - xgboost
+#     - logistic_regression
+#   cv:
+#     n_splits: 2
+#     shuffle: true
+#     random_state: 42
+#   promote_top_k: 3
+#   # Optional tuning budget for screening:
+#   # optimization:
+#   #   method: optuna
+#   #   n_trials: 10
+#   #   timeout_seconds: 300

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -59,3 +59,25 @@ experiment:
     #   weights:
     #     - 0.5
     #     - 0.5
+
+# Optional screening stage — evaluates the cross-product of representation_ids x model_families
+# with a cheap reduced-fold CV, then prints a promotion snippet for the top-k candidates.
+# screening:
+#   representation_ids:
+#     - standardize-onehot
+#     - median-ordinal
+#     - median-frequency
+#   model_families:
+#     - lightgbm
+#     - xgboost
+#     - ridge
+#   cv:
+#     n_splits: 2
+#     shuffle: true
+#     random_state: 42
+#   promote_top_k: 3
+#   # Optional tuning budget for screening:
+#   # optimization:
+#   #   method: optuna
+#   #   n_trials: 10
+#   #   timeout_seconds: 300

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -7,7 +7,7 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 ## System Flow
 
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths. Screening config uses `screening.representation_ids` x `screening.model_families` cross-product expansion; incompatible pairs are skipped with a warning at config validation time.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the full `experiment.candidates` contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -171,22 +171,14 @@ Trial child-run tags:
 Submission runs use:
 - `run_kind=submission`
 - `tracking_schema_version=4`
+- `competition_slug`
 - `candidate_id`
-- `candidate_type`
 - `submission_event_id`
-- `representation_id`
-- `model_registry_key`
+- `git_commit` when available
+- `git_branch` when available
 
 Submission run params include:
 - `candidate_id`
-- `candidate_type`
-- `config_fingerprint`
-- `representation_id`
-- `model_registry_key`
-- `estimator_name`
-- `cv_metric_name`
-- `cv_metric_mean`
-- `cv_metric_std`
 - `submission_file_name`
 
 Submission run metrics:

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -48,14 +48,9 @@ def _stage_uses_training_runtime(stage: str | None) -> bool:
 
 
 def _resolve_selected_candidate_indices(
-    runtime_config,
+    configured_candidates: tuple,
     selection: BootstrapCliSelection,
 ) -> tuple[int, ...]:
-    configured_candidates = (
-        runtime_config.screening_candidates
-        if selection.stage == "screening"
-        else runtime_config.experiment_candidates
-    )
     if selection.candidate_index is not None:
         resolved_index = selection.candidate_index - 1
         if resolved_index < 0 or resolved_index >= len(configured_candidates):
@@ -83,12 +78,41 @@ def _raise_mixed_patch_runtime_error(selection: BootstrapCliSelection) -> None:
     )
 
 
+def _filter_compatible_screening_candidates(
+    screening_candidates: tuple,
+    task_type: str,
+    representation_registry: dict,
+    resolve_model_id_fn,
+    validate_compatibility_fn,
+) -> tuple:
+    filtered = []
+    for candidate in screening_candidates:
+        if candidate.model_family is None or candidate.representation_id is None:
+            continue
+        representation_definition = representation_registry.get(candidate.representation_id)
+        if representation_definition is None:
+            continue
+        try:
+            model_id = resolve_model_id_fn(task_type=task_type, model_family=candidate.model_family)
+            validate_compatibility_fn(
+                task_type=task_type,
+                model_id=model_id,
+                categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
+            )
+        except ValueError:
+            continue
+        filtered.append(candidate)
+    return tuple(filtered)
+
+
 def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
     if _should_skip_runtime_bootstrap(argv):
         return
 
     from tabular_shenanigans.bootstrap_config import load_bootstrap_runtime_config
     from tabular_shenanigans.execution_routing import resolve_model_candidate_runtime_execution
+    from tabular_shenanigans.models import resolve_candidate_model_id, validate_model_preprocessing_compatibility
+    from tabular_shenanigans.representations.registry import REPRESENTATION_REGISTRY
     from tabular_shenanigans.runtime_execution import (
         PATCH_GPU_BACKEND,
         activate_runtime_acceleration,
@@ -101,18 +125,25 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
     if not _stage_uses_training_runtime(selection.stage):
         return
 
-    selected_candidate_indices = _resolve_selected_candidate_indices(runtime_config, selection)
-    if not selected_candidate_indices or runtime_config.task_type is None:
+    if runtime_config.task_type is None:
+        return
+
+    if selection.stage == "screening":
+        configured_candidates = _filter_compatible_screening_candidates(
+            runtime_config.screening_candidates,
+            runtime_config.task_type,
+            REPRESENTATION_REGISTRY,
+            resolve_candidate_model_id,
+            validate_model_preprocessing_compatibility,
+        )
+    else:
+        configured_candidates = runtime_config.experiment_candidates
+
+    selected_candidate_indices = _resolve_selected_candidate_indices(configured_candidates, selection)
+    if not selected_candidate_indices:
         return
 
     capabilities = detect_runtime_capabilities()
-    from tabular_shenanigans.representations.registry import REPRESENTATION_REGISTRY
-
-    configured_candidates = (
-        runtime_config.screening_candidates
-        if selection.stage == "screening"
-        else runtime_config.experiment_candidates
-    )
     selected_model_contexts = []
     for candidate_index in selected_candidate_indices:
         candidate = configured_candidates[candidate_index]

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -117,10 +117,20 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
     elif candidate is not None:
         experiment_candidate_list = [_coerce_bootstrap_candidate(candidate)]
 
-    screening_candidate_list = _coerce_bootstrap_candidate_list(
-        None if screening is None else screening.get("candidates"),
-        "screening.candidates",
-    )
+    screening_candidate_list: list[BootstrapCandidateRuntimeConfig] = []
+    if screening is not None:
+        screening_repr_ids = screening.get("representation_ids")
+        screening_model_families = screening.get("model_families")
+        if isinstance(screening_repr_ids, list) and isinstance(screening_model_families, list):
+            for repr_id in screening_repr_ids:
+                for model_family in screening_model_families:
+                    screening_candidate_list.append(
+                        BootstrapCandidateRuntimeConfig(
+                            candidate_type="model",
+                            model_family=model_family if isinstance(model_family, str) else None,
+                            representation_id=repr_id if isinstance(repr_id, str) else None,
+                        )
+                    )
 
     return BootstrapRuntimeConfig(
         compute_target=_validate_compute_target(None if runtime is None else runtime.get("compute_target")),

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -74,30 +74,32 @@ class CompetitionConfig(BaseModel):
 class ScreeningConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    candidates: list["ModelCandidateConfig"] = Field(min_length=1)
+    representation_ids: list[str] = Field(min_length=1)
+    model_families: list[str] = Field(min_length=1)
+    optimization: "CandidateOptimizationConfig | None" = None
     cv: CompetitionCvConfig = Field(
         default_factory=lambda: CompetitionCvConfig(n_splits=2, shuffle=True, random_state=42)
     )
     promote_top_k: int = Field(default=3, ge=1)
+    candidates: list["ModelCandidateConfig"] = Field(default_factory=list, exclude=True)
     active_candidate_index: int = Field(default=0, exclude=True, repr=False, ge=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_user_provided_candidates(cls, values: object) -> object:
+        if not isinstance(values, dict):
+            return values
+        if "candidates" in values:
+            raise ValueError(
+                "screening.candidates is not a user-facing field. "
+                "Use screening.representation_ids and screening.model_families instead. "
+                "The candidates list is built automatically from the cross-product."
+            )
+        return values
 
     @property
     def candidate(self) -> "ModelCandidateConfig":
         return self.candidates[self.active_candidate_index]
-
-    @model_validator(mode="after")
-    def validate_active_candidate_index(self) -> "ScreeningConfig":
-        if self.active_candidate_index >= len(self.candidates):
-            raise ValueError(
-                "screening.active_candidate_index must reference a configured candidate. "
-                f"Got {self.active_candidate_index} for {len(self.candidates)} candidates."
-            )
-        if self.promote_top_k > len(self.candidates):
-            raise ValueError(
-                "screening.promote_top_k cannot exceed the number of screening candidates. "
-                f"Got promote_top_k={self.promote_top_k} for {len(self.candidates)} candidates."
-            )
-        return self
 
 
 class CandidateOptimizationConfig(BaseModel):
@@ -331,42 +333,71 @@ class AppConfig(BaseModel):
             )
 
         if self.screening is not None:
-            resolved_screening_candidate_ids: dict[str, list[int]] = {}
-            for candidate_index, candidate in enumerate(self.screening.candidates, start=1):
-                try:
-                    candidate.representation_id = resolve_representation_id(candidate.representation_id)
-                    representation_definition = get_representation_definition(candidate.representation_id)
-                    resolved_model_registry_key = self.resolve_screening_model_registry_key_for_index(
-                        candidate_index - 1
-                    )
-                    validate_model_preprocessing_compatibility(
-                        task_type=competition.task_type,
-                        model_id=resolved_model_registry_key,
-                        categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
-                    )
-                    validate_model_parameter_overrides(
-                        task_type=competition.task_type,
-                        model_id=resolved_model_registry_key,
-                        parameter_overrides=candidate.model_params,
-                    )
-                    if candidate.optimization is not None:
-                        optimization = candidate.optimization
-                        if optimization.n_trials is None and optimization.timeout_seconds is None:
-                            raise ValueError(
-                                "At least one screening candidate.optimization stopping condition is required. "
-                                "Set screening candidate.optimization.n_trials or "
-                                "screening candidate.optimization.timeout_seconds."
-                            )
-                        if not is_model_tunable(competition.task_type, resolved_model_registry_key):
-                            supported_tunable_model_families = get_tunable_model_ids(competition.task_type)
-                            raise ValueError(
-                                f"Configured screening model_family '{candidate.model_family}' does not support "
-                                f"optimization for task_type '{competition.task_type}'. Supported tunable model "
-                                f"families: {supported_tunable_model_families}"
-                            )
-                except ValueError as exc:
-                    raise ValueError(f"screening.candidates[{candidate_index}] is invalid: {exc}") from exc
+            screening = self.screening
 
+            resolved_representation_ids = []
+            for raw_repr_id in screening.representation_ids:
+                resolved_repr_id = resolve_representation_id(raw_repr_id)
+                get_representation_definition(resolved_repr_id)
+                resolved_representation_ids.append(resolved_repr_id)
+
+            resolved_model_families: list[tuple[str, str]] = []
+            for raw_model_family in screening.model_families:
+                resolved_model_id = resolve_candidate_model_id(
+                    task_type=competition.task_type,
+                    model_family=raw_model_family,
+                )
+                resolved_model_families.append((raw_model_family, resolved_model_id))
+
+            expanded_candidates: list[ModelCandidateConfig] = []
+            for repr_id in resolved_representation_ids:
+                representation_definition = get_representation_definition(repr_id)
+                for model_family, model_registry_key in resolved_model_families:
+                    try:
+                        validate_model_preprocessing_compatibility(
+                            task_type=competition.task_type,
+                            model_id=model_registry_key,
+                            categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
+                        )
+                    except ValueError as exc:
+                        print(
+                            f"Screening: skipping incompatible pair "
+                            f"(model_family={model_family!r}, representation_id={repr_id!r}): {exc}"
+                        )
+                        continue
+                    expanded_candidates.append(
+                        ModelCandidateConfig(
+                            representation_id=repr_id,
+                            model_family=model_family,
+                            optimization=screening.optimization.model_copy(deep=True)
+                            if screening.optimization is not None
+                            else None,
+                        )
+                    )
+
+            if not expanded_candidates:
+                raise ValueError(
+                    "screening: no valid (model_family, representation_id) pairs survived "
+                    "compatibility checks. All cross-product pairs were incompatible."
+                )
+
+            screening.candidates = expanded_candidates
+
+            if screening.active_candidate_index >= len(screening.candidates):
+                raise ValueError(
+                    "screening.active_candidate_index must reference a valid screening candidate. "
+                    f"Got {screening.active_candidate_index} for {len(screening.candidates)} candidates."
+                )
+
+            if screening.promote_top_k > len(screening.candidates):
+                raise ValueError(
+                    "screening.promote_top_k cannot exceed the number of valid screening candidates. "
+                    f"Got promote_top_k={screening.promote_top_k} for "
+                    f"{len(screening.candidates)} valid candidates."
+                )
+
+            resolved_screening_candidate_ids: dict[str, list[int]] = {}
+            for candidate_index, candidate in enumerate(screening.candidates, start=1):
                 resolved_candidate_id = self.resolve_screening_candidate_id_for_index(candidate_index - 1)
                 resolved_screening_candidate_ids.setdefault(resolved_candidate_id, []).append(candidate_index)
 
@@ -384,6 +415,27 @@ class AppConfig(BaseModel):
                     "Configured screening candidates must derive distinct candidate_id values. "
                     f"Duplicates: {duplicate_summary}"
                 )
+
+            if screening.optimization is not None:
+                optimization = screening.optimization
+                if optimization.n_trials is None and optimization.timeout_seconds is None:
+                    raise ValueError(
+                        "At least one screening.optimization stopping condition is required. "
+                        "Set screening.optimization.n_trials or screening.optimization.timeout_seconds."
+                    )
+                for model_family, model_registry_key in resolved_model_families:
+                    has_expanded_candidate = any(
+                        c.model_family == model_family for c in expanded_candidates
+                    )
+                    if not has_expanded_candidate:
+                        continue
+                    if not is_model_tunable(competition.task_type, model_registry_key):
+                        supported_tunable_model_families = get_tunable_model_ids(competition.task_type)
+                        raise ValueError(
+                            f"Configured screening model_family '{model_family}' does not support "
+                            f"optimization for task_type '{competition.task_type}'. Supported tunable "
+                            f"model families: {supported_tunable_model_families}"
+                        )
         return self
 
     @property

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -719,10 +719,7 @@ def create_submission_run(config: AppConfig, submission_event: SubmissionEvent) 
             "tracking_schema_version": TRACKING_SCHEMA_VERSION,
             "competition_slug": submission_event.competition_slug,
             "candidate_id": submission_event.candidate_id,
-            "candidate_type": submission_event.candidate_type,
             "submission_event_id": submission_event.submission_event_id,
-            "representation_id": submission_event.representation_id,
-            "model_registry_key": submission_event.model_registry_key,
             **_git_metadata(),
         },
     )
@@ -731,14 +728,6 @@ def create_submission_run(config: AppConfig, submission_event: SubmissionEvent) 
         run.info.run_id,
         {
             "candidate_id": submission_event.candidate_id,
-            "candidate_type": submission_event.candidate_type,
-            "config_fingerprint": submission_event.config_fingerprint,
-            "representation_id": submission_event.representation_id,
-            "model_registry_key": submission_event.model_registry_key,
-            "estimator_name": submission_event.estimator_name,
-            "cv_metric_name": submission_event.cv_metric_name,
-            "cv_metric_mean": submission_event.cv_metric_mean,
-            "cv_metric_std": submission_event.cv_metric_std,
             "submission_file_name": submission_event.submission_file_name,
         },
     )


### PR DESCRIPTION
## Summary
- Replace explicit `screening.candidates` list with `screening.representation_ids` × `screening.model_families` cross-product expansion, with incompatible pair skipping and shared `screening.optimization` propagation
- Align bootstrap-time screening candidate filtering with runtime validation so `--index` resolves consistently
- Slim `create_submission_run` tags/params to essential fields (`candidate_id`, `submission_event_id`, git metadata)
- Update docs and add screening examples to both example configs

## Test plan
- [x] Config with incompatible pair (e.g. `ridge` + `native`) skips with warning, compatible pairs expand correctly
- [x] Old-style `screening.candidates` in YAML produces clear validation error
- [x] `screening.optimization` propagates to all expanded candidates
- [x] Out-of-range `screening.active_candidate_index` rejected at config validation
- [x] Bootstrap and runtime candidate ordering match after filtering

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)