### PR TITLE
Refactor representations to explicit operator/pruner specs

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -86,7 +86,7 @@ Optional top-level section: `screening`.
 
 `train` drains `experiment.candidates` in order unless narrowed with `--candidate-id` or `--index`. `submit --index <n>` uses a 1-based index into this list.
 
-`screening` evaluates the valid cross-product of `screening.representation_ids` and `screening.model_families`, then prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
+`screening` evaluates the valid cross-product of `screening.representations` and `screening.model_families`, then prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
 
 #### Candidate Shapes
 
@@ -95,13 +95,15 @@ Optional top-level section: `screening`.
 - `model_family`:
   - regression: `ridge`, `elasticnet`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `realmlp`, `lightgbm`, `catboost`, `xgboost`
   - binary: `logistic_regression`, `random_forest`, `extra_trees`, `hist_gradient_boosting`, `realmlp`, `lightgbm`, `catboost`, `xgboost`
-- `representation_id`: registered representation (e.g., `median-native`, `standardize-onehot`, `kbins-frequency`, or competition-specific like `s6e3_fr1-median-native`)
+- `representation`: explicit operator/pruner spec
+  - `operators`: one or more operator entries like `standardize_numeric`, `native_numeric`, `native_categorical`, `ordinal_encode_categoricals`, `frequency_encode_categoricals`, `onehot_encode_low_cardinality_categoricals`, `row_missing_count`
+  - `pruners`: optional pruner entries like `high_correlation_prune`
 - optional `model_params`: manual estimator overrides
   - `logistic_regression` is `saga`-only; `model_params` uses `l1_ratio` only; `penalty` and `solver` are not supported
 - optional `optimization`
   - logistic regression Optuna trials fix `solver="saga"` and `max_iter=1000`, tune `C`, `tol`, `class_weight`, and `l1_ratio`
 
-Hard-invalid: representations with `native` categorical preprocessor and any `model_family` other than `catboost` or `realmlp`.
+Hard-invalid: representations with `native_categorical` and any `model_family` other than `catboost` or `realmlp`.
 
 **Blend candidate:**
 - `candidate_type: blend`
