### PR TITLE
Replace screening cartesian-product config with explicit candidates

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -86,7 +86,7 @@ Optional top-level section: `screening`.
 
 `train` drains `experiment.candidates` in order unless narrowed with `--candidate-id` or `--index`. `submit --index <n>` uses a 1-based index into this list.
 
-`screening` evaluates the valid cross-product of `screening.representations` and `screening.model_families`, then prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
+`screening` evaluates the explicit list of `screening.candidates`, then prints a copy/paste-ready YAML snippet for the top `screening.promote_top_k` candidates to paste into `experiment.candidates`.
 
 #### Candidate Shapes
 
@@ -121,13 +121,12 @@ Hard-invalid: representations with `native_categorical` and any `model_family` o
 
 | Key | Required | Notes |
 | --- | --- | --- |
-| `representations` | yes | explicit representation specs; screening expands these against `model_families` |
-| `model_families` | yes | model families to screen against `representations` |
-| `optimization` | no | optional shared tuning budget applied to each valid screening candidate |
+| `candidates` | yes | explicit list of `(model_family, representation)` pairs to screen |
+| `optimization` | no | optional shared tuning budget applied to all candidates; per-candidate `optimization` overrides this |
 | `cv.n_splits` | no | defaults to `2` |
 | `cv.shuffle` | no | defaults to `true` |
 | `cv.random_state` | no | defaults to `42` |
-| `promote_top_k` | no | defaults to `3`; must be `<=` the number of valid cross-product pairs |
+| `promote_top_k` | no | defaults to `3`; must be `<=` the number of configured candidates |
 
 ## Commands
 

--- a/config.binary.example.yaml
+++ b/config.binary.example.yaml
@@ -81,30 +81,44 @@ experiment:
     #     - 0.5
     #     - 0.5
 
-# Optional screening stage — evaluates the cross-product of representations x model_families
+# Optional screening stage — runs explicit (model_family, representation) pairs
 # with a cheap reduced-fold CV, then prints a promotion snippet for the top-k candidates.
 # screening:
-#   representations:
-#     - operators:
-#         - id: standardize_numeric
-#         - id: onehot_encode_low_cardinality_categoricals
-#           max_cardinality: 20
-#     - operators:
-#         - id: native_numeric
-#         - id: ordinal_encode_categoricals
-#     - operators:
-#         - id: native_numeric
-#         - id: frequency_encode_categoricals
-#   model_families:
-#     - lightgbm
-#     - xgboost
-#     - logistic_regression
+#   candidates:
+#     - candidate_type: model
+#       model_family: lightgbm
+#       representation:
+#         operators:
+#           - id: robust_scale_numeric
+#           - id: ordinal_encode_categoricals
+#         pruners: []
+#     - candidate_type: model
+#       model_family: xgboost
+#       representation:
+#         operators:
+#           - id: robust_scale_numeric
+#           - id: ordinal_encode_categoricals
+#         pruners: []
+#     - candidate_type: model
+#       model_family: logistic_regression
+#       representation:
+#         operators:
+#           - id: standardize_numeric
+#           - id: onehot_encode_low_cardinality_categoricals
+#         pruners: []
+#     - candidate_type: model
+#       model_family: catboost
+#       representation:
+#         operators:
+#           - id: native_numeric
+#           - id: native_categorical
+#         pruners: []
 #   cv:
 #     n_splits: 2
 #     shuffle: true
 #     random_state: 42
 #   promote_top_k: 3
-#   # Optional tuning budget for screening:
+#   # Optional shared tuning budget applied to all candidates:
 #   # optimization:
 #   #   method: optuna
 #   #   n_trials: 10

--- a/config.regression.example.yaml
+++ b/config.regression.example.yaml
@@ -69,30 +69,37 @@ experiment:
     #     - 0.5
     #     - 0.5
 
-# Optional screening stage — evaluates the cross-product of representations x model_families
+# Optional screening stage — runs explicit (model_family, representation) pairs
 # with a cheap reduced-fold CV, then prints a promotion snippet for the top-k candidates.
 # screening:
