### PR TITLE
Refactor CV fold evaluation flow

### DIFF
--- a/src/tabular_shenanigans/_model_builders.py
+++ b/src/tabular_shenanigans/_model_builders.py
@@ -78,6 +78,43 @@ def resolve_booster_runtime_defaults(model_id: str) -> dict[str, object]:
     return {}
 
 
+def _module_startswith(values: object, prefix: str) -> bool:
+    return type(values).__module__.startswith(prefix)
+
+
+def coerce_xgboost_matrix_input(values: object) -> object:
+    runtime_execution_context = get_runtime_execution_context()
+    if runtime_execution_context.resolved_gpu_backend != NATIVE_GPU_BACKEND:
+        return values
+
+    try:
+        import cudf
+    except ImportError as exc:
+        raise RuntimeError(
+            "XGBoost GPU-native inputs require the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    try:
+        import cupy as cp
+    except ImportError as exc:
+        raise RuntimeError(
+            "XGBoost GPU-native inputs require the optional GPU dependencies. "
+            "Install them with `uv sync --extra boosters --extra gpu`."
+        ) from exc
+
+    if _module_startswith(values, "cudf") or _module_startswith(values, "cupy"):
+        return values
+
+    if isinstance(values, pd.DataFrame):
+        return cudf.from_pandas(values)
+
+    if hasattr(values, "to_pandas"):
+        return cudf.from_pandas(values.to_pandas())
+
+    return cp.asarray(values)
+
+
 def import_cuml_linear_model(
     model_class_name: str,
     *,

--- a/src/tabular_shenanigans/_model_registry.py
+++ b/src/tabular_shenanigans/_model_registry.py
@@ -35,8 +35,10 @@ from tabular_shenanigans._model_builders import (
     build_xgboost_classifier,
     build_xgboost_regressor,
     build_xgboost_tuning_space,
+    coerce_xgboost_matrix_input,
 )
 from tabular_shenanigans._model_types import GpuRoutingRule, ModelDefinition
+from tabular_shenanigans.lightgbm_cuda_backend import coerce_lightgbm_matrix_input
 from tabular_shenanigans.representations.types import RepresentationContract
 from tabular_shenanigans.runtime_execution import (
     NATIVE_GPU_BACKEND,
@@ -134,6 +136,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LGBMRegressor",
             builder=build_lightgbm_regressor,
             tuning_space_builder=build_lightgbm_tuning_space,
+            coerce_input=coerce_lightgbm_matrix_input,
             supports_sparse_preprocessed_input=True,
             gpu_routing_rules=(
                 GpuRoutingRule(gpu_backends=(NATIVE_GPU_BACKEND,)),
@@ -156,6 +159,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="XGBRegressor",
             builder=build_xgboost_regressor,
             tuning_space_builder=build_xgboost_tuning_space,
+            coerce_input=coerce_xgboost_matrix_input,
             supports_sparse_preprocessed_input=True,
             supports_gpu_native_dense_onehot_input=True,
             gpu_routing_rules=(
@@ -247,6 +251,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="LGBMClassifier",
             builder=build_lightgbm_classifier,
             tuning_space_builder=build_lightgbm_tuning_space,
+            coerce_input=coerce_lightgbm_matrix_input,
             supports_sparse_preprocessed_input=True,
             gpu_routing_rules=(
                 GpuRoutingRule(gpu_backends=(NATIVE_GPU_BACKEND,)),
@@ -269,6 +274,7 @@ MODEL_REGISTRY: dict[str, dict[str, ModelDefinition]] = {
             model_name="XGBClassifier",
             builder=build_xgboost_classifier,
             tuning_space_builder=build_xgboost_tuning_space,
+            coerce_input=coerce_xgboost_matrix_input,
             supports_sparse_preprocessed_input=True,
             supports_gpu_native_dense_onehot_input=True,
             gpu_routing_rules=(
@@ -423,5 +429,4 @@ def build_model_fit_kwargs(
     if model_definition.fit_kwargs_builder is None or not uses_native_categorical_preprocessing:
         return {}
     return model_definition.fit_kwargs_builder(x_train_processed, numeric_columns, categorical_columns)
-
 

--- a/src/tabular_shenanigans/_model_types.py
+++ b/src/tabular_shenanigans/_model_types.py
@@ -4,10 +4,16 @@ from typing import Callable
 
 import numpy as np
 import pandas as pd
+from sklearn.base import clone
 
 ModelBuilder = Callable[[int, dict[str, object] | None], tuple[object, dict[str, object]]]
 FitKwargsBuilder = Callable[[object, list[str], list[str]], dict[str, object]]
 TuningSpaceBuilder = Callable[[object], dict[str, object]]
+ModelInputCoercer = Callable[[object], object]
+
+
+def identity_model_input(values: object) -> object:
+    return values
 
 
 @dataclass(frozen=True)
@@ -25,6 +31,7 @@ class ModelDefinition:
     builder: ModelBuilder
     fit_kwargs_builder: FitKwargsBuilder | None = None
     tuning_space_builder: TuningSpaceBuilder | None = None
+    coerce_input: ModelInputCoercer = identity_model_input
     supports_native_categorical_preprocessing: bool = False
     supports_sparse_preprocessed_input: bool = False
     supports_gpu_native_dense_onehot_input: bool = False
@@ -37,6 +44,9 @@ class BinaryLabelEncodingClassifier:
         self.estimator = estimator
         self.classes_: np.ndarray | None = None
         self._class_to_encoded_value: dict[object, int] = {}
+
+    def __sklearn_clone__(self) -> "BinaryLabelEncodingClassifier":
+        return type(self)(clone(self.estimator))
 
     def fit(self, x_train: object, y_train: pd.Series, **fit_kwargs: object) -> "BinaryLabelEncodingClassifier":
         observed_classes = pd.unique(y_train)
@@ -67,6 +77,9 @@ class BinaryLabelEncodingClassifier:
 class SingleTargetRegressionAdapter:
     def __init__(self, estimator: object) -> None:
         self.estimator = estimator
+
+    def __sklearn_clone__(self) -> "SingleTargetRegressionAdapter":
+        return type(self)(clone(self.estimator))
 
     def fit(self, x_train: object, y_train: pd.Series, **fit_kwargs: object) -> "SingleTargetRegressionAdapter":
         self.estimator.fit(x_train, y_train, **fit_kwargs)

--- a/src/tabular_shenanigans/lightgbm_cuda_backend.py
+++ b/src/tabular_shenanigans/lightgbm_cuda_backend.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 import numpy as np
 import pandas as pd
 from scipy import sparse
+from sklearn.base import clone
 
 LIGHTGBM_CUDA_BUILD_DISABLED_FRAGMENT = "CUDA Tree Learner was not enabled in this build."
 
@@ -130,6 +131,12 @@ class RepositoryLightGbmEstimator:
     def __init__(self, estimator: object, *, requires_cuda_build: bool) -> None:
         self.estimator = estimator
         self.requires_cuda_build = requires_cuda_build
+
+    def __sklearn_clone__(self) -> "RepositoryLightGbmEstimator":
+        return type(self)(
+            clone(self.estimator),
+            requires_cuda_build=self.requires_cuda_build,
+        )
 
     def fit(self, x_train: object, y_train: object, **fit_kwargs: object) -> "RepositoryLightGbmEstimator":
         if self.requires_cuda_build:

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -4,14 +4,15 @@ from dataclasses import dataclass, replace
 import numpy as np
 import pandas as pd
 from scipy import sparse
+from sklearn.base import clone
 
 from tabular_shenanigans.candidate_artifacts import build_target_summary
-from tabular_shenanigans.lightgbm_cuda_backend import coerce_lightgbm_matrix_input
 from tabular_shenanigans.competition import ensure_prepared_competition_context
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.cv import is_higher_better, resolve_positive_label, score_predictions
 from tabular_shenanigans.data import CompetitionDatasetContext, get_binary_prediction_kind
 from tabular_shenanigans.models import (
+    ModelDefinition,
     build_model,
     build_model_fit_kwargs,
 )
@@ -23,6 +24,7 @@ from tabular_shenanigans.representations import (
     compile_representation,
     resolve_feature_schema,
 )
+from tabular_shenanigans.runtime_execution import NATIVE_GPU_BACKEND
 
 
 def _module_startswith(values: object, prefix: str) -> bool:
@@ -84,6 +86,52 @@ class ModelCvEvaluation:
 
 
 @dataclass(frozen=True)
+class FoldEvaluationResult:
+    valid_predictions: np.ndarray
+    test_predictions: np.ndarray | None
+    metric_value: float
+    train_rows: int
+    valid_rows: int
+    preprocess_wall_seconds: float
+    fit_wall_seconds: float
+    predict_wall_seconds: float
+    residency_profile: dict[str, object]
+
+    def to_metric_row(self, *, fold_index: int, metric_name: str) -> dict[str, object]:
+        return {
+            "fold": fold_index,
+            "metric_name": metric_name,
+            "metric_value": self.metric_value,
+            "train_rows": self.train_rows,
+            "valid_rows": self.valid_rows,
+        }
+
+
+@dataclass(frozen=True)
+class CvEvaluationResult:
+    cv_evaluation: ModelCvEvaluation
+    runtime_profile: dict[str, object]
+
+
+@dataclass(frozen=True)
+class FullCvEvaluationResult:
+    cv_evaluation: ModelCvEvaluation
+    runtime_profile: dict[str, object]
+    oof_predictions: np.ndarray
+    final_test_predictions: np.ndarray
+    test_prediction_probabilities: np.ndarray | None = None
+
+
+@dataclass(frozen=True)
+class CvFoldLoopResult:
+    model_definition: ModelDefinition
+    model_params: dict[str, object]
+    fold_results: list[FoldEvaluationResult]
+    fold_metrics: list[dict[str, object]]
+    runtime_profile: dict[str, object]
+
+
+@dataclass(frozen=True)
 class PreparedTrainingContext:
     id_column: str
     label_column: str
@@ -101,10 +149,8 @@ class PreparedTrainingContext:
     compiled_representation: CompiledRepresentation
     representation_id: str
     matrix_output_kind: str
-    uses_xgboost_gpu_native_inputs: bool
     preserves_gpu_preprocessed_inputs: bool
     preprocessing_backend: str
-    model_compute_target: str
 
 
 def build_prepared_training_context(
@@ -171,9 +217,9 @@ def build_prepared_training_context(
         x_train_sample=x_train_raw,
         representation_contract=representation_contract,
     )
-    uses_xgboost_gpu_native_inputs = (
+    preserves_gpu_preprocessed_inputs = (
         config.resolved_model_registry_key == "xgboost"
-        and runtime_execution_context.resolved_compute_target == "gpu"
+        and runtime_execution_context.resolved_gpu_backend == NATIVE_GPU_BACKEND
     )
     return PreparedTrainingContext(
         id_column=id_column,
@@ -192,10 +238,8 @@ def build_prepared_training_context(
         compiled_representation=compiled_representation,
         representation_id=representation_id,
         matrix_output_kind=compiled_representation.matrix_output_kind,
-        uses_xgboost_gpu_native_inputs=uses_xgboost_gpu_native_inputs,
-        preserves_gpu_preprocessed_inputs=uses_xgboost_gpu_native_inputs,
+        preserves_gpu_preprocessed_inputs=preserves_gpu_preprocessed_inputs,
         preprocessing_backend=compiled_representation.preprocessing_backend,
-        model_compute_target=runtime_execution_context.resolved_compute_target,
     )
 
 
@@ -221,35 +265,6 @@ def _coerce_processed_matrix(
     if matrix_output_kind == "sparse_csr":
         return sparse.csr_matrix(values)
     return np.asarray(values)
-
-
-def _coerce_xgboost_gpu_input(values: object) -> object:
-    try:
-        import cudf
-    except ImportError as exc:
-        raise RuntimeError(
-            "XGBoost GPU-native inputs require the optional GPU dependencies. "
-            "Install them with `uv sync --extra boosters --extra gpu`."
-        ) from exc
-
-    try:
-        import cupy as cp
-    except ImportError as exc:
-        raise RuntimeError(
-            "XGBoost GPU-native inputs require the optional GPU dependencies. "
-            "Install them with `uv sync --extra boosters --extra gpu`."
-        ) from exc
-
-    if _module_startswith(values, "cudf") or _module_startswith(values, "cupy"):
-        return values
-
-    if isinstance(values, pd.DataFrame):
-        return cudf.from_pandas(values)
-
-    if hasattr(values, "to_pandas"):
-        return cudf.from_pandas(values.to_pandas())
-
-    return cp.asarray(values)
 
 
 def _coerce_prediction_values(values: object) -> np.ndarray:
@@ -315,184 +330,191 @@ def _describe_matrix_residency(values: object) -> dict[str, object]:
     }
 
 
-def _run_cv_evaluation(
-    task_type: str,
-    primary_metric: str,
-    model_spec: TrainingModelSpec,
+def _resolve_processed_feature_columns(
     training_context: PreparedTrainingContext,
-    cv_random_state: int,
-    collect_prediction_artifacts: bool,
-) -> tuple[
-    ModelCvEvaluation,
-    np.ndarray | None,
-    np.ndarray | None,
-    np.ndarray | None,
-    dict[str, object],
-]:
-    model_definition, _, model_params = build_model(
-        task_type,
-        model_spec.model_registry_key,
-        cv_random_state,
-        parameter_overrides=model_spec.parameter_overrides,
-    )
-    resolved_model_registry_key = model_definition.model_id
-    estimator_name = model_definition.model_name
-    representation_id = training_context.representation_id
-    matrix_output_kind = training_context.matrix_output_kind
-    uses_xgboost_gpu_native_inputs = training_context.uses_xgboost_gpu_native_inputs
-    preserves_gpu_preprocessed_inputs = training_context.preserves_gpu_preprocessed_inputs
-    preprocessing_backend = training_context.preprocessing_backend
-    model_compute_target = training_context.model_compute_target
-    compiled_representation = training_context.compiled_representation
+    x_fold_train_processed: object,
+) -> tuple[list[str], list[str]]:
+    if training_context.matrix_output_kind != "native_frame" or not isinstance(x_fold_train_processed, pd.DataFrame):
+        return (
+            training_context.feature_schema.numeric_columns,
+            training_context.feature_schema.categorical_columns,
+        )
 
-    oof_predictions = (
-        np.zeros(training_context.x_train_features.shape[0], dtype=float)
-        if collect_prediction_artifacts
-        else None
-    )
-    test_predictions_per_fold = [] if collect_prediction_artifacts else None
-    fold_metrics: list[dict[str, object]] = []
-    binary_prediction_kind = None
+    processed_categorical_columns = [
+        column_name
+        for column_name in x_fold_train_processed.columns
+        if x_fold_train_processed[column_name].dtype == object
+        or pd.api.types.is_string_dtype(x_fold_train_processed[column_name])
+    ]
+    processed_numeric_columns = [
+        column_name
+        for column_name in x_fold_train_processed.columns
+        if column_name not in processed_categorical_columns
+    ]
+    return processed_numeric_columns, processed_categorical_columns
+
+
+def _coerce_model_inputs(
+    model_definition: ModelDefinition,
+    x_fold_train_processed: object,
+    x_fold_valid_processed: object,
+    x_test_processed: object | None,
+) -> tuple[object, object, object | None]:
+    x_fold_train_processed = model_definition.coerce_input(x_fold_train_processed)
+    x_fold_valid_processed = model_definition.coerce_input(x_fold_valid_processed)
+    if x_test_processed is not None:
+        x_test_processed = model_definition.coerce_input(x_test_processed)
+    return x_fold_train_processed, x_fold_valid_processed, x_test_processed
+
+
+def _predict_fold(
+    *,
+    model: object,
+    task_type: str,
+    x_fold_valid_processed: object,
+    x_test_processed: object | None,
+    positive_label: object | None,
+) -> tuple[np.ndarray, np.ndarray | None]:
     if task_type == "binary":
-        binary_prediction_kind = get_binary_prediction_kind(primary_metric)
-    preprocess_wall_seconds = 0.0
-    fit_wall_seconds = 0.0
-    predict_wall_seconds = 0.0
-    first_fold_residency: dict[str, object] | None = None
-
-    for fold_index, train_idx, valid_idx in training_context.split_indices:
-        x_fold_train = training_context.x_train_features.iloc[train_idx]
-        x_fold_valid = training_context.x_train_features.iloc[valid_idx]
-        y_fold_train = training_context.y_train.iloc[train_idx]
-        y_fold_valid = training_context.y_train.iloc[valid_idx]
-
-        preprocess_started = time.perf_counter()
-        fitted_representation = compiled_representation.fit(x_fold_train, y_fold_train)
-        x_fold_train_processed = fitted_representation.transform(x_fold_train)
-        x_fold_valid_processed = fitted_representation.transform(x_fold_valid)
-        x_test_processed = None
-        if collect_prediction_artifacts:
-            x_test_processed = fitted_representation.transform(training_context.x_test_features)
-
-        x_fold_train_processed = _coerce_processed_matrix(
-            x_fold_train_processed,
-            matrix_output_kind,
-            preserves_gpu_preprocessed_inputs,
+        if positive_label is None:
+            raise ValueError("Binary training requires resolved class metadata.")
+        positive_class_index = list(model.classes_).index(positive_label)
+        fold_valid_predictions = _select_binary_positive_class_scores(
+            model.predict_proba(x_fold_valid_processed),
+            positive_class_index=positive_class_index,
         )
-        x_fold_valid_processed = _coerce_processed_matrix(
-            x_fold_valid_processed,
-            matrix_output_kind,
-            preserves_gpu_preprocessed_inputs,
-        )
+        fold_test_predictions = None
         if x_test_processed is not None:
-            x_test_processed = _coerce_processed_matrix(
-                x_test_processed,
-                matrix_output_kind,
-                preserves_gpu_preprocessed_inputs,
-            )
-
-        if uses_xgboost_gpu_native_inputs:
-            # Convert fold-local preprocessing outputs to GPU-native inputs before XGBoost fit/predict.
-            x_fold_train_processed = _coerce_xgboost_gpu_input(x_fold_train_processed)
-            x_fold_valid_processed = _coerce_xgboost_gpu_input(x_fold_valid_processed)
-            if x_test_processed is not None:
-                x_test_processed = _coerce_xgboost_gpu_input(x_test_processed)
-        elif resolved_model_registry_key == "lightgbm":
-            x_fold_train_processed = coerce_lightgbm_matrix_input(x_fold_train_processed)
-            x_fold_valid_processed = coerce_lightgbm_matrix_input(x_fold_valid_processed)
-            if x_test_processed is not None:
-                x_test_processed = coerce_lightgbm_matrix_input(x_test_processed)
-        preprocess_wall_seconds += time.perf_counter() - preprocess_started
-        if first_fold_residency is None:
-            first_fold_residency = {
-                "train_processed": _describe_matrix_residency(x_fold_train_processed),
-                "valid_processed": _describe_matrix_residency(x_fold_valid_processed),
-                "test_processed": (
-                    _describe_matrix_residency(x_test_processed) if x_test_processed is not None else None
-                ),
-            }
-
-        _, model, _ = build_model(
-            task_type,
-            resolved_model_registry_key,
-            cv_random_state,
-            parameter_overrides=model_spec.parameter_overrides,
-        )
-        if matrix_output_kind == "native_frame" and isinstance(x_fold_train_processed, pd.DataFrame):
-            processed_categorical_columns = [
-                c for c in x_fold_train_processed.columns
-                if x_fold_train_processed[c].dtype == object or pd.api.types.is_string_dtype(x_fold_train_processed[c])
-            ]
-            processed_numeric_columns = [
-                c for c in x_fold_train_processed.columns if c not in processed_categorical_columns
-            ]
-        else:
-            processed_numeric_columns = training_context.feature_schema.numeric_columns
-            processed_categorical_columns = training_context.feature_schema.categorical_columns
-        model_fit_kwargs = build_model_fit_kwargs(
-            model_definition=model_definition,
-            x_train_processed=x_fold_train_processed,
-            numeric_columns=processed_numeric_columns,
-            categorical_columns=processed_categorical_columns,
-            uses_native_categorical_preprocessing=matrix_output_kind == "native_frame",
-        )
-        fit_started = time.perf_counter()
-        model.fit(x_fold_train_processed, y_fold_train, **model_fit_kwargs)
-        fit_wall_seconds += time.perf_counter() - fit_started
-
-        predict_started = time.perf_counter()
-        if task_type == "binary":
-            if training_context.positive_label is None or training_context.negative_label is None:
-                raise ValueError("Binary training requires resolved class metadata.")
-            positive_class_index = list(model.classes_).index(training_context.positive_label)
-            fold_valid_predictions = _select_binary_positive_class_scores(
-                model.predict_proba(x_fold_valid_processed),
+            fold_test_predictions = _select_binary_positive_class_scores(
+                model.predict_proba(x_test_processed),
                 positive_class_index=positive_class_index,
             )
-            fold_test_predictions = None
-            if x_test_processed is not None:
-                fold_test_predictions = _select_binary_positive_class_scores(
-                    model.predict_proba(x_test_processed),
-                    positive_class_index=positive_class_index,
-                )
-        else:
-            fold_valid_predictions = model.predict(x_fold_valid_processed)
-            fold_test_predictions = None
-            if x_test_processed is not None:
-                fold_test_predictions = model.predict(x_test_processed)
+    else:
+        fold_valid_predictions = model.predict(x_fold_valid_processed)
+        fold_test_predictions = None
+        if x_test_processed is not None:
+            fold_test_predictions = model.predict(x_test_processed)
 
-        fold_valid_predictions = _coerce_prediction_values(fold_valid_predictions)
-        if fold_test_predictions is not None:
-            fold_test_predictions = _coerce_prediction_values(fold_test_predictions)
-        predict_wall_seconds += time.perf_counter() - predict_started
+    resolved_valid_predictions = _coerce_prediction_values(fold_valid_predictions)
+    resolved_test_predictions = None
+    if fold_test_predictions is not None:
+        resolved_test_predictions = _coerce_prediction_values(fold_test_predictions)
+    return resolved_valid_predictions, resolved_test_predictions
 
-        fold_score = score_predictions(
-            task_type=task_type,
-            primary_metric=primary_metric,
-            y_true=y_fold_valid,
-            y_pred=fold_valid_predictions,
-            positive_label=training_context.positive_label,
+
+def _evaluate_fold(
+    *,
+    train_idx: np.ndarray,
+    valid_idx: np.ndarray,
+    task_type: str,
+    primary_metric: str,
+    model_definition: ModelDefinition,
+    base_model: object,
+    training_context: PreparedTrainingContext,
+    collect_prediction_artifacts: bool,
+) -> FoldEvaluationResult:
+    x_fold_train = training_context.x_train_features.iloc[train_idx]
+    x_fold_valid = training_context.x_train_features.iloc[valid_idx]
+    y_fold_train = training_context.y_train.iloc[train_idx]
+    y_fold_valid = training_context.y_train.iloc[valid_idx]
+
+    preprocess_started = time.perf_counter()
+    fitted_representation = training_context.compiled_representation.fit(x_fold_train, y_fold_train)
+    x_fold_train_processed = fitted_representation.transform(x_fold_train)
+    x_fold_valid_processed = fitted_representation.transform(x_fold_valid)
+    x_test_processed = None
+    if collect_prediction_artifacts:
+        x_test_processed = fitted_representation.transform(training_context.x_test_features)
+
+    x_fold_train_processed = _coerce_processed_matrix(
+        x_fold_train_processed,
+        training_context.matrix_output_kind,
+        training_context.preserves_gpu_preprocessed_inputs,
+    )
+    x_fold_valid_processed = _coerce_processed_matrix(
+        x_fold_valid_processed,
+        training_context.matrix_output_kind,
+        training_context.preserves_gpu_preprocessed_inputs,
+    )
+    if x_test_processed is not None:
+        x_test_processed = _coerce_processed_matrix(
+            x_test_processed,
+            training_context.matrix_output_kind,
+            training_context.preserves_gpu_preprocessed_inputs,
         )
+    x_fold_train_processed, x_fold_valid_processed, x_test_processed = _coerce_model_inputs(
+        model_definition,
+        x_fold_train_processed,
+        x_fold_valid_processed,
+        x_test_processed,
+    )
+    preprocess_wall_seconds = time.perf_counter() - preprocess_started
 
-        if oof_predictions is not None:
-            oof_predictions[valid_idx] = fold_valid_predictions
-        if test_predictions_per_fold is not None and fold_test_predictions is not None:
-            test_predictions_per_fold.append(np.asarray(fold_test_predictions, dtype=float))
-        fold_metrics.append(
-            {
-                "fold": fold_index,
-                "metric_name": primary_metric,
-                "metric_value": fold_score,
-                "train_rows": int(len(train_idx)),
-                "valid_rows": int(len(valid_idx)),
-            }
-        )
+    processed_numeric_columns, processed_categorical_columns = _resolve_processed_feature_columns(
+        training_context,
+        x_fold_train_processed,
+    )
+    model_fit_kwargs = build_model_fit_kwargs(
+        model_definition=model_definition,
+        x_train_processed=x_fold_train_processed,
+        numeric_columns=processed_numeric_columns,
+        categorical_columns=processed_categorical_columns,
+        uses_native_categorical_preprocessing=training_context.matrix_output_kind == "native_frame",
+    )
 
+    model = clone(base_model)
+    fit_started = time.perf_counter()
+    model.fit(x_fold_train_processed, y_fold_train, **model_fit_kwargs)
+    fit_wall_seconds = time.perf_counter() - fit_started
+
+    predict_started = time.perf_counter()
+    fold_valid_predictions, fold_test_predictions = _predict_fold(
+        model=model,
+        task_type=task_type,
+        x_fold_valid_processed=x_fold_valid_processed,
+        x_test_processed=x_test_processed,
+        positive_label=training_context.positive_label,
+    )
+    predict_wall_seconds = time.perf_counter() - predict_started
+
+    fold_score = score_predictions(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        y_true=y_fold_valid,
+        y_pred=fold_valid_predictions,
+        positive_label=training_context.positive_label,
+    )
+    residency_profile = {
+        "train_processed": _describe_matrix_residency(x_fold_train_processed),
+        "valid_processed": _describe_matrix_residency(x_fold_valid_processed),
+        "test_processed": _describe_matrix_residency(x_test_processed) if x_test_processed is not None else None,
+    }
+    return FoldEvaluationResult(
+        valid_predictions=fold_valid_predictions,
+        test_predictions=fold_test_predictions,
+        metric_value=fold_score,
+        train_rows=int(len(train_idx)),
+        valid_rows=int(len(valid_idx)),
+        preprocess_wall_seconds=preprocess_wall_seconds,
+        fit_wall_seconds=fit_wall_seconds,
+        predict_wall_seconds=predict_wall_seconds,
+        residency_profile=residency_profile,
+    )
+
+
+def _build_cv_evaluation(
+    *,
+    model_definition: ModelDefinition,
+    model_params: dict[str, object],
+    representation_id: str,
+    primary_metric: str,
+    fold_metrics: list[dict[str, object]],
+) -> ModelCvEvaluation:
     fold_metrics_df = pd.DataFrame(fold_metrics)
-    cv_evaluation = ModelCvEvaluation(
+    return ModelCvEvaluation(
         model_result=ModelRunResult(
-            model_registry_key=resolved_model_registry_key,
-            estimator_name=estimator_name,
+            model_registry_key=model_definition.model_id,
+            estimator_name=model_definition.model_name,
             representation_id=representation_id,
             model_params=model_params,
             cv_summary=CvSummary(
@@ -504,8 +526,19 @@ def _run_cv_evaluation(
         ),
         fold_metrics_df=fold_metrics_df,
     )
-    runtime_profile = {
-        "fold_count": len(training_context.split_indices),
+
+
+def _build_runtime_profile(
+    *,
+    fold_count: int,
+    preprocessing_backend: str,
+    preprocess_wall_seconds: float,
+    fit_wall_seconds: float,
+    predict_wall_seconds: float,
+    first_fold_residency: dict[str, object] | None,
+) -> dict[str, object]:
+    return {
+        "fold_count": fold_count,
         "preprocessing_backend": preprocessing_backend,
         "cv_preprocess_wall_seconds": preprocess_wall_seconds,
         "cv_fit_wall_seconds": fit_wall_seconds,
@@ -514,17 +547,20 @@ def _run_cv_evaluation(
         "first_fold_residency": first_fold_residency,
     }
 
-    if not collect_prediction_artifacts:
-        return cv_evaluation, None, None, None, runtime_profile
 
-    if oof_predictions is None or test_predictions_per_fold is None:
-        raise RuntimeError("Prediction artifacts were requested but not collected.")
-
+def _finalize_test_predictions(
+    *,
+    task_type: str,
+    primary_metric: str,
+    training_context: PreparedTrainingContext,
+    test_predictions_per_fold: list[np.ndarray],
+) -> tuple[np.ndarray, np.ndarray | None]:
     mean_test_predictions = np.mean(np.vstack(test_predictions_per_fold), axis=0)
     test_prediction_probabilities = None
     if task_type == "regression" and primary_metric == "rmsle":
         mean_test_predictions = np.clip(mean_test_predictions, a_min=0.0, a_max=None)
-    if task_type == "binary" and binary_prediction_kind == "label":
+
+    if task_type == "binary" and get_binary_prediction_kind(primary_metric) == "label":
         if training_context.positive_label is None or training_context.negative_label is None:
             raise ValueError("Binary label exports require resolved class metadata.")
         test_prediction_probabilities = np.asarray(mean_test_predictions, dtype=float)
@@ -533,15 +569,136 @@ def _run_cv_evaluation(
             training_context.positive_label,
             training_context.negative_label,
         )
-    else:
-        final_test_predictions = mean_test_predictions
+        return np.asarray(final_test_predictions), test_prediction_probabilities
 
-    return (
-        cv_evaluation,
-        oof_predictions,
-        np.asarray(final_test_predictions),
-        test_prediction_probabilities,
-        runtime_profile,
+    return np.asarray(mean_test_predictions), test_prediction_probabilities
+
+
+def _run_cv_fold_loop(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    training_context: PreparedTrainingContext,
+    cv_random_state: int,
+    collect_prediction_artifacts: bool,
+) -> CvFoldLoopResult:
+    model_definition, base_model, model_params = build_model(
+        task_type,
+        model_spec.model_registry_key,
+        cv_random_state,
+        parameter_overrides=model_spec.parameter_overrides,
+    )
+    fold_results: list[FoldEvaluationResult] = []
+    fold_metrics: list[dict[str, object]] = []
+    preprocess_wall_seconds = 0.0
+    fit_wall_seconds = 0.0
+    predict_wall_seconds = 0.0
+    first_fold_residency: dict[str, object] | None = None
+
+    for fold_index, train_idx, valid_idx in training_context.split_indices:
+        fold_result = _evaluate_fold(
+            train_idx=train_idx,
+            valid_idx=valid_idx,
+            task_type=task_type,
+            primary_metric=primary_metric,
+            model_definition=model_definition,
+            base_model=base_model,
+            training_context=training_context,
+            collect_prediction_artifacts=collect_prediction_artifacts,
+        )
+        fold_results.append(fold_result)
+        fold_metrics.append(fold_result.to_metric_row(fold_index=fold_index, metric_name=primary_metric))
+        preprocess_wall_seconds += fold_result.preprocess_wall_seconds
+        fit_wall_seconds += fold_result.fit_wall_seconds
+        predict_wall_seconds += fold_result.predict_wall_seconds
+        if first_fold_residency is None:
+            first_fold_residency = fold_result.residency_profile
+
+    runtime_profile = _build_runtime_profile(
+        fold_count=len(training_context.split_indices),
+        preprocessing_backend=training_context.preprocessing_backend,
+        preprocess_wall_seconds=preprocess_wall_seconds,
+        fit_wall_seconds=fit_wall_seconds,
+        predict_wall_seconds=predict_wall_seconds,
+        first_fold_residency=first_fold_residency,
+    )
+    return CvFoldLoopResult(
+        model_params=model_params,
+        model_definition=model_definition,
+        fold_results=fold_results,
+        fold_metrics=fold_metrics,
+        runtime_profile=runtime_profile,
+    )
+
+
+def _run_cv_evaluation(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    training_context: PreparedTrainingContext,
+    cv_random_state: int,
+) -> CvEvaluationResult:
+    fold_loop_result = _run_cv_fold_loop(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        model_spec=model_spec,
+        training_context=training_context,
+        cv_random_state=cv_random_state,
+        collect_prediction_artifacts=False,
+    )
+    return CvEvaluationResult(
+        cv_evaluation=_build_cv_evaluation(
+            model_definition=fold_loop_result.model_definition,
+            model_params=fold_loop_result.model_params,
+            representation_id=training_context.representation_id,
+            primary_metric=primary_metric,
+            fold_metrics=fold_loop_result.fold_metrics,
+        ),
+        runtime_profile=fold_loop_result.runtime_profile,
+    )
+
+
+def _run_full_cv_evaluation(
+    task_type: str,
+    primary_metric: str,
+    model_spec: TrainingModelSpec,
+    training_context: PreparedTrainingContext,
+    cv_random_state: int,
+) -> FullCvEvaluationResult:
+    fold_loop_result = _run_cv_fold_loop(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        model_spec=model_spec,
+        training_context=training_context,
+        cv_random_state=cv_random_state,
+        collect_prediction_artifacts=True,
+    )
+    oof_predictions = np.zeros(training_context.x_train_features.shape[0], dtype=float)
+    test_predictions_per_fold: list[np.ndarray] = []
+    for (_, _, valid_idx), fold_result in zip(training_context.split_indices, fold_loop_result.fold_results):
+        oof_predictions[valid_idx] = fold_result.valid_predictions
+        if fold_result.test_predictions is None:
+            raise RuntimeError("Full evaluation must collect test predictions for every fold.")
+        test_predictions_per_fold.append(np.asarray(fold_result.test_predictions, dtype=float))
+
+    final_test_predictions, test_prediction_probabilities = _finalize_test_predictions(
+        task_type=task_type,
+        primary_metric=primary_metric,
+        training_context=training_context,
+        test_predictions_per_fold=test_predictions_per_fold,
+    )
+    return FullCvEvaluationResult(
+        cv_evaluation=_build_cv_evaluation(
+            model_definition=fold_loop_result.model_definition,
+            model_params=fold_loop_result.model_params,
+            representation_id=training_context.representation_id,
+            primary_metric=primary_metric,
+            fold_metrics=fold_loop_result.fold_metrics,
+        ),
+        runtime_profile=fold_loop_result.runtime_profile,
+        oof_predictions=oof_predictions,
+        final_test_predictions=final_test_predictions,
+        test_prediction_probabilities=test_prediction_probabilities,
     )
 
 
@@ -552,15 +709,14 @@ def score_model_spec(
     training_context: PreparedTrainingContext,
     cv_random_state: int,
 ) -> ModelCvEvaluation:
-    cv_evaluation, _, _, _, _ = _run_cv_evaluation(
+    evaluation_result = _run_cv_evaluation(
         task_type=task_type,
         primary_metric=primary_metric,
         model_spec=model_spec,
         training_context=training_context,
         cv_random_state=cv_random_state,
-        collect_prediction_artifacts=False,
     )
-    return cv_evaluation
+    return evaluation_result.cv_evaluation
 
 
 def evaluate_model_spec(
@@ -570,22 +726,19 @@ def evaluate_model_spec(
     training_context: PreparedTrainingContext,
     cv_random_state: int,
 ) -> ModelEvaluationArtifacts:
-    cv_evaluation, oof_predictions, final_test_predictions, test_prediction_probabilities, runtime_profile = _run_cv_evaluation(
+    evaluation_result = _run_full_cv_evaluation(
         task_type=task_type,
         primary_metric=primary_metric,
         model_spec=model_spec,
         training_context=training_context,
         cv_random_state=cv_random_state,
-        collect_prediction_artifacts=True,
     )
-    if oof_predictions is None or final_test_predictions is None:
-        raise RuntimeError("Training evaluation must return OOF and test predictions.")
 
     return ModelEvaluationArtifacts(
-        model_result=cv_evaluation.model_result,
-        fold_metrics_df=cv_evaluation.fold_metrics_df,
-        oof_predictions=oof_predictions,
-        final_test_predictions=final_test_predictions,
-        test_prediction_probabilities=test_prediction_probabilities,
-        runtime_profile=runtime_profile,
+        model_result=evaluation_result.cv_evaluation.model_result,
+        fold_metrics_df=evaluation_result.cv_evaluation.fold_metrics_df,
+        oof_predictions=evaluation_result.oof_predictions,
+        final_test_predictions=evaluation_result.final_test_predictions,
+        test_prediction_probabilities=evaluation_result.test_prediction_probabilities,
+        runtime_profile=evaluation_result.runtime_profile,
     )


### PR DESCRIPTION
## Summary
- extract fold-local CV execution into focused helpers
- move model-specific input coercion into model definitions
- split scoring-only vs full evaluation into separate internal paths and make estimator wrappers clone-safe

## Verification
- uv run python -m py_compile src/tabular_shenanigans/_model_types.py src/tabular_shenanigans/_model_builders.py src/tabular_shenanigans/_model_registry.py src/tabular_shenanigans/lightgbm_cuda_backend.py src/tabular_shenanigans/model_evaluation.py
- synthetic in-memory evaluate_model_spec coverage for random_forest, xgboost, lightgbm, and catboost across binary and regression CPU paths
- synthetic score_model_spec and evaluate_model_spec comparison for binary accuracy
- GPU verification not exercised on this host

Closes #304