@@ -119,8 +121,8 @@ Hard-invalid: representations with `native` categorical preprocessor and any `mo
 
 | Key | Required | Notes |
 | --- | --- | --- |
-| `representation_ids` | yes | registered representation IDs; screening expands these against `model_families` |
-| `model_families` | yes | model families to screen against `representation_ids` |
+| `representations` | yes | explicit representation specs; screening expands these against `model_families` |
+| `model_families` | yes | model families to screen against `representations` |
 | `optimization` | no | optional shared tuning budget applied to each valid screening candidate |
 | `cv.n_splits` | no | defaults to `2` |
 | `cv.shuffle` | no | defaults to `true` |

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -43,7 +43,12 @@ experiment:
     # Remove entries you do not want to include in the current train batch.
     - candidate_type: model
       model_family: logistic_regression
-      representation_id: standardize-onehot
+      representation:
+        operators:
+          - id: standardize_numeric
+          - id: onehot_encode_low_cardinality_categoricals
+            max_cardinality: 20
+        pruners: []
       model_params: {}
       # For logistic_regression, use l1_ratio only:
       # model_params:
@@ -60,7 +65,11 @@ experiment:
 
     - candidate_type: model
       model_family: lightgbm
-      representation_id: median-ordinal
+      representation:
+        operators:
+          - id: native_numeric
+          - id: ordinal_encode_categoricals
+        pruners: []
       model_params: {}
 
     # Optional blend candidate shape:
@@ -72,13 +81,20 @@ experiment:
     #     - 0.5
     #     - 0.5
 
-# Optional screening stage — evaluates the cross-product of representation_ids x model_families
+# Optional screening stage — evaluates the cross-product of representations x model_families
 # with a cheap reduced-fold CV, then prints a promotion snippet for the top-k candidates.
 # screening:
-#   representation_ids:
-#     - standardize-onehot
-#     - median-ordinal
-#     - median-frequency
+#   representations:
+#     - operators:
+#         - id: standardize_numeric
+#         - id: onehot_encode_low_cardinality_categoricals
+#           max_cardinality: 20
+#     - operators:
+#         - id: native_numeric
+#         - id: ordinal_encode_categoricals
+#     - operators:
+#         - id: native_numeric
+#         - id: frequency_encode_categoricals
 #   model_families:
 #     - lightgbm
 #     - xgboost

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -37,7 +37,12 @@ experiment:
     # Remove entries you do not want to include in the current train batch.
     - candidate_type: model
       model_family: elasticnet
-      representation_id: standardize-onehot
+      representation:
+        operators:
+          - id: standardize_numeric
+          - id: onehot_encode_low_cardinality_categoricals
+            max_cardinality: 20
+        pruners: []
       model_params: {}
       # To enable optimization, replace model_params with an optimization block:
       # optimization:
@@ -48,7 +53,11 @@ experiment:
 
     - candidate_type: model
       model_family: lightgbm
-      representation_id: median-ordinal
+      representation:
+        operators:
+          - id: native_numeric
+          - id: ordinal_encode_categoricals
+        pruners: []
       model_params: {}
 
     # Optional blend candidate shape:
@@ -60,13 +69,20 @@ experiment:
     #     - 0.5
     #     - 0.5
 
-# Optional screening stage — evaluates the cross-product of representation_ids x model_families
+# Optional screening stage — evaluates the cross-product of representations x model_families
 # with a cheap reduced-fold CV, then prints a promotion snippet for the top-k candidates.
 # screening:
-#   representation_ids:
-#     - standardize-onehot
-#     - median-ordinal
-#     - median-frequency
+#   representations:
+#     - operators:
+#         - id: standardize_numeric
+#         - id: onehot_encode_low_cardinality_categoricals
+#           max_cardinality: 20
+#     - operators:
+#         - id: native_numeric
+#         - id: ordinal_encode_categoricals
+#     - operators:
+#         - id: native_numeric
+#         - id: frequency_encode_categoricals
 #   model_families:
 #     - lightgbm
 #     - xgboost

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -7,7 +7,7 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 ## System Flow
 
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths. Screening config uses `screening.representation_ids` x `screening.model_families` cross-product expansion; incompatible pairs are skipped with a warning at config validation time.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths. Screening config uses `screening.representations` x `screening.model_families` cross-product expansion; incompatible pairs are skipped with a warning at config validation time.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the full `experiment.candidates` contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.
@@ -386,7 +386,7 @@ Current preprocessing selection on GPU hosts:
 - [candidate_artifacts.py](/src/tabular_shenanigans/candidate_artifacts.py): shared manifest/config helpers and temp-bundle file writers for candidate/context artifacts.
 - [data.py](/src/tabular_shenanigans/data.py): Kaggle downloads, zip access, schema inference, and sample-submission loading.
 - [eda.py](/src/tabular_shenanigans/eda.py): local EDA report generation.
-- [representations/](/src/tabular_shenanigans/representations): representation runtime — types, steps (numeric/categorical/feature-engineering), output adapters, compilation, fitted representation, and registry. Replaces the former `feature_recipes/` and split preprocessing configuration with a single `representation_id` contract.
+- [representations/](/src/tabular_shenanigans/representations): representation runtime — operator/pruner specs, feature-bundle compilation, compatibility contract derivation, and final materialization. Replaces the former `feature_recipes/` and registered `representation_id` registry with explicit representation config.
 - [model_evaluation.py](/src/tabular_shenanigans/model_evaluation.py): shared prepared training context, reusable CV evaluation logic for train/tune, and fold-stage runtime profiling for benchmark checkpoints.
 - [models.py](/src/tabular_shenanigans/models.py): model registry, capability checks, estimator construction (runtime/task-contract params only; hyperparameter defaults are upstream), and tuning space definitions.
 - [preprocess.py](/src/tabular_shenanigans/preprocess.py): raw feature-frame preparation, `NativeFramePreprocessor`, and `FrequencyFramePreprocessor` backends used by GPU preprocessing paths.

--- a/src/tabular_shenanigans/_model_registry.py
+++ b/src/tabular_shenanigans/_model_registry.py
@@ -37,6 +37,7 @@ from tabular_shenanigans._model_builders import (
     build_xgboost_tuning_space,
 )
 from tabular_shenanigans._model_types import GpuRoutingRule, ModelDefinition
+from tabular_shenanigans.representations.types import RepresentationContract
 from tabular_shenanigans.runtime_execution import (
     CPU_GPU_BACKEND,
     NATIVE_GPU_BACKEND,
@@ -451,6 +452,44 @@ def validate_model_preprocessing_compatibility(
         "categorical_preprocessor='native'. "
         f"Supported native categorical model families: {native_model_families}."
     )
+
+
+def validate_model_representation_compatibility(
+    task_type: str,
+    model_id: str,
+    representation_contract: RepresentationContract,
+) -> None:
+    validate_model_output_compatibility(
+        task_type=task_type,
+        model_id=model_id,
+        has_native_categorical=representation_contract.has_native_categorical,
+        has_sparse_numeric=representation_contract.has_sparse_numeric,
+    )
+
+
+def validate_model_output_compatibility(
+    task_type: str,
+    model_id: str,
+    has_native_categorical: bool,
+    has_sparse_numeric: bool,
+) -> None:
+    model_definition = get_model_definition(task_type, model_id)
+
+    if has_native_categorical and not model_definition.supports_native_categorical_preprocessing:
+        native_model_families = sorted(
+            candidate_model_id
+            for candidate_model_id, candidate_definition in get_task_model_registry(task_type).items()
+            if candidate_definition.supports_native_categorical_preprocessing
+        )
+        raise ValueError(
+            f"Model family '{model_definition.model_id}' does not support native categorical representations. "
+            f"Supported native categorical model families: {native_model_families}."
+        )
+
+    if has_sparse_numeric and not model_definition.supports_sparse_preprocessed_input:
+        raise ValueError(
+            f"Model family '{model_definition.model_id}' does not support sparse numeric representations."
+        )
 
 
 def resolve_model_matrix_output_kind(

--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -81,23 +81,20 @@ def _raise_mixed_patch_runtime_error(selection: BootstrapCliSelection) -> None:
 def _filter_compatible_screening_candidates(
     screening_candidates: tuple,
     task_type: str,
-    representation_registry: dict,
     resolve_model_id_fn,
     validate_compatibility_fn,
 ) -> tuple:
     filtered = []
     for candidate in screening_candidates:
-        if candidate.model_family is None or candidate.representation_id is None:
-            continue
-        representation_definition = representation_registry.get(candidate.representation_id)
-        if representation_definition is None:
+        if candidate.model_family is None or candidate.representation is None:
             continue
         try:
             model_id = resolve_model_id_fn(task_type=task_type, model_family=candidate.model_family)
             validate_compatibility_fn(
                 task_type=task_type,
                 model_id=model_id,
-                categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
+                has_native_categorical=candidate.has_native_categorical,
+                has_sparse_numeric=candidate.has_sparse_numeric,
             )
         except ValueError:
             continue
@@ -111,8 +108,7 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
 
     from tabular_shenanigans.bootstrap_config import load_bootstrap_runtime_config
     from tabular_shenanigans.execution_routing import resolve_model_candidate_runtime_execution
-    from tabular_shenanigans.models import resolve_candidate_model_id, validate_model_preprocessing_compatibility
-    from tabular_shenanigans.representations.registry import REPRESENTATION_REGISTRY
+    from tabular_shenanigans.models import resolve_candidate_model_id, validate_model_output_compatibility
     from tabular_shenanigans.runtime_execution import (
         PATCH_GPU_BACKEND,
         activate_runtime_acceleration,
@@ -132,9 +128,8 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
         configured_candidates = _filter_compatible_screening_candidates(
             runtime_config.screening_candidates,
             runtime_config.task_type,
-            REPRESENTATION_REGISTRY,
             resolve_candidate_model_id,
-            validate_model_preprocessing_compatibility,
+            validate_model_output_compatibility,
         )
     else:
         configured_candidates = runtime_config.experiment_candidates
@@ -150,11 +145,8 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
         if (
             candidate.candidate_type != "model"
             or candidate.model_family is None
-            or candidate.representation_id is None
+            or candidate.representation is None
         ):
-            continue
-        representation_definition = REPRESENTATION_REGISTRY.get(candidate.representation_id)
-        if representation_definition is None:
             continue
         selected_model_contexts.append(
             resolve_model_candidate_runtime_execution(
@@ -163,8 +155,8 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
                 capabilities=capabilities,
                 task_type=runtime_config.task_type,
                 model_family=candidate.model_family,
-                numeric_preprocessor=representation_definition.numeric_preprocessor_id,
-                categorical_preprocessor=representation_definition.categorical_preprocessor_id,
+                numeric_preprocessor=candidate.routing_numeric_preprocessor,
+                categorical_preprocessor=candidate.routing_categorical_preprocessor,
             )
         )
 

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -2,13 +2,86 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+from tabular_shenanigans.naming import _short_hash
 
 
 @dataclass(frozen=True)
 class BootstrapCandidateRuntimeConfig:
     candidate_type: str | None = None
     model_family: str | None = None
+    representation: dict[str, object] | None = None
     representation_id: str | None = None
+    routing_numeric_preprocessor: str = "custom"
+    routing_categorical_preprocessor: str = "custom"
+    has_native_categorical: bool = False
+    has_sparse_numeric: bool = False
+
+
+def _normalize_representation_component_payload(component: object, field_name: str) -> dict[str, object]:
+    if not isinstance(component, dict):
+        raise ValueError(f"{field_name} entries must be mappings.")
+    component_id = component.get("id")
+    if not isinstance(component_id, str) or not component_id:
+        raise ValueError(f"{field_name} entries must include a non-empty string 'id'.")
+    return {
+        "id": component_id,
+        "params": {str(key): value for key, value in component.items() if key != "id"},
+    }
+
+
+def _build_bootstrap_representation_summary(
+    representation: dict[str, object] | None,
+) -> tuple[str | None, str, str, bool, bool]:
+    if representation is None:
+        return None, "custom", "custom", False, False
+
+    operators = representation.get("operators")
+    pruners = representation.get("pruners", [])
+    if not isinstance(operators, list) or not operators:
+        raise ValueError("representation.operators must be a non-empty list.")
+    if not isinstance(pruners, list):
+        raise ValueError("representation.pruners must be a list when provided.")
+
+    normalized_operators = [
+        _normalize_representation_component_payload(component, "representation.operators")
+        for component in operators
+    ]
+    normalized_pruners = [
+        _normalize_representation_component_payload(component, "representation.pruners")
+        for component in pruners
+    ]
+    fingerprint_payload = {"operators": normalized_operators, "pruners": normalized_pruners}
+    representation_id = f"repr-{_short_hash(fingerprint_payload)}"
+
+    operator_ids = {operator["id"] for operator in normalized_operators}
+    has_native_categorical = "native_categorical" in operator_ids
+    has_sparse_numeric = "onehot_encode_low_cardinality_categoricals" in operator_ids
+
+    routing_numeric_preprocessor = "custom"
+    if operator_ids == {"standardize_numeric"}:
+        routing_numeric_preprocessor = "standardize"
+    elif operator_ids == {"native_numeric"}:
+        routing_numeric_preprocessor = "median"
+    elif "standardize_numeric" in operator_ids and "native_numeric" not in operator_ids:
+        routing_numeric_preprocessor = "standardize"
+
+    routing_categorical_preprocessor = "custom"
+    if has_native_categorical and not has_sparse_numeric:
+        routing_categorical_preprocessor = "native"
+    elif "onehot_encode_low_cardinality_categoricals" in operator_ids:
+        routing_categorical_preprocessor = "onehot"
+    elif "frequency_encode_categoricals" in operator_ids:
+        routing_categorical_preprocessor = "frequency"
+    elif "ordinal_encode_categoricals" in operator_ids:
+        routing_categorical_preprocessor = "ordinal"
+
+    return (
+        representation_id,
+        routing_numeric_preprocessor,
+        routing_categorical_preprocessor,
+        has_native_categorical,
+        has_sparse_numeric,
+    )
 
 
 @dataclass(frozen=True)
@@ -55,10 +128,23 @@ def _coerce_bootstrap_candidate(candidate: object) -> BootstrapCandidateRuntimeC
         return BootstrapCandidateRuntimeConfig()
     if not isinstance(candidate, dict):
         raise ValueError("experiment.candidates items must be mappings when provided.")
+    representation = candidate.get("representation") if isinstance(candidate.get("representation"), dict) else None
+    (
+        representation_id,
+        routing_numeric_preprocessor,
+        routing_categorical_preprocessor,
+        has_native_categorical,
+        has_sparse_numeric,
+    ) = _build_bootstrap_representation_summary(representation)
     return BootstrapCandidateRuntimeConfig(
         candidate_type=candidate.get("candidate_type"),
         model_family=candidate.get("model_family"),
-        representation_id=candidate.get("representation_id"),
+        representation=representation,
+        representation_id=representation_id,
+        routing_numeric_preprocessor=routing_numeric_preprocessor,
+        routing_categorical_preprocessor=routing_categorical_preprocessor,
+        has_native_categorical=has_native_categorical,
+        has_sparse_numeric=has_sparse_numeric,
     )
 
 
@@ -118,16 +204,29 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
 
     screening_candidate_list: list[BootstrapCandidateRuntimeConfig] = []
     if screening is not None:
-        screening_repr_ids = screening.get("representation_ids")
+        screening_representations = screening.get("representations")
         screening_model_families = screening.get("model_families")
-        if isinstance(screening_repr_ids, list) and isinstance(screening_model_families, list):
-            for repr_id in screening_repr_ids:
+        if isinstance(screening_representations, list) and isinstance(screening_model_families, list):
+            for representation in screening_representations:
                 for model_family in screening_model_families:
+                    normalized_representation = representation if isinstance(representation, dict) else None
+                    (
+                        representation_id,
+                        routing_numeric_preprocessor,
+                        routing_categorical_preprocessor,
+                        has_native_categorical,
+                        has_sparse_numeric,
+                    ) = _build_bootstrap_representation_summary(normalized_representation)
                     screening_candidate_list.append(
                         BootstrapCandidateRuntimeConfig(
                             candidate_type="model",
                             model_family=model_family if isinstance(model_family, str) else None,
-                            representation_id=repr_id if isinstance(repr_id, str) else None,
+                            representation=normalized_representation,
+                            representation_id=representation_id,
+                            routing_numeric_preprocessor=routing_numeric_preprocessor,
+                            routing_categorical_preprocessor=routing_categorical_preprocessor,
+                            has_native_categorical=has_native_categorical,
+                            has_sparse_numeric=has_sparse_numeric,
                         )
                     )
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -11,7 +11,7 @@ from tabular_shenanigans.models import (
     is_model_tunable,
     resolve_candidate_model_id,
     validate_model_parameter_overrides,
-    validate_model_preprocessing_compatibility,
+    validate_model_representation_compatibility,
 )
 from tabular_shenanigans.naming import (
     build_blend_candidate_id,
@@ -19,8 +19,9 @@ from tabular_shenanigans.naming import (
     normalize_blend_weights,
 )
 from tabular_shenanigans.representations import (
-    get_representation_definition,
-    resolve_representation_id,
+    build_representation_contract,
+    build_representation_spec_from_payload,
+    validate_representation_spec,
 )
 from tabular_shenanigans.preprocess_execution import resolve_preprocessing_execution_plan
 
@@ -71,10 +72,40 @@ class CompetitionConfig(BaseModel):
     features: CompetitionFeaturesConfig = Field(default_factory=CompetitionFeaturesConfig)
 
 
+class RepresentationComponentConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(min_length=1)
+
+    def params(self) -> dict[str, object]:
+        return dict(self.model_extra or {})
+
+    def to_payload(self) -> dict[str, object]:
+        return {"id": self.id, **self.params()}
+
+
+class RepresentationConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operators: list[RepresentationComponentConfig] = Field(min_length=1)
+    pruners: list[RepresentationComponentConfig] = Field(default_factory=list)
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "operators": [operator.to_payload() for operator in self.operators],
+            "pruners": [pruner.to_payload() for pruner in self.pruners],
+        }
+
+    def to_runtime_spec(self):
+        representation_spec = build_representation_spec_from_payload(self.to_payload())
+        validate_representation_spec(representation_spec)
+        return representation_spec
+
+
 class ScreeningConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    representation_ids: list[str] = Field(min_length=1)
+    representations: list[RepresentationConfig] = Field(min_length=1)
     model_families: list[str] = Field(min_length=1)
     optimization: "CandidateOptimizationConfig | None" = None
     cv: CompetitionCvConfig = Field(
@@ -92,8 +123,13 @@ class ScreeningConfig(BaseModel):
         if "candidates" in values:
             raise ValueError(
                 "screening.candidates is not a user-facing field. "
-                "Use screening.representation_ids and screening.model_families instead. "
+                "Use screening.representations and screening.model_families instead. "
                 "The candidates list is built automatically from the cross-product."
+            )
+        if "representation_ids" in values:
+            raise ValueError(
+                "screening.representation_ids is no longer supported. "
+                "Use screening.representations."
             )
         return values
 
@@ -119,7 +155,8 @@ class ModelCandidateConfig(BaseCandidateConfig):
     model_config = ConfigDict(extra="forbid")
 
     candidate_type: Literal["model"] = "model"
-    representation_id: str = Field(min_length=1)
+    representation: RepresentationConfig
+    representation_id: str = Field(default="", exclude=True)
     model_family: str = Field(min_length=1)
     model_params: dict[str, object] = Field(default_factory=dict)
     optimization: CandidateOptimizationConfig | None = None
@@ -129,12 +166,18 @@ class ModelCandidateConfig(BaseCandidateConfig):
     def reject_legacy_fields(cls, values: object) -> object:
         if not isinstance(values, dict):
             return values
-        legacy_fields = {"preprocessor", "numeric_preprocessor", "categorical_preprocessor", "feature_recipe_id"}
+        legacy_fields = {
+            "representation_id",
+            "preprocessor",
+            "numeric_preprocessor",
+            "categorical_preprocessor",
+            "feature_recipe_id",
+        }
         found_legacy = sorted(legacy_fields.intersection(values))
         if found_legacy:
             raise ValueError(
                 f"Legacy candidate fields {found_legacy} are no longer supported. "
-                "Use candidate.representation_id instead."
+                "Use candidate.representation."
             )
         return values
 
@@ -145,6 +188,7 @@ class ModelCandidateConfig(BaseCandidateConfig):
                 "candidate.model_params and candidate.optimization are mutually exclusive. "
                 "Use model_params for fixed training or optimization for tuning, not both."
             )
+        self.representation_id = self.representation.to_runtime_spec().representation_id
         return self
 
 
@@ -265,13 +309,13 @@ class AppConfig(BaseModel):
         for candidate_index, candidate in enumerate(self.experiment.candidates, start=1):
             try:
                 if isinstance(candidate, ModelCandidateConfig):
-                    candidate.representation_id = resolve_representation_id(candidate.representation_id)
-                    representation_definition = get_representation_definition(candidate.representation_id)
+                    representation_spec = candidate.representation.to_runtime_spec()
+                    representation_contract = build_representation_contract(representation_spec)
                     resolved_model_registry_key = self.resolve_model_registry_key_for_index(candidate_index - 1)
-                    validate_model_preprocessing_compatibility(
+                    validate_model_representation_compatibility(
                         task_type=competition.task_type,
                         model_id=resolved_model_registry_key,
-                        categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
+                        representation_contract=representation_contract,
                     )
                     validate_model_parameter_overrides(
                         task_type=competition.task_type,
@@ -317,11 +361,11 @@ class AppConfig(BaseModel):
         if self.screening is not None:
             screening = self.screening
 
-            resolved_representation_ids = []
-            for raw_repr_id in screening.representation_ids:
-                resolved_repr_id = resolve_representation_id(raw_repr_id)
-                get_representation_definition(resolved_repr_id)
-                resolved_representation_ids.append(resolved_repr_id)
+            resolved_representations = []
+            for representation in screening.representations:
+                representation_spec = representation.to_runtime_spec()
+                representation_contract = build_representation_contract(representation_spec)
+                resolved_representations.append((representation, representation_spec, representation_contract))
 
             resolved_model_families: list[tuple[str, str]] = []
             for raw_model_family in screening.model_families:
@@ -332,24 +376,23 @@ class AppConfig(BaseModel):
                 resolved_model_families.append((raw_model_family, resolved_model_id))
 
             expanded_candidates: list[ModelCandidateConfig] = []
-            for repr_id in resolved_representation_ids:
-                representation_definition = get_representation_definition(repr_id)
+            for representation, representation_spec, representation_contract in resolved_representations:
                 for model_family, model_registry_key in resolved_model_families:
                     try:
-                        validate_model_preprocessing_compatibility(
+                        validate_model_representation_compatibility(
                             task_type=competition.task_type,
                             model_id=model_registry_key,
-                            categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
+                            representation_contract=representation_contract,
                         )
                     except ValueError as exc:
                         print(
                             f"Screening: skipping incompatible pair "
-                            f"(model_family={model_family!r}, representation_id={repr_id!r}): {exc}"
+                            f"(model_family={model_family!r}, representation_id={representation_spec.representation_id!r}): {exc}"
                         )
                         continue
                     expanded_candidates.append(
                         ModelCandidateConfig(
-                            representation_id=repr_id,
+                            representation=representation.model_copy(deep=True),
                             model_family=model_family,
                             optimization=screening.optimization.model_copy(deep=True)
                             if screening.optimization is not None
@@ -359,7 +402,7 @@ class AppConfig(BaseModel):
 
             if not expanded_candidates:
                 raise ValueError(
-                    "screening: no valid (model_family, representation_id) pairs survived "
+                    "screening: no valid (model_family, representation) pairs survived "
                     "compatibility checks. All cross-product pairs were incompatible."
                 )
 
@@ -563,6 +606,22 @@ class AppConfig(BaseModel):
             model_family=candidate.model_family,
         )
 
+    def resolve_representation_spec_for_index(self, candidate_index: int | None = None):
+        candidate = self.get_candidate(candidate_index)
+        if not isinstance(candidate, ModelCandidateConfig):
+            raise ValueError("representation spec is only available for model candidates.")
+        return candidate.representation.to_runtime_spec()
+
+    def resolve_representation_contract_for_index(self, candidate_index: int | None = None):
+        return build_representation_contract(self.resolve_representation_spec_for_index(candidate_index))
+
+    def resolve_screening_representation_spec_for_index(self, candidate_index: int | None = None):
+        candidate = self.get_screening_candidate(candidate_index)
+        return candidate.representation.to_runtime_spec()
+
+    def resolve_screening_representation_contract_for_index(self, candidate_index: int | None = None):
+        return build_representation_contract(self.resolve_screening_representation_spec_for_index(candidate_index))
+
     def resolve_blend_weights_for_index(self, candidate_index: int | None = None) -> list[float]:
         candidate = self.get_candidate(candidate_index)
         if not isinstance(candidate, BlendCandidateConfig):
@@ -610,15 +669,15 @@ class AppConfig(BaseModel):
         if not isinstance(candidate, ModelCandidateConfig):
             return runtime_execution_context
 
-        representation_definition = get_representation_definition(candidate.representation_id)
+        representation_contract = self.resolve_representation_contract_for_index(candidate_index)
         resolved_runtime_execution_context = resolve_model_candidate_runtime_execution(
             requested_compute_target=self.experiment.runtime.compute_target,
             requested_gpu_backend=self.experiment.runtime.gpu_backend,
             capabilities=runtime_execution_context.capabilities,
             task_type=self.competition.task_type,
             model_family=candidate.model_family,
-            numeric_preprocessor=representation_definition.numeric_preprocessor_id,
-            categorical_preprocessor=representation_definition.categorical_preprocessor_id,
+            numeric_preprocessor=representation_contract.routing_numeric_preprocessor,
+            categorical_preprocessor=representation_contract.routing_categorical_preprocessor,
         )
         return resolved_runtime_execution_context.__class__(
             requested_compute_target=resolved_runtime_execution_context.requested_compute_target,
@@ -631,25 +690,17 @@ class AppConfig(BaseModel):
         )
 
     def preprocessing_execution_plan_for_index(self, candidate_index: int | None = None):
-        from tabular_shenanigans.models import resolve_model_matrix_output_kind
-
         candidate = self.get_candidate(candidate_index)
         if not isinstance(candidate, ModelCandidateConfig):
             raise ValueError("preprocessing_execution_plan is only available for model candidates.")
 
-        representation_definition = get_representation_definition(candidate.representation_id)
+        representation_contract = self.resolve_representation_contract_for_index(candidate_index)
         runtime_execution_context = self.runtime_execution_context_for_index(candidate_index)
-        matrix_output_kind = resolve_model_matrix_output_kind(
-            task_type=self.competition.task_type,
-            model_id=self.resolve_model_registry_key_for_index(candidate_index),
-            categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
-            runtime_execution_context=runtime_execution_context,
-        )
         return resolve_preprocessing_execution_plan(
             runtime_execution_context=runtime_execution_context,
-            numeric_preprocessor_id=representation_definition.numeric_preprocessor_id,
-            categorical_preprocessor_id=representation_definition.categorical_preprocessor_id,
-            matrix_output_kind=matrix_output_kind,
+            numeric_preprocessor_id=representation_contract.routing_numeric_preprocessor,
+            categorical_preprocessor_id=representation_contract.routing_categorical_preprocessor,
+            matrix_output_kind=representation_contract.matrix_output_kind,
         )
 
     def resolve_candidate_id_for_index(self, candidate_index: int | None = None) -> str:
@@ -663,6 +714,7 @@ class AppConfig(BaseModel):
                 "competition": _competition_identity_fingerprint_payload(competition),
                 "candidate": {
                     "representation_id": candidate.representation_id,
+                    "representation": candidate.representation.to_payload(),
                     "model_family": candidate.model_family,
                     "model_registry_key": self.resolve_model_registry_key_for_index(candidate_index),
                     "model_params": candidate.model_params,
@@ -705,6 +757,7 @@ class AppConfig(BaseModel):
             "competition": _competition_identity_fingerprint_payload(competition),
             "candidate": {
                 "representation_id": candidate.representation_id,
+                "representation": candidate.representation.to_payload(),
                 "model_family": candidate.model_family,
                 "model_registry_key": self.resolve_screening_model_registry_key_for_index(candidate_index),
                 "model_params": candidate.model_params,

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -19,8 +19,8 @@ from tabular_shenanigans.preprocess import prepare_feature_frames
 from tabular_shenanigans.representations import (
     CompiledRepresentation,
     ResolvedFeatureSchema,
+    build_representation_contract,
     compile_representation,
-    get_representation_definition,
     resolve_feature_schema,
 )
 
@@ -153,8 +153,9 @@ def build_prepared_training_context(
         negative_label=negative_label,
         observed_label_pair=observed_label_pair,
     )
-    representation_id = candidate.representation_id
-    representation_definition = get_representation_definition(representation_id)
+    representation_spec = candidate.representation.to_runtime_spec()
+    representation_contract = build_representation_contract(representation_spec)
+    representation_id = representation_spec.representation_id
     feature_schema = resolve_feature_schema(
         x_train_raw=x_train_raw,
         force_categorical=features.force_categorical,
@@ -163,11 +164,10 @@ def build_prepared_training_context(
     )
     runtime_execution_context = config.runtime_execution_context
     compiled_representation = compile_representation(
-        definition=representation_definition,
+        representation_spec=representation_spec,
         feature_schema=feature_schema,
-        runtime_execution_context=runtime_execution_context,
-        task_type=competition.task_type,
-        model_id=config.resolved_model_registry_key,
+        x_train_sample=x_train_raw,
+        representation_contract=representation_contract,
     )
     uses_xgboost_gpu_native_inputs = (
         config.resolved_model_registry_key == "xgboost"

--- a/src/tabular_shenanigans/models.py
+++ b/src/tabular_shenanigans/models.py
@@ -16,6 +16,8 @@ from tabular_shenanigans._model_registry import (
     resolve_candidate_model_id,
     resolve_model_id,
     resolve_model_matrix_output_kind,
+    validate_model_output_compatibility,
+    validate_model_representation_compatibility,
     validate_model_preprocessing_compatibility,
 )
 from tabular_shenanigans._model_types import (
@@ -46,6 +48,8 @@ __all__ = [
     "resolve_candidate_model_id",
     "resolve_model_id",
     "resolve_model_matrix_output_kind",
+    "validate_model_output_compatibility",
+    "validate_model_representation_compatibility",
     "validate_model_parameter_overrides",
     "validate_model_preprocessing_compatibility",
 ]

--- a/src/tabular_shenanigans/representations/__init__.py
+++ b/src/tabular_shenanigans/representations/__init__.py
@@ -1,46 +1,210 @@
+from __future__ import annotations
+
+from tabular_shenanigans.naming import _short_hash
 from tabular_shenanigans.representations.compilation import (
     CompiledRepresentation,
+    FittedRepresentation,
     compile_representation,
+    materialize_feature_bundle,
 )
 from tabular_shenanigans.representations.feature_schema import (
     ResolvedFeatureSchema,
     resolve_feature_schema,
     resolve_feature_types,
 )
-from tabular_shenanigans.representations.fitted import FittedRepresentation
-from tabular_shenanigans.representations.registry import (
-    REPRESENTATION_REGISTRY,
-    get_representation_definition,
-    resolve_representation_id,
+from tabular_shenanigans.representations.operators import (
+    SUPPORTED_OPERATOR_IDS,
+    SUPPORTED_PRUNER_IDS,
+    validate_component_params,
 )
 from tabular_shenanigans.representations.types import (
+    FeatureBlock,
+    FeatureBundle,
     FitMode,
-    FittedOutputAdapter,
-    FittedStep,
-    OutputAdapter,
-    OutputContract,
-    RepresentationDefinition,
-    RepresentationStep,
+    MaterializedRepresentation,
+    MatrixOutputKind,
+    OutputKind,
+    RepresentationComponentSpec,
+    RepresentationContract,
+    RepresentationSpec,
 )
 
-# Register competition-specific representations
-import tabular_shenanigans.representations.playground_series_s6e3 as _s6e3  # noqa: F401
+
+def normalize_representation_component_payload(component: object, component_kind: str) -> dict[str, object]:
+    if not isinstance(component, dict):
+        raise ValueError(f"{component_kind} entries must be mappings.")
+    component_id = component.get("id")
+    if not isinstance(component_id, str) or not component_id:
+        raise ValueError(f"{component_kind} entries must include a non-empty string 'id'.")
+    params = {str(key): value for key, value in component.items() if key != "id"}
+    return {"id": component_id, "params": params}
+
+
+def build_representation_spec_from_payload(payload: dict[str, object]) -> RepresentationSpec:
+    operators_payload = payload.get("operators")
+    pruners_payload = payload.get("pruners", [])
+    if not isinstance(operators_payload, list) or not operators_payload:
+        raise ValueError("representation.operators must be a non-empty list.")
+    if not isinstance(pruners_payload, list):
+        raise ValueError("representation.pruners must be a list when provided.")
+
+    normalized_operators = [
+        normalize_representation_component_payload(component, "representation.operators")
+        for component in operators_payload
+    ]
+    normalized_pruners = [
+        normalize_representation_component_payload(component, "representation.pruners")
+        for component in pruners_payload
+    ]
+
+    fingerprint_payload = {
+        "operators": normalized_operators,
+        "pruners": normalized_pruners,
+    }
+    representation_id = f"repr-{_short_hash(fingerprint_payload)}"
+    return RepresentationSpec(
+        representation_id=representation_id,
+        operators=tuple(
+            RepresentationComponentSpec(
+                component_id=component["id"],
+                params=dict(component["params"]),
+            )
+            for component in normalized_operators
+        ),
+        pruners=tuple(
+            RepresentationComponentSpec(
+                component_id=component["id"],
+                params=dict(component["params"]),
+            )
+            for component in normalized_pruners
+        ),
+        fingerprint_payload=fingerprint_payload,
+    )
+
+
+def build_representation_contract(
+    representation_spec: RepresentationSpec,
+) -> RepresentationContract:
+    operator_ids = {operator.component_id for operator in representation_spec.operators}
+
+    has_dense_numeric = bool(
+        operator_ids.intersection(
+            {
+                "standardize_numeric",
+                "frequency_encode_categoricals",
+                "ordinal_encode_categoricals",
+                "row_missing_count",
+            }
+        )
+    )
+    has_sparse_numeric = "onehot_encode_low_cardinality_categoricals" in operator_ids
+    has_native_categorical = "native_categorical" in operator_ids
+    has_native_numeric = "native_numeric" in operator_ids
+    has_native_tabular = has_native_categorical or has_native_numeric
+
+    if has_native_tabular and has_sparse_numeric:
+        raise ValueError(
+            "Representations cannot mix native tabular operators with sparse operators. "
+            "Use dense/native operators together or sparse/dense operators together."
+        )
+
+    if has_native_tabular:
+        matrix_output_kind: MatrixOutputKind = "native_frame"
+    elif has_sparse_numeric:
+        matrix_output_kind = "sparse_csr"
+    else:
+        matrix_output_kind = "dense_array"
+
+    routing_numeric_preprocessor = "custom"
+    if operator_ids == {"standardize_numeric"}:
+        routing_numeric_preprocessor = "standardize"
+    elif operator_ids == {"native_numeric"}:
+        routing_numeric_preprocessor = "median"
+    elif "standardize_numeric" in operator_ids and "native_numeric" not in operator_ids:
+        routing_numeric_preprocessor = "standardize"
+
+    routing_categorical_preprocessor = "custom"
+    if has_native_categorical and not has_sparse_numeric:
+        routing_categorical_preprocessor = "native"
+    elif operator_ids.intersection({"onehot_encode_low_cardinality_categoricals"}):
+        routing_categorical_preprocessor = "onehot"
+    elif operator_ids.intersection({"frequency_encode_categoricals"}):
+        routing_categorical_preprocessor = "frequency"
+    elif operator_ids.intersection({"ordinal_encode_categoricals"}):
+        routing_categorical_preprocessor = "ordinal"
+
+    return RepresentationContract(
+        representation_id=representation_spec.representation_id,
+        output_kinds=frozenset(
+            kind
+            for kind, enabled in (
+                ("dense_numeric", has_dense_numeric),
+                ("sparse_numeric", has_sparse_numeric),
+                ("native_tabular", has_native_tabular),
+            )
+            if enabled
+        ),
+        has_dense_numeric=has_dense_numeric,
+        has_sparse_numeric=has_sparse_numeric,
+        has_native_tabular=has_native_tabular,
+        has_native_categorical=has_native_categorical,
+        has_native_numeric=has_native_numeric,
+        matrix_output_kind=matrix_output_kind,
+        routing_numeric_preprocessor=routing_numeric_preprocessor,
+        routing_categorical_preprocessor=routing_categorical_preprocessor,
+    )
+
+
+def validate_representation_spec(representation_spec: RepresentationSpec) -> None:
+    unsupported_operator_ids = sorted(
+        operator.component_id
+        for operator in representation_spec.operators
+        if operator.component_id not in SUPPORTED_OPERATOR_IDS
+    )
+    if unsupported_operator_ids:
+        raise ValueError(
+            f"Unsupported representation operators: {unsupported_operator_ids}. "
+            f"Supported operators: {sorted(SUPPORTED_OPERATOR_IDS)}"
+        )
+    for operator in representation_spec.operators:
+        validate_component_params(operator.component_id, operator.params, "operator")
+
+    unsupported_pruner_ids = sorted(
+        pruner.component_id
+        for pruner in representation_spec.pruners
+        if pruner.component_id not in SUPPORTED_PRUNER_IDS
+    )
+    if unsupported_pruner_ids:
+        raise ValueError(
+            f"Unsupported representation pruners: {unsupported_pruner_ids}. "
+            f"Supported pruners: {sorted(SUPPORTED_PRUNER_IDS)}"
+        )
+    for pruner in representation_spec.pruners:
+        validate_component_params(pruner.component_id, pruner.params, "pruner")
+
+    build_representation_contract(representation_spec)
+
 
 __all__ = [
     "CompiledRepresentation",
-    "FitMode",
-    "FittedOutputAdapter",
+    "FeatureBlock",
+    "FeatureBundle",
     "FittedRepresentation",
-    "FittedStep",
-    "OutputAdapter",
-    "OutputContract",
-    "REPRESENTATION_REGISTRY",
-    "RepresentationDefinition",
-    "RepresentationStep",
+    "FitMode",
+    "MaterializedRepresentation",
+    "MatrixOutputKind",
+    "OutputKind",
+    "RepresentationComponentSpec",
+    "RepresentationContract",
+    "RepresentationSpec",
     "ResolvedFeatureSchema",
+    "SUPPORTED_OPERATOR_IDS",
+    "SUPPORTED_PRUNER_IDS",
+    "build_representation_contract",
+    "build_representation_spec_from_payload",
     "compile_representation",
-    "get_representation_definition",
+    "materialize_feature_bundle",
     "resolve_feature_schema",
     "resolve_feature_types",
-    "resolve_representation_id",
+    "validate_representation_spec",
 ]

--- a/src/tabular_shenanigans/representations/compilation.py
+++ b/src/tabular_shenanigans/representations/compilation.py
@@ -3,85 +3,144 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pandas as pd
+from scipy import sparse
 
 from tabular_shenanigans.representations.feature_schema import ResolvedFeatureSchema
-from tabular_shenanigans.representations.fitted import FittedRepresentation
-from tabular_shenanigans.representations.steps import (
-    bind_step_columns,
-    is_categorical_step,
-    is_numeric_step,
+from tabular_shenanigans.representations.operators import build_feature_generator, build_feature_pruner
+from tabular_shenanigans.representations.types import (
+    FeatureBundle,
+    FeatureGenerator,
+    FeaturePruner,
+    MaterializedRepresentation,
+    RepresentationContract,
+    RepresentationSpec,
 )
-from tabular_shenanigans.representations.types import FittedStep, RepresentationDefinition
+
+
+GENERIC_PREPROCESSING_BACKEND = "feature_bundle"
+
+
+@dataclass(frozen=True)
+class FittedRepresentation:
+    representation_id: str
+    fitted_generators: tuple[object, ...]
+    fitted_pruners: tuple[object, ...]
+    contract: RepresentationContract
+
+    def transform(self, X: pd.DataFrame) -> object:
+        bundle = FeatureBundle(blocks=tuple(generator.transform(X) for generator in self.fitted_generators))
+        for pruner in self.fitted_pruners:
+            bundle = pruner.transform(bundle)
+        return materialize_feature_bundle(bundle, self.contract).values
 
 
 @dataclass(frozen=True)
 class CompiledRepresentation:
-    definition: RepresentationDefinition
+    representation_spec: RepresentationSpec
     feature_schema: ResolvedFeatureSchema
-    bound_steps: tuple[object, ...]
+    generators: tuple[FeatureGenerator, ...]
+    pruners: tuple[FeaturePruner, ...]
+    contract: RepresentationContract
     matrix_output_kind: str
     preprocessing_backend: str
 
     def fit(self, X_train: pd.DataFrame, y_train: pd.Series) -> FittedRepresentation:
-        current = X_train.copy()
-        fitted_steps: list[FittedStep] = []
-        for step in self.bound_steps:
-            y_arg = y_train if step.fit_mode == "supervised" else None
-            fitted_step = step.fit(current, y_arg)
-            current = fitted_step.transform(current)
-            fitted_steps.append(fitted_step)
-        fitted_output_adapter = self.definition.output_adapter.fit(current)
+        fitted_generators = []
+        for generator in self.generators:
+            y_arg = y_train if generator.fit_mode == "supervised" else None
+            fitted_generators.append(generator.fit(X_train, y_arg))
+
+        bundle = FeatureBundle(blocks=tuple(generator.transform(X_train) for generator in fitted_generators))
+        fitted_pruners = []
+        for pruner in self.pruners:
+            y_arg = y_train if pruner.fit_mode == "supervised" else None
+            fitted_pruner = pruner.fit(bundle, y_arg)
+            bundle = fitted_pruner.transform(bundle)
+            fitted_pruners.append(fitted_pruner)
+
         return FittedRepresentation(
-            representation_id=self.definition.representation_id,
-            fitted_steps=tuple(fitted_steps),
-            fitted_output_adapter=fitted_output_adapter,
+            representation_id=self.representation_spec.representation_id,
+            fitted_generators=tuple(fitted_generators),
+            fitted_pruners=tuple(fitted_pruners),
+            contract=self.contract,
         )
 
 
-def compile_representation(
-    definition: RepresentationDefinition,
-    feature_schema: ResolvedFeatureSchema,
-    runtime_execution_context: object,
-    task_type: str,
-    model_id: str,
-) -> CompiledRepresentation:
-    from tabular_shenanigans.models import (
-        resolve_model_matrix_output_kind,
-        validate_model_preprocessing_compatibility,
-    )
-    from tabular_shenanigans.preprocess_execution import resolve_preprocessing_execution_plan
+def materialize_feature_bundle(
+    bundle: FeatureBundle,
+    contract: RepresentationContract,
+) -> MaterializedRepresentation:
+    dense_frame = bundle.dense_frame()
+    native_frame = bundle.native_frame()
+    sparse_matrix = bundle.sparse_matrix()
 
-    validate_model_preprocessing_compatibility(
-        task_type=task_type,
-        model_id=model_id,
-        categorical_preprocessor_id=definition.categorical_preprocessor_id,
-    )
-    matrix_output_kind = resolve_model_matrix_output_kind(
-        task_type=task_type,
-        model_id=model_id,
-        categorical_preprocessor_id=definition.categorical_preprocessor_id,
-        runtime_execution_context=runtime_execution_context,
-    )
-    execution_plan = resolve_preprocessing_execution_plan(
-        runtime_execution_context=runtime_execution_context,
-        numeric_preprocessor_id=definition.numeric_preprocessor_id,
-        categorical_preprocessor_id=definition.categorical_preprocessor_id,
-        matrix_output_kind=matrix_output_kind,
-    )
-
-    bound_steps: list[object] = []
-    for step in definition.steps:
-        if is_numeric_step(step) and hasattr(step, "columns") and step.columns is None:
-            bound_steps.append(bind_step_columns(step, list(feature_schema.numeric_columns)))
-        elif is_categorical_step(step) and hasattr(step, "columns") and step.columns is None:
-            bound_steps.append(bind_step_columns(step, list(feature_schema.categorical_columns)))
+    if contract.matrix_output_kind == "native_frame":
+        frames = [frame for frame in (native_frame, dense_frame) if not frame.empty]
+        if not frames:
+            values = pd.DataFrame()
+        elif len(frames) == 1:
+            values = frames[0]
         else:
-            bound_steps.append(step)
+            values = pd.concat(frames, axis=1)
+        return MaterializedRepresentation(
+            matrix_output_kind="native_frame",
+            values=values,
+            preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+        )
 
+    if contract.matrix_output_kind == "sparse_csr":
+        matrices = []
+        if not dense_frame.empty:
+            matrices.append(sparse.csr_matrix(dense_frame.to_numpy(dtype=float)))
+        if sparse_matrix is not None:
+            matrices.append(sparse.csr_matrix(sparse_matrix))
+        if not matrices:
+            values = sparse.csr_matrix((dense_frame.shape[0], 0), dtype=float)
+        elif len(matrices) == 1:
+            values = matrices[0]
+        else:
+            values = sparse.hstack(matrices, format="csr")
+        return MaterializedRepresentation(
+            matrix_output_kind="sparse_csr",
+            values=values,
+            preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+        )
+
+    return MaterializedRepresentation(
+        matrix_output_kind="dense_array",
+        values=dense_frame.to_numpy(dtype=float),
+        preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+    )
+
+
+def compile_representation(
+    representation_spec: RepresentationSpec,
+    feature_schema: ResolvedFeatureSchema,
+    x_train_sample: pd.DataFrame,
+    representation_contract: RepresentationContract,
+) -> CompiledRepresentation:
+    generators = tuple(
+        build_feature_generator(
+            component_id=component.component_id,
+            params=component.params,
+            feature_schema=feature_schema,
+            X_sample=x_train_sample,
+        )
+        for component in representation_spec.operators
+    )
+    pruners = tuple(
+        build_feature_pruner(
+            component_id=component.component_id,
+            params=component.params,
+        )
+        for component in representation_spec.pruners
+    )
     return CompiledRepresentation(
-        definition=definition,
+        representation_spec=representation_spec,
         feature_schema=feature_schema,
-        bound_steps=tuple(bound_steps),
-        matrix_output_kind=execution_plan.matrix_output_kind,
-        preprocessing_backend=execution_plan.preprocessing_backend,
+        generators=generators,
+        pruners=pruners,
+        contract=representation_contract,
+        matrix_output_kind=representation_contract.matrix_output_kind,
+        preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
     )

--- a/src/tabular_shenanigans/representations/operators.py
+++ b/src/tabular_shenanigans/representations/operators.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder, StandardScaler
+
+from tabular_shenanigans.representations.feature_schema import ResolvedFeatureSchema
+from tabular_shenanigans.representations.types import (
+    FeatureBlock,
+    FeatureGenerator,
+    FeaturePruner,
+    FeatureBundle,
+    FitMode,
+    FittedFeatureGenerator,
+    FittedFeaturePruner,
+    OutputKind,
+)
+
+
+def _normalize_categorical_series(series: pd.Series, missing_value: str) -> pd.Series:
+    return series.astype(object).where(series.notna(), missing_value).astype(str)
+
+
+def _validate_no_unknown_params(
+    component_kind: str,
+    component_id: str,
+    params: dict[str, object],
+    allowed_keys: set[str],
+) -> None:
+    unknown_keys = sorted(key for key in params if key not in allowed_keys)
+    if unknown_keys:
+        raise ValueError(
+            f"{component_kind} '{component_id}' does not support parameters {unknown_keys}. "
+            f"Supported parameters: {sorted(allowed_keys)}"
+        )
+
+
+@dataclass(frozen=True)
+class _FittedDenseFrameGenerator:
+    block_id: str
+    output_kind: OutputKind = "dense_numeric"
+    transform_fn: Callable[[pd.DataFrame], pd.DataFrame] = lambda X: X
+
+    def transform(self, X: pd.DataFrame) -> FeatureBlock:
+        frame = self.transform_fn(X)
+        return FeatureBlock(
+            block_id=self.block_id,
+            output_kind=self.output_kind,
+            values=frame,
+            feature_names=tuple(frame.columns.tolist()),
+        )
+
+
+@dataclass(frozen=True)
+class _FittedNativeFrameGenerator:
+    block_id: str
+    columns: tuple[str, ...]
+    normalize_categoricals: bool = False
+    missing_value: str = "__missing__"
+    output_kind: OutputKind = "native_tabular"
+
+    def transform(self, X: pd.DataFrame) -> FeatureBlock:
+        if not self.columns:
+            frame = pd.DataFrame(index=X.index)
+        else:
+            frame = X.loc[:, list(self.columns)].copy()
+        if self.normalize_categoricals:
+            for column in frame.columns:
+                frame[column] = _normalize_categorical_series(frame[column], self.missing_value)
+        return FeatureBlock(
+            block_id=self.block_id,
+            output_kind=self.output_kind,
+            values=frame,
+            feature_names=tuple(frame.columns.tolist()),
+        )
+
+
+@dataclass(frozen=True)
+class _FittedSparseGenerator:
+    block_id: str
+    transformer: object
+    columns: tuple[str, ...]
+    feature_names: tuple[str, ...]
+    output_kind: OutputKind = "sparse_numeric"
+
+    def transform(self, X: pd.DataFrame) -> FeatureBlock:
+        if not self.columns:
+            matrix = sparse.csr_matrix((len(X.index), 0), dtype=float)
+        else:
+            matrix = sparse.csr_matrix(self.transformer.transform(X.loc[:, list(self.columns)]))
+        return FeatureBlock(
+            block_id=self.block_id,
+            output_kind=self.output_kind,
+            values=matrix,
+            feature_names=self.feature_names,
+        )
+
+
+@dataclass(frozen=True)
+class _FittedHighCorrelationPruner:
+    dropped_columns: frozenset[str]
+
+    def transform(self, bundle: FeatureBundle) -> FeatureBundle:
+        return bundle.drop_dense_columns(set(self.dropped_columns))
+
+
+@dataclass(frozen=True)
+class NativeNumericGenerator:
+    operator_id: str = "native_numeric"
+    fit_mode: FitMode = "stateless"
+    output_kind: OutputKind = "native_tabular"
+    columns: tuple[str, ...] = ()
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del X, y
+        return _FittedNativeFrameGenerator(
+            block_id=self.operator_id,
+            columns=self.columns,
+        )
+
+
+@dataclass(frozen=True)
+class NativeCategoricalGenerator:
+    operator_id: str = "native_categorical"
+    fit_mode: FitMode = "stateless"
+    output_kind: OutputKind = "native_tabular"
+    columns: tuple[str, ...] = ()
+    missing_value: str = "__missing__"
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del X, y
+        return _FittedNativeFrameGenerator(
+            block_id=self.operator_id,
+            columns=self.columns,
+            normalize_categoricals=True,
+            missing_value=self.missing_value,
+        )
+
+
+@dataclass(frozen=True)
+class StandardizeNumericGenerator:
+    operator_id: str = "standardize_numeric"
+    fit_mode: FitMode = "unsupervised"
+    output_kind: OutputKind = "dense_numeric"
+    columns: tuple[str, ...] = ()
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del y
+        transformer = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="median")),
+                ("scaler", StandardScaler()),
+            ]
+        )
+        if self.columns:
+            transformer.fit(X.loc[:, list(self.columns)])
+        output_columns = [f"{self.operator_id}__{column}" for column in self.columns]
+
+        def _transform(frame: pd.DataFrame) -> pd.DataFrame:
+            if not self.columns:
+                return pd.DataFrame(index=frame.index)
+            transformed = transformer.transform(frame.loc[:, list(self.columns)])
+            return pd.DataFrame(transformed, index=frame.index, columns=output_columns)
+
+        return _FittedDenseFrameGenerator(block_id=self.operator_id, transform_fn=_transform)
+
+
+@dataclass(frozen=True)
+class FrequencyEncodeCategoricalsGenerator:
+    operator_id: str = "frequency_encode_categoricals"
+    fit_mode: FitMode = "unsupervised"
+    output_kind: OutputKind = "dense_numeric"
+    columns: tuple[str, ...] = ()
+    missing_value: str = "__missing__"
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del y
+        category_frequencies: dict[str, dict[str, float]] = {}
+        for column in self.columns:
+            normalized = _normalize_categorical_series(X[column], self.missing_value)
+            frequencies = normalized.value_counts(normalize=True, dropna=False)
+            category_frequencies[column] = {
+                str(category_value): float(freq_value)
+                for category_value, freq_value in frequencies.items()
+            }
+        output_columns = [f"{self.operator_id}__{column}" for column in self.columns]
+
+        def _transform(frame: pd.DataFrame) -> pd.DataFrame:
+            encoded_columns: dict[str, pd.Series] = {}
+            for input_column, output_column in zip(self.columns, output_columns, strict=True):
+                normalized = _normalize_categorical_series(frame[input_column], self.missing_value)
+                encoded_columns[output_column] = normalized.map(category_frequencies[input_column]).fillna(0.0)
+            return pd.DataFrame(encoded_columns, index=frame.index).astype(float)
+
+        return _FittedDenseFrameGenerator(block_id=self.operator_id, transform_fn=_transform)
+
+
+@dataclass(frozen=True)
+class OrdinalEncodeCategoricalsGenerator:
+    operator_id: str = "ordinal_encode_categoricals"
+    fit_mode: FitMode = "unsupervised"
+    output_kind: OutputKind = "dense_numeric"
+    columns: tuple[str, ...] = ()
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del y
+        transformer = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="most_frequent")),
+                (
+                    "ordinal",
+                    OrdinalEncoder(
+                        handle_unknown="use_encoded_value",
+                        unknown_value=-1,
+                        encoded_missing_value=-1,
+                    ),
+                ),
+            ]
+        )
+        prepared = X.loc[:, list(self.columns)].astype(object)
+        if self.columns:
+            transformer.fit(prepared)
+        output_columns = [f"{self.operator_id}__{column}" for column in self.columns]
+
+        def _transform(frame: pd.DataFrame) -> pd.DataFrame:
+            if not self.columns:
+                return pd.DataFrame(index=frame.index)
+            transformed = transformer.transform(frame.loc[:, list(self.columns)].astype(object))
+            return pd.DataFrame(transformed, index=frame.index, columns=output_columns)
+
+        return _FittedDenseFrameGenerator(block_id=self.operator_id, transform_fn=_transform)
+
+
+@dataclass(frozen=True)
+class OneHotLowCardinalityCategoricalsGenerator:
+    operator_id: str = "onehot_encode_low_cardinality_categoricals"
+    fit_mode: FitMode = "unsupervised"
+    output_kind: OutputKind = "sparse_numeric"
+    columns: tuple[str, ...] = ()
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del y
+        transformer = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="most_frequent")),
+                ("onehot", OneHotEncoder(handle_unknown="ignore", sparse_output=True)),
+            ]
+        )
+        prepared = X.loc[:, list(self.columns)].astype(object)
+        feature_names: tuple[str, ...] = ()
+        if self.columns:
+            transformer.fit(prepared)
+            onehot = transformer.named_steps["onehot"]
+            feature_names = tuple(
+                f"{self.operator_id}__{feature_name}"
+                for feature_name in onehot.get_feature_names_out(list(self.columns))
+            )
+        return _FittedSparseGenerator(
+            block_id=self.operator_id,
+            transformer=transformer,
+            columns=self.columns,
+            feature_names=feature_names,
+        )
+
+
+@dataclass(frozen=True)
+class RowMissingCountGenerator:
+    operator_id: str = "row_missing_count"
+    fit_mode: FitMode = "stateless"
+    output_kind: OutputKind = "dense_numeric"
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator:
+        del X, y
+
+        def _transform(frame: pd.DataFrame) -> pd.DataFrame:
+            return pd.DataFrame(
+                {f"{self.operator_id}__value": frame.isna().sum(axis=1).astype(float)},
+                index=frame.index,
+            )
+
+        return _FittedDenseFrameGenerator(block_id=self.operator_id, transform_fn=_transform)
+
+
+@dataclass(frozen=True)
+class HighCorrelationPruner:
+    pruner_id: str = "high_correlation_prune"
+    fit_mode: FitMode = "unsupervised"
+    threshold: float = 0.98
+
+    def fit(self, bundle: FeatureBundle, y: pd.Series | None) -> FittedFeaturePruner:
+        del y
+        dense_frame = bundle.dense_frame()
+        if dense_frame.empty or dense_frame.shape[1] < 2:
+            return _FittedHighCorrelationPruner(dropped_columns=frozenset())
+
+        correlation_frame = dense_frame.corr().abs()
+        upper_triangle = correlation_frame.where(
+            np.triu(np.ones(correlation_frame.shape), k=1).astype(bool)
+        )
+        dropped_columns = frozenset(
+            column for column in upper_triangle.columns if (upper_triangle[column] > self.threshold).any()
+        )
+        return _FittedHighCorrelationPruner(dropped_columns=dropped_columns)
+
+
+def _select_low_cardinality_categoricals(
+    X: pd.DataFrame,
+    columns: list[str],
+    max_cardinality: int,
+) -> tuple[str, ...]:
+    selected_columns = []
+    for column in columns:
+        unique_count = int(X[column].nunique(dropna=True))
+        if unique_count <= max_cardinality:
+            selected_columns.append(column)
+    return tuple(selected_columns)
+
+
+def build_feature_generator(
+    component_id: str,
+    params: dict[str, object],
+    feature_schema: ResolvedFeatureSchema,
+    X_sample: pd.DataFrame,
+) -> FeatureGenerator:
+    if component_id == "native_numeric":
+        _validate_no_unknown_params("operator", component_id, params, set())
+        return NativeNumericGenerator(columns=tuple(feature_schema.numeric_columns))
+
+    if component_id == "native_categorical":
+        _validate_no_unknown_params("operator", component_id, params, {"missing_value"})
+        missing_value = str(params.get("missing_value", "__missing__"))
+        return NativeCategoricalGenerator(
+            columns=tuple(feature_schema.categorical_columns),
+            missing_value=missing_value,
+        )
+
+    if component_id == "standardize_numeric":
+        _validate_no_unknown_params("operator", component_id, params, set())
+        return StandardizeNumericGenerator(columns=tuple(feature_schema.numeric_columns))
+
+    if component_id == "frequency_encode_categoricals":
+        _validate_no_unknown_params("operator", component_id, params, {"missing_value"})
+        missing_value = str(params.get("missing_value", "__missing__"))
+        return FrequencyEncodeCategoricalsGenerator(
+            columns=tuple(feature_schema.categorical_columns),
+            missing_value=missing_value,
+        )
+
+    if component_id == "ordinal_encode_categoricals":
+        _validate_no_unknown_params("operator", component_id, params, set())
+        return OrdinalEncodeCategoricalsGenerator(columns=tuple(feature_schema.categorical_columns))
+
+    if component_id == "onehot_encode_low_cardinality_categoricals":
+        _validate_no_unknown_params("operator", component_id, params, {"max_cardinality"})
+        max_cardinality = int(params.get("max_cardinality", 16))
+        if max_cardinality < 1:
+            raise ValueError("operator 'onehot_encode_low_cardinality_categoricals' requires max_cardinality >= 1.")
+        eligible_columns = _select_low_cardinality_categoricals(
+            X=X_sample,
+            columns=feature_schema.categorical_columns,
+            max_cardinality=max_cardinality,
+        )
+        return OneHotLowCardinalityCategoricalsGenerator(columns=eligible_columns)
+
+    if component_id == "row_missing_count":
+        _validate_no_unknown_params("operator", component_id, params, set())
+        return RowMissingCountGenerator()
+
+    raise ValueError(f"Unsupported operator id '{component_id}'.")
+
+
+def build_feature_pruner(component_id: str, params: dict[str, object]) -> FeaturePruner:
+    if component_id == "high_correlation_prune":
+        _validate_no_unknown_params("pruner", component_id, params, {"threshold"})
+        threshold = float(params.get("threshold", 0.98))
+        if threshold <= 0.0 or threshold > 1.0:
+            raise ValueError("pruner 'high_correlation_prune' requires threshold in (0.0, 1.0].")
+        return HighCorrelationPruner(threshold=threshold)
+
+    raise ValueError(f"Unsupported pruner id '{component_id}'.")
+
+
+def validate_component_params(component_id: str, params: dict[str, object], component_kind: str) -> None:
+    if component_kind == "operator":
+        if component_id in {"native_numeric", "standardize_numeric", "ordinal_encode_categoricals", "row_missing_count"}:
+            _validate_no_unknown_params(component_kind, component_id, params, set())
+            return
+        if component_id in {"native_categorical", "frequency_encode_categoricals"}:
+            _validate_no_unknown_params(component_kind, component_id, params, {"missing_value"})
+            return
+        if component_id == "onehot_encode_low_cardinality_categoricals":
+            _validate_no_unknown_params(component_kind, component_id, params, {"max_cardinality"})
+            max_cardinality = int(params.get("max_cardinality", 16))
+            if max_cardinality < 1:
+                raise ValueError(
+                    "operator 'onehot_encode_low_cardinality_categoricals' requires max_cardinality >= 1."
+                )
+            return
+    if component_kind == "pruner":
+        if component_id == "high_correlation_prune":
+            _validate_no_unknown_params(component_kind, component_id, params, {"threshold"})
+            threshold = float(params.get("threshold", 0.98))
+            if threshold <= 0.0 or threshold > 1.0:
+                raise ValueError("pruner 'high_correlation_prune' requires threshold in (0.0, 1.0].")
+            return
+    raise ValueError(f"Unsupported {component_kind} id '{component_id}'.")
+
+
+SUPPORTED_OPERATOR_IDS = frozenset(
+    {
+        "native_numeric",
+        "native_categorical",
+        "standardize_numeric",
+        "frequency_encode_categoricals",
+        "ordinal_encode_categoricals",
+        "onehot_encode_low_cardinality_categoricals",
+        "row_missing_count",
+    }
+)
+
+SUPPORTED_PRUNER_IDS = frozenset({"high_correlation_prune"})

--- a/src/tabular_shenanigans/representations/types.py
+++ b/src/tabular_shenanigans/representations/types.py
@@ -4,37 +4,138 @@ from dataclasses import dataclass
 from typing import Literal, Protocol
 
 import pandas as pd
+from scipy import sparse
 
 FitMode = Literal["stateless", "unsupervised", "supervised"]
-OutputContract = Literal["native_frame", "dense_array", "sparse_csr"]
-
-
-class FittedStep(Protocol):
-    def transform(self, X: pd.DataFrame) -> pd.DataFrame: ...
-
-
-class RepresentationStep(Protocol):
-    step_id: str
-    fit_mode: FitMode
-
-    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedStep: ...
-
-
-class FittedOutputAdapter(Protocol):
-    def transform(self, X: pd.DataFrame) -> object: ...
-
-
-class OutputAdapter(Protocol):
-    output_contract: OutputContract
-
-    def fit(self, X: pd.DataFrame) -> FittedOutputAdapter: ...
+OutputKind = Literal["dense_numeric", "sparse_numeric", "native_tabular"]
+MatrixOutputKind = Literal["dense_array", "sparse_csr", "native_frame"]
 
 
 @dataclass(frozen=True)
-class RepresentationDefinition:
+class RepresentationComponentSpec:
+    component_id: str
+    params: dict[str, object]
+
+
+@dataclass(frozen=True)
+class RepresentationSpec:
     representation_id: str
-    representation_name: str
-    steps: tuple[RepresentationStep, ...]
-    output_adapter: OutputAdapter
-    numeric_preprocessor_id: str
-    categorical_preprocessor_id: str
+    operators: tuple[RepresentationComponentSpec, ...]
+    pruners: tuple[RepresentationComponentSpec, ...]
+    fingerprint_payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class FeatureBlock:
+    block_id: str
+    output_kind: OutputKind
+    values: pd.DataFrame | sparse.csr_matrix
+    feature_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MaterializedRepresentation:
+    matrix_output_kind: MatrixOutputKind
+    values: object
+    preprocessing_backend: str
+
+
+@dataclass(frozen=True)
+class RepresentationContract:
+    representation_id: str
+    output_kinds: frozenset[OutputKind]
+    has_dense_numeric: bool
+    has_sparse_numeric: bool
+    has_native_tabular: bool
+    has_native_categorical: bool
+    has_native_numeric: bool
+    matrix_output_kind: MatrixOutputKind
+    routing_numeric_preprocessor: str
+    routing_categorical_preprocessor: str
+
+
+class FittedFeatureGenerator(Protocol):
+    block_id: str
+    output_kind: OutputKind
+
+    def transform(self, X: pd.DataFrame) -> FeatureBlock: ...
+
+
+class FeatureGenerator(Protocol):
+    operator_id: str
+    fit_mode: FitMode
+    output_kind: OutputKind
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | None) -> FittedFeatureGenerator: ...
+
+
+class FittedFeaturePruner(Protocol):
+    def transform(self, bundle: "FeatureBundle") -> "FeatureBundle": ...
+
+
+class FeaturePruner(Protocol):
+    pruner_id: str
+    fit_mode: FitMode
+
+    def fit(self, bundle: "FeatureBundle", y: pd.Series | None) -> FittedFeaturePruner: ...
+
+
+@dataclass(frozen=True)
+class FeatureBundle:
+    blocks: tuple[FeatureBlock, ...]
+
+    @property
+    def dense_blocks(self) -> tuple[FeatureBlock, ...]:
+        return tuple(block for block in self.blocks if block.output_kind == "dense_numeric")
+
+    @property
+    def sparse_blocks(self) -> tuple[FeatureBlock, ...]:
+        return tuple(block for block in self.blocks if block.output_kind == "sparse_numeric")
+
+    @property
+    def native_blocks(self) -> tuple[FeatureBlock, ...]:
+        return tuple(block for block in self.blocks if block.output_kind == "native_tabular")
+
+    def dense_frame(self) -> pd.DataFrame:
+        frames = [block.values for block in self.dense_blocks if isinstance(block.values, pd.DataFrame)]
+        if not frames:
+            return pd.DataFrame()
+        return pd.concat(frames, axis=1)
+
+    def native_frame(self) -> pd.DataFrame:
+        frames = [block.values for block in self.native_blocks if isinstance(block.values, pd.DataFrame)]
+        if not frames:
+            return pd.DataFrame()
+        return pd.concat(frames, axis=1)
+
+    def sparse_matrix(self) -> sparse.csr_matrix | None:
+        matrices = [block.values for block in self.sparse_blocks if sparse.issparse(block.values)]
+        if not matrices:
+            return None
+        if len(matrices) == 1:
+            return sparse.csr_matrix(matrices[0])
+        return sparse.hstack(matrices, format="csr")
+
+    def drop_dense_columns(self, column_names: set[str]) -> "FeatureBundle":
+        if not column_names:
+            return self
+
+        next_blocks: list[FeatureBlock] = []
+        for block in self.blocks:
+            if block.output_kind != "dense_numeric" or not isinstance(block.values, pd.DataFrame):
+                next_blocks.append(block)
+                continue
+
+            kept_columns = [column for column in block.values.columns if column not in column_names]
+            if not kept_columns:
+                continue
+            next_blocks.append(
+                FeatureBlock(
+                    block_id=block.block_id,
+                    output_kind=block.output_kind,
+                    values=block.values.loc[:, kept_columns],
+                    feature_names=tuple(kept_columns),
+                )
+            )
+
+        return FeatureBundle(blocks=tuple(next_blocks))

--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -79,6 +79,7 @@ def _build_config_snapshot(
     )
     config_snapshot["resolved_model_registry_key"] = model_spec.model_registry_key
     config_snapshot["resolved_representation_id"] = candidate.representation_id
+    config_snapshot["resolved_representation"] = candidate.representation.to_payload()
     if model_spec.parameter_overrides:
         config_snapshot["resolved_model_parameter_overrides"] = model_spec.parameter_overrides
     if tuning_provenance is not None:
@@ -124,6 +125,7 @@ def _build_candidate_manifest(
         "mlflow_run_id": mlflow_run_id,
         "model_family": candidate.model_family,
         "representation_id": candidate.representation_id,
+        "representation": candidate.representation.to_payload(),
         "feature_columns": training_context.x_train_features.columns.tolist(),
         "preprocessing_backend": training_context.preprocessing_backend,
         "model_registry_key": model_result.model_registry_key,

--- a/src/tabular_shenanigans/tune.py
+++ b/src/tabular_shenanigans/tune.py
@@ -47,6 +47,7 @@ def _build_optimization_config_snapshot(
     )
     config_snapshot["resolved_model_registry_key"] = tuning_model_spec.model_registry_key
     config_snapshot["resolved_representation_id"] = training_context.representation_id
+    config_snapshot["resolved_representation"] = config.experiment.candidate.representation.to_payload()
     return config_snapshot
 
 


### PR DESCRIPTION
## Summary
- replace registered representation ids with explicit operator/pruner representation config
- compile configured operators into a feature bundle with fail-fast compatibility checks
- update bootstrap/config/docs/examples for the new representation workflow

## Verification
- compileall over src/tabular_shenanigans with PYTHONPYCACHEPREFIX=/tmp/pythoncache
- repo-environment config loading smoke test for both example configs
- synthetic sparse/native representation fit-transform smoke test

Closes #266