-#   representations:
-#     - operators:
-#         - id: standardize_numeric
-#         - id: onehot_encode_low_cardinality_categoricals
-#           max_cardinality: 20
-#     - operators:
-#         - id: native_numeric
-#         - id: ordinal_encode_categoricals
-#     - operators:
-#         - id: native_numeric
-#         - id: frequency_encode_categoricals
-#   model_families:
-#     - lightgbm
-#     - xgboost
-#     - ridge
+#   candidates:
+#     - candidate_type: model
+#       model_family: lightgbm
+#       representation:
+#         operators:
+#           - id: robust_scale_numeric
+#           - id: ordinal_encode_categoricals
+#         pruners: []
+#     - candidate_type: model
+#       model_family: xgboost
+#       representation:
+#         operators:
+#           - id: robust_scale_numeric
+#           - id: ordinal_encode_categoricals
+#         pruners: []
+#     - candidate_type: model
+#       model_family: ridge
+#       representation:
+#         operators:
+#           - id: standardize_numeric
+#           - id: onehot_encode_low_cardinality_categoricals
+#         pruners: []
 #   cv:
 #     n_splits: 2
 #     shuffle: true
 #     random_state: 42
 #   promote_top_k: 3
-#   # Optional tuning budget for screening:
+#   # Optional shared tuning budget applied to all candidates:
 #   # optimization:
 #   #   method: optuna
 #   #   n_trials: 10

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -7,7 +7,7 @@ For setup, commands, and config reference, see [USAGE.md](/USAGE.md).
 ## System Flow
 
 1. Enter the bootstrap entrypoint before importing runtime modules that depend on `pandas` or `sklearn`.
-2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths. Screening config uses `screening.representations` x `screening.model_families` cross-product expansion; incompatible pairs are skipped with a warning at config validation time.
+2. Read `experiment.runtime.compute_target` and the optional advanced `experiment.runtime.gpu_backend` override from repository-root `config.yaml`, resolve hardware capability separately from tuple routing, inspect the selected train or screening candidates before importing the runtime stack, install RAPIDS hooks only when the selected batch resolves entirely to `gpu_patch`, and route GPU-capable booster families onto their GPU parameter paths. Screening config uses explicit `screening.candidates`; each candidate is validated for compatibility and fails hard if incompatible.
 3. Load and validate the repository-root `config.yaml`.
 4. Normalize and validate `competition.task_type`, `competition.primary_metric`, and the full `experiment.candidates` contract.
 5. Resolve the MLflow tracking URI from `experiment.tracking.tracking_uri`.

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -214,31 +214,32 @@ def load_bootstrap_runtime_config(path: str | Path = "config.yaml") -> Bootstrap
 
     screening_candidate_list: list[BootstrapCandidateRuntimeConfig] = []
     if screening is not None:
