### PR TITLE
Finish #258 hard-cut config cleanup

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -86,9 +86,7 @@ Optional top-level section: `screening`.
 
 `train` drains `experiment.candidates` in order unless narrowed with `--candidate-id` or `--index`. `submit --index <n>` uses a 1-based index into this list.
 
-`screening` evaluates `screening.candidates` in order and prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
-
-Deprecated: `experiment.candidate` (singular) is still accepted as a one-entry list and emits a deprecation notice.
+`screening` evaluates the valid cross-product of `screening.representation_ids` and `screening.model_families`, then prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
 
 #### Candidate Shapes
 
@@ -121,11 +119,13 @@ Hard-invalid: representations with `native` categorical preprocessor and any `mo
 
 | Key | Required | Notes |
 | --- | --- | --- |
+| `representation_ids` | yes | registered representation IDs; screening expands these against `model_families` |
+| `model_families` | yes | model families to screen against `representation_ids` |
+| `optimization` | no | optional shared tuning budget applied to each valid screening candidate |
 | `cv.n_splits` | no | defaults to `2` |
 | `cv.shuffle` | no | defaults to `true` |
 | `cv.random_state` | no | defaults to `42` |
-| `promote_top_k` | no | defaults to `3`; must be `<= len(screening.candidates)` |
-| `candidates` | yes | model candidates only; same shape as `experiment.candidates` model entries |
+| `promote_top_k` | no | defaults to `3`; must be `<=` the number of valid cross-product pairs |
 
 ## Commands
 

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -100,10 +100,11 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
         raise ValueError("experiment.runtime must be a mapping when provided.")
     candidate = experiment.get("candidate")
     candidates = experiment.get("candidates")
-    if candidate is not None and candidates is not None:
-        raise ValueError("Use either experiment.candidate or experiment.candidates, not both.")
-    if candidate is not None and not isinstance(candidate, dict):
-        raise ValueError("experiment.candidate must be a mapping when provided.")
+    if candidate is not None:
+        raise ValueError(
+            "Legacy experiment.candidate is no longer supported. "
+            "Use experiment.candidates."
+        )
     competition = raw_data.get("competition")
     if competition is not None and not isinstance(competition, dict):
         raise ValueError("competition must be a mapping when provided.")
@@ -114,8 +115,6 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
     experiment_candidate_list: list[BootstrapCandidateRuntimeConfig] = []
     if candidates is not None:
         experiment_candidate_list = _coerce_bootstrap_candidate_list(candidates, "experiment.candidates")
-    elif candidate is not None:
-        experiment_candidate_list = [_coerce_bootstrap_candidate(candidate)]
 
     screening_candidate_list: list[BootstrapCandidateRuntimeConfig] = []
     if screening is not None:

--- a/src/tabular_shenanigans/cli.py
+++ b/src/tabular_shenanigans/cli.py
@@ -327,11 +327,6 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     load_dotenv(dotenv_path=Path(".env"), override=False)
     config = load_config()
-    if config.experiment.legacy_candidate_contract_used:
-        print(
-            "Config deprecation: experiment.candidate is deprecated. "
-            "Migrate config.yaml to experiment.candidates."
-        )
     _print_resolved_setup(config)
 
     if args.stage is None:

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -215,24 +215,6 @@ class ExperimentConfig(BaseModel):
     runtime: ExperimentRuntimeConfig = Field(default_factory=ExperimentRuntimeConfig)
     tracking: ExperimentTrackingConfig = Field(default_factory=ExperimentTrackingConfig)
     active_candidate_index: int = Field(default=0, exclude=True, repr=False, ge=0)
-    legacy_candidate_contract_used: bool = Field(default=False, exclude=True, repr=False)
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_single_candidate_contract(cls, values: object) -> object:
-        if not isinstance(values, dict):
-            return values
-
-        if values.get("candidate") is not None and values.get("candidates") is not None:
-            raise ValueError("Use either experiment.candidate or experiment.candidates, not both.")
-
-        if values.get("candidate") is None:
-            return values
-
-        migrated_values = dict(values)
-        migrated_values["candidates"] = [migrated_values.pop("candidate")]
-        migrated_values["legacy_candidate_contract_used"] = True
-        return migrated_values
 
     @model_validator(mode="after")
     def validate_active_candidate_index(self) -> "ExperimentConfig":


### PR DESCRIPTION
## Summary
- remove the remaining experiment.candidate compatibility path from both config loaders
- remove the obsolete CLI deprecation branch tied to that legacy contract
- align USAGE.md with the implemented screening cross-product contract

## Verification
- temp-config check: legacy experiment.candidate now hard-fails in load_config()
- temp-config check: legacy experiment.candidate now hard-fails in load_bootstrap_runtime_config()
- smoke flow against smoke-binary-canonical: screening -> train -> submit --dry-run succeeds with a temp file-backed MLflow store

Closes #258