### PR TITLE
Avoid unnecessary MLflow manifest download during screening (#278)

### DIFF
--- a/src/tabular_shenanigans/train.py
+++ b/src/tabular_shenanigans/train.py
@@ -49,6 +49,16 @@ class OptimizationArtifacts:
     trials_df: pd.DataFrame
 
 
+@dataclass(frozen=True)
+class TrainingWorkflowResult:
+    run_id: str
+    experiment_id: str
+    candidate_id: str
+    run_kind: str
+    metric_mean: float | None = None
+    metric_std: float | None = None
+
+
 def _resolve_training_model_spec(
     config: AppConfig,
     model_spec: TrainingModelSpec | None = None,
@@ -233,7 +243,7 @@ def run_training(
     optimization_artifacts: OptimizationArtifacts | None = None,
     prepared_training_context: PreparedTrainingContext | None = None,
     optimization_config: dict[str, object] | None = None,
-) -> CandidateRunRef:
+) -> TrainingWorkflowResult:
     if not config.is_model_candidate:
         raise ValueError("run_training only supports selected candidate_type=model.")
 
@@ -323,20 +333,34 @@ def run_training(
         fit_wall_seconds=fit_wall_seconds,
         optimization_summary=optimization_summary,
     )
-    return candidate_run
+    cv = model_result.cv_summary
+    return TrainingWorkflowResult(
+        run_id=candidate_run.run_id,
+        experiment_id=candidate_run.experiment_id,
+        candidate_id=candidate_run.candidate_id,
+        run_kind=candidate_run.run_kind,
+        metric_mean=cv.metric_mean,
+        metric_std=cv.metric_std,
+    )
 
 
 def run_training_workflow(
     config: AppConfig,
     dataset_context: CompetitionDatasetContext,
     optimization_override: object | None = None,
-) -> CandidateRunRef:
+) -> TrainingWorkflowResult:
     with use_runtime_execution_context(config.runtime_execution_context):
         competition = config.competition
         if config.is_blend_candidate:
             from tabular_shenanigans.blend import run_blend_training
 
-            return run_blend_training(config=config, dataset_context=dataset_context)
+            blend_run = run_blend_training(config=config, dataset_context=dataset_context)
+            return TrainingWorkflowResult(
+                run_id=blend_run.run_id,
+                experiment_id=blend_run.experiment_id,
+                candidate_id=blend_run.candidate_id,
+                run_kind=blend_run.run_kind,
+            )
 
         candidate = config.experiment.candidate
         candidate_run = create_candidate_run(
@@ -362,7 +386,7 @@ def run_training_workflow(
                     )
                     try:
                         if effective_optimization is None:
-                            run_training(
+                            training_result = run_training(
                                 config=config,
                                 dataset_context=dataset_context,
                                 candidate_run=candidate_run,
@@ -383,7 +407,7 @@ def run_training_workflow(
                                 prepared_training_context=prepared_training_context,
                                 optimization_override=effective_optimization,
                             )
-                            run_training(
+                            training_result = run_training(
                                 config=config,
                                 dataset_context=dataset_context,
                                 candidate_run=candidate_run,
@@ -412,7 +436,7 @@ def run_training_workflow(
                 )
                 log_uploaded = True
                 run_status = "FINISHED"
-                return candidate_run
+                return training_result
             except Exception:
                 if log_path.exists() and not log_uploaded:
                     upload_run_log(

--- a/src/tabular_shenanigans/training_orchestration.py
+++ b/src/tabular_shenanigans/training_orchestration.py
@@ -1,13 +1,11 @@
-import tempfile
 import time
 import traceback
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
 
 from tabular_shenanigans.config import AppConfig, BlendCandidateConfig, ModelCandidateConfig
 from tabular_shenanigans.data import CompetitionDatasetContext
-from tabular_shenanigans.mlflow_store import candidate_run_exists, download_candidate_manifest
+from tabular_shenanigans.mlflow_store import candidate_run_exists
 from tabular_shenanigans.train import run_training_workflow
 
 
@@ -47,13 +45,6 @@ class TrainingBatchSummary:
     @property
     def failed_count(self) -> int:
         return sum(result.status == "failed" for result in self.results)
-
-
-def _metric_from_manifest(manifest: dict[str, object]) -> tuple[float, float]:
-    cv_summary = manifest.get("cv_summary")
-    if not isinstance(cv_summary, dict):
-        raise ValueError("Candidate manifest cv_summary must be a mapping.")
-    return float(cv_summary["metric_mean"]), float(cv_summary["metric_std"])
 
 
 def run_training_batch(
@@ -168,22 +159,8 @@ def run_training_batch(
 
         wall_seconds = time.perf_counter() - started
 
-        metric_mean = None
-        metric_std = None
-        if screening:
-            try:
-                with tempfile.TemporaryDirectory(prefix="tabular-shenanigans-screening-manifest-") as temp_dir:
-                    manifest = download_candidate_manifest(
-                        config=candidate_config,
-                        run_id=candidate_run.run_id,
-                        destination_dir=Path(temp_dir),
-                    )
-                metric_mean, metric_std = _metric_from_manifest(manifest)
-            except Exception as exc:
-                print(
-                    f"Warning: failed to extract screening metrics for "
-                    f"candidate_index={candidate_index + 1}: {exc}"
-                )
+        metric_mean = candidate_run.metric_mean
+        metric_std = candidate_run.metric_std
 
         status = "screened" if screening else "trained"
         completion_line = (


### PR DESCRIPTION
## Summary
- Introduces `TrainingWorkflowResult` dataclass that carries CV metrics (`metric_mean`, `metric_std`) alongside the run reference fields.
- `run_training` and `run_training_workflow` now return `TrainingWorkflowResult` with metrics populated from the local `CvSummary`.
- Removes the manifest download round-trip, `_metric_from_manifest` helper, and unused `tempfile`/`Path`/`download_candidate_manifest` imports from `training_orchestration.py`.

## Test plan
- [ ] Run a screening batch and verify `metric_mean`/`metric_std` appear in the batch summary output
- [ ] Run a normal training batch and verify no regressions

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)