-        screening_representations = screening.get("representations")
-        screening_model_families = screening.get("model_families")
-        if isinstance(screening_representations, list) and isinstance(screening_model_families, list):
-            for representation in screening_representations:
-                for model_family in screening_model_families:
-                    normalized_representation = representation if isinstance(representation, dict) else None
-                    (
-                        representation_id,
-                        routing_numeric_preprocessor,
-                        routing_categorical_preprocessor,
-                        has_native_categorical,
-                        has_sparse_numeric,
-                    ) = _build_bootstrap_representation_summary(normalized_representation)
-                    screening_candidate_list.append(
-                        BootstrapCandidateRuntimeConfig(
-                            candidate_type="model",
-                            model_family=model_family if isinstance(model_family, str) else None,
-                            representation=normalized_representation,
-                            representation_id=representation_id,
-                            routing_numeric_preprocessor=routing_numeric_preprocessor,
-                            routing_categorical_preprocessor=routing_categorical_preprocessor,
-                            has_native_categorical=has_native_categorical,
-                            has_sparse_numeric=has_sparse_numeric,
-                        )
+        screening_candidates = screening.get("candidates")
+        if isinstance(screening_candidates, list):
+            for candidate in screening_candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                model_family = candidate.get("model_family")
+                representation = candidate.get("representation") if isinstance(candidate.get("representation"), dict) else None
+                (
+                    representation_id,
+                    routing_numeric_preprocessor,
+                    routing_categorical_preprocessor,
+                    has_native_categorical,
+                    has_sparse_numeric,
+                ) = _build_bootstrap_representation_summary(representation)
+                screening_candidate_list.append(
+                    BootstrapCandidateRuntimeConfig(
+                        candidate_type="model",
+                        model_family=model_family if isinstance(model_family, str) else None,
+                        representation=representation,
+                        representation_id=representation_id,
+                        routing_numeric_preprocessor=routing_numeric_preprocessor,
+                        routing_categorical_preprocessor=routing_categorical_preprocessor,
+                        has_native_categorical=has_native_categorical,
+                        has_sparse_numeric=has_sparse_numeric,
                     )
+                )
 
     return BootstrapRuntimeConfig(
         compute_target=_validate_compute_target(None if runtime is None else runtime.get("compute_target")),

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -105,31 +105,28 @@ class RepresentationConfig(BaseModel):
 class ScreeningConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    representations: list[RepresentationConfig] = Field(min_length=1)
-    model_families: list[str] = Field(min_length=1)
+    candidates: list["ModelCandidateConfig"] = Field(min_length=1)
     optimization: "CandidateOptimizationConfig | None" = None
     cv: CompetitionCvConfig = Field(
         default_factory=lambda: CompetitionCvConfig(n_splits=2, shuffle=True, random_state=42)
     )
     promote_top_k: int = Field(default=3, ge=1)
-    candidates: list["ModelCandidateConfig"] = Field(default_factory=list, exclude=True)
     active_candidate_index: int = Field(default=0, exclude=True, repr=False, ge=0)
 
     @model_validator(mode="before")
     @classmethod
-    def reject_user_provided_candidates(cls, values: object) -> object:
+    def reject_legacy_fields(cls, values: object) -> object:
         if not isinstance(values, dict):
             return values
-        if "candidates" in values:
+        if "representations" in values or "model_families" in values:
             raise ValueError(
-                "screening.candidates is not a user-facing field. "
-                "Use screening.representations and screening.model_families instead. "
-                "The candidates list is built automatically from the cross-product."
+                "screening.representations and screening.model_families are no longer supported. "
+                "Use screening.candidates with explicit (model_family, representation) pairs instead."
             )
         if "representation_ids" in values:
             raise ValueError(
                 "screening.representation_ids is no longer supported. "
-                "Use screening.representations."
+                "Use screening.candidates."
             )
         return values
 
@@ -361,52 +358,40 @@ class AppConfig(BaseModel):
         if self.screening is not None:
             screening = self.screening
 
-            resolved_representations = []
-            for representation in screening.representations:
-                representation_spec = representation.to_runtime_spec()
-                representation_contract = build_representation_contract(representation_spec)
-                resolved_representations.append((representation, representation_spec, representation_contract))
-
-            resolved_model_families: list[tuple[str, str]] = []
-            for raw_model_family in screening.model_families:
-                resolved_model_id = resolve_candidate_model_id(
-                    task_type=competition.task_type,
-                    model_family=raw_model_family,
-                )
-                resolved_model_families.append((raw_model_family, resolved_model_id))
-
-            expanded_candidates: list[ModelCandidateConfig] = []
-            for representation, representation_spec, representation_contract in resolved_representations:
-                for model_family, model_registry_key in resolved_model_families:
-                    try:
-                        validate_model_representation_compatibility(
-                            task_type=competition.task_type,
-                            model_id=model_registry_key,
-                            representation_contract=representation_contract,
-                        )
-                    except ValueError as exc:
-                        print(
-                            f"Screening: skipping incompatible pair "
-                            f"(model_family={model_family!r}, representation_id={representation_spec.representation_id!r}): {exc}"
-                        )
-                        continue
-                    expanded_candidates.append(
-                        ModelCandidateConfig(
-                            representation=representation.model_copy(deep=True),
-                            model_family=model_family,
-                            optimization=screening.optimization.model_copy(deep=True)
-                            if screening.optimization is not None
-                            else None,
-                        )
+            if screening.optimization is not None:
+                optimization = screening.optimization
+                if optimization.n_trials is None and optimization.timeout_seconds is None:
+                    raise ValueError(
+                        "At least one screening.optimization stopping condition is required. "
+                        "Set screening.optimization.n_trials or screening.optimization.timeout_seconds."
                     )
 
-            if not expanded_candidates:
-                raise ValueError(
-                    "screening: no valid (model_family, representation) pairs survived "
-                    "compatibility checks. All cross-product pairs were incompatible."
-                )
-
-            screening.candidates = expanded_candidates
+            for candidate_index, candidate in enumerate(screening.candidates, start=1):
+                try:
+                    representation_spec = candidate.representation.to_runtime_spec()
+                    representation_contract = build_representation_contract(representation_spec)
+                    model_registry_key = resolve_candidate_model_id(
+                        task_type=competition.task_type,
+                        model_family=candidate.model_family,
+                    )
+                    validate_model_representation_compatibility(
+                        task_type=competition.task_type,
+                        model_id=model_registry_key,
+                        representation_contract=representation_contract,
+                    )
+                    effective_optimization = candidate.optimization or screening.optimization
+                    if effective_optimization is not None:
+                        if not is_model_tunable(competition.task_type, model_registry_key):
+                            supported_tunable_model_families = get_tunable_model_ids(competition.task_type)
+                            raise ValueError(
+                                f"model_family '{candidate.model_family}' does not support "
+                                f"optimization for task_type '{competition.task_type}'. "
+                                f"Supported tunable model families: {supported_tunable_model_families}"
+                            )
+                        if candidate.optimization is None:
+                            candidate.optimization = screening.optimization.model_copy(deep=True)
+                except ValueError as exc:
+                    raise ValueError(f"screening.candidates[{candidate_index}] is invalid: {exc}") from exc
 
             if screening.active_candidate_index >= len(screening.candidates):
                 raise ValueError(
@@ -440,27 +425,6 @@ class AppConfig(BaseModel):
                     "Configured screening candidates must derive distinct candidate_id values. "
                     f"Duplicates: {duplicate_summary}"
                 )
-
-            if screening.optimization is not None:
-                optimization = screening.optimization
-                if optimization.n_trials is None and optimization.timeout_seconds is None:
-                    raise ValueError(
-                        "At least one screening.optimization stopping condition is required. "
-                        "Set screening.optimization.n_trials or screening.optimization.timeout_seconds."
-                    )
-                for model_family, model_registry_key in resolved_model_families:
-                    has_expanded_candidate = any(
-                        c.model_family == model_family for c in expanded_candidates
-                    )
-                    if not has_expanded_candidate:
-                        continue
-                    if not is_model_tunable(competition.task_type, model_registry_key):
-                        supported_tunable_model_families = get_tunable_model_ids(competition.task_type)
-                        raise ValueError(
-                            f"Configured screening model_family '{model_family}' does not support "
-                            f"optimization for task_type '{competition.task_type}'. Supported tunable "
-                            f"model families: {supported_tunable_model_families}"
-                        )
         return self
 
     @property


### PR DESCRIPTION
## Summary

- Removes `screening.representations` × `screening.model_families` cross-product expansion
- `screening.candidates` is now the only supported input shape, using the same explicit list format as `experiment.candidates`
- Incompatible pairs now fail hard at config validation instead of silently skipping with a warning
- `screening.optimization` remains a shared setting and propagates to candidates that don't override it
- `bootstrap_config.py` updated to read from `screening.candidates` directly
- Example configs and docs updated to the new shape
- `config.yaml` converted to 47 explicit GPU step 2 candidates (7 GPU models × 8 representations minus incompatible pairs)

## Test plan

- [ ] Old config with `representations`/`model_families` is rejected with a clear error message
- [ ] Valid explicit `screening.candidates` load correctly and pass compatibility validation
- [ ] Incompatible pair (e.g. `naive_bayes` + `native_categorical`) fails with a clear per-candidate error
- [ ] `screening.optimization` propagates to all candidates that lack their own
- [ ] `bootstrap_config.py` reads 47 candidates correctly from the new config shape
- [ ] Run `uv run python main.py screening` end-to-end on GPU host with the new config

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)