### PR TITLE
Fix bootstrap GPU routing: robust_scale_numeric unmapped and NATIVE_GPU context not exported

### DIFF
--- a/src/tabular_shenanigans/bootstrap.py
+++ b/src/tabular_shenanigans/bootstrap.py
@@ -110,6 +110,7 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
     from tabular_shenanigans.execution_routing import resolve_model_candidate_runtime_execution
     from tabular_shenanigans.models import resolve_candidate_model_id, validate_model_output_compatibility
     from tabular_shenanigans.runtime_execution import (
+        NATIVE_GPU_BACKEND,
         PATCH_GPU_BACKEND,
         activate_runtime_acceleration,
         detect_runtime_capabilities,
@@ -170,6 +171,11 @@ def _apply_runtime_bootstrap(argv: list[str] | None) -> None:
     if resolved_backends == {PATCH_GPU_BACKEND}:
         runtime_context = activate_runtime_acceleration(selected_model_contexts[0])
         export_runtime_execution_context(runtime_context)
+        return
+
+    if NATIVE_GPU_BACKEND in resolved_backends:
+        gpu_context = next(ctx for ctx in selected_model_contexts if ctx.resolved_gpu_backend == NATIVE_GPU_BACKEND)
+        export_runtime_execution_context(gpu_context)
         return
 
 

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -66,11 +66,11 @@ def _build_bootstrap_representation_summary(
     )
 
     routing_numeric_preprocessor = "custom"
-    if operator_ids == {"standardize_numeric"}:
+    if "standardize_numeric" in operator_ids and "native_numeric" not in operator_ids:
         routing_numeric_preprocessor = "standardize"
-    elif operator_ids == {"native_numeric"}:
+    elif "native_numeric" in operator_ids:
         routing_numeric_preprocessor = "median"
-    elif "standardize_numeric" in operator_ids and "native_numeric" not in operator_ids:
+    elif "robust_scale_numeric" in operator_ids:
         routing_numeric_preprocessor = "standardize"
 
     routing_categorical_preprocessor = "custom"


### PR DESCRIPTION
Closes #284

## Summary

- **`bootstrap_config.py`**: Consolidates and extends `routing_numeric_preprocessor` logic in `_build_bootstrap_representation_summary()`:
  - Broadens `native_numeric` from strict set equality to membership check — fixes R6 (`{native_numeric, native_categorical}` was resolving to `"custom"`)
  - Adds `elif "robust_scale_numeric" in operator_ids` → `"standardize"` — fixes R2–R8 for all native-GPU model families (xgboost, lightgbm, catboost)

- **`bootstrap.py`**: Adds a NATIVE_GPU export block in `_apply_runtime_bootstrap()` after the existing PATCH block — imports `NATIVE_GPU_BACKEND` and calls `export_runtime_execution_context()` on the first native-GPU context when any resolved backend is native GPU. Handles both pure and mixed CPU+native batches.

## Breaking changes

None. Both changes extend coverage of existing logic; no previously-working routing paths are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)