### PR TITLE
Refactor representation pipeline (#302)

### DIFF
--- a/src/tabular_shenanigans/_model_registry.py
+++ b/src/tabular_shenanigans/_model_registry.py
@@ -39,7 +39,6 @@ from tabular_shenanigans._model_builders import (
 )
 from tabular_shenanigans._model_types import GpuRoutingRule, ModelDefinition
 from tabular_shenanigans.lightgbm_cuda_backend import coerce_lightgbm_matrix_input
-from tabular_shenanigans.representations.types import RepresentationContract
 from tabular_shenanigans.runtime_execution import (
     NATIVE_GPU_BACKEND,
     PATCH_GPU_BACKEND,
@@ -330,13 +329,14 @@ def get_tunable_model_ids(task_type: str) -> list[str]:
 def validate_model_representation_compatibility(
     task_type: str,
     model_id: str,
-    representation_contract: RepresentationContract,
+    has_native_categorical: bool,
+    has_sparse_numeric: bool,
 ) -> None:
     validate_model_output_compatibility(
         task_type=task_type,
         model_id=model_id,
-        has_native_categorical=representation_contract.has_native_categorical,
-        has_sparse_numeric=representation_contract.has_sparse_numeric,
+        has_native_categorical=has_native_categorical,
+        has_sparse_numeric=has_sparse_numeric,
     )
 
 
@@ -429,4 +429,3 @@ def build_model_fit_kwargs(
     if model_definition.fit_kwargs_builder is None or not uses_native_categorical_preprocessing:
         return {}
     return model_definition.fit_kwargs_builder(x_train_processed, numeric_columns, categorical_columns)
-

--- a/src/tabular_shenanigans/bootstrap_config.py
+++ b/src/tabular_shenanigans/bootstrap_config.py
@@ -2,8 +2,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
-from tabular_shenanigans.naming import _short_hash
-from tabular_shenanigans.operator_properties import SPARSE_PRODUCING_OPERATOR_IDS
+from tabular_shenanigans.representations import (
+    build_representation_id_from_payload,
+    normalize_representation_payload,
+    representation_has_native_categorical,
+    representation_has_sparse_numeric,
+)
 
 
 @dataclass(frozen=True)
@@ -14,47 +18,16 @@ class BootstrapCandidateRuntimeConfig:
     representation_id: str | None = None
     has_native_categorical: bool = False
     has_sparse_numeric: bool = False
-
-
-def _normalize_representation_component_payload(component: object, field_name: str) -> dict[str, object]:
-    if not isinstance(component, dict):
-        raise ValueError(f"{field_name} entries must be mappings.")
-    component_id = component.get("id")
-    if not isinstance(component_id, str) or not component_id:
-        raise ValueError(f"{field_name} entries must include a non-empty string 'id'.")
-    return {
-        "id": component_id,
-        "params": {str(key): value for key, value in component.items() if key != "id"},
-    }
-
-
 def _build_bootstrap_representation_summary(
     representation: dict[str, object] | None,
 ) -> tuple[str | None, bool, bool]:
     if representation is None:
         return None, False, False
 
-    operators = representation.get("operators")
-    pruners = representation.get("pruners", [])
-    if not isinstance(operators, list) or not operators:
-        raise ValueError("representation.operators must be a non-empty list.")
-    if not isinstance(pruners, list):
-        raise ValueError("representation.pruners must be a list when provided.")
-
-    normalized_operators = [
-        _normalize_representation_component_payload(component, "representation.operators")
-        for component in operators
-    ]
-    normalized_pruners = [
-        _normalize_representation_component_payload(component, "representation.pruners")
-        for component in pruners
-    ]
-    fingerprint_payload = {"operators": normalized_operators, "pruners": normalized_pruners}
-    representation_id = f"repr-{_short_hash(fingerprint_payload)}"
-
-    operator_ids = {operator["id"] for operator in normalized_operators}
-    has_native_categorical = "native_categorical" in operator_ids
-    has_sparse_numeric = bool(operator_ids.intersection(SPARSE_PRODUCING_OPERATOR_IDS))
+    operators, _ = normalize_representation_payload(representation)
+    representation_id = build_representation_id_from_payload(representation)
+    has_native_categorical = representation_has_native_categorical(operators)
+    has_sparse_numeric = representation_has_sparse_numeric(operators)
 
     return representation_id, has_native_categorical, has_sparse_numeric
 

--- a/src/tabular_shenanigans/config.py
+++ b/src/tabular_shenanigans/config.py
@@ -19,9 +19,14 @@ from tabular_shenanigans.naming import (
     normalize_blend_weights,
 )
 from tabular_shenanigans.representations import (
-    build_representation_contract,
-    build_representation_spec_from_payload,
-    validate_representation_spec,
+    build_representation_id_from_config,
+    normalize_representation_config,
+    representation_has_cuml_compatible_numerics,
+    representation_has_frequency_categorical,
+    representation_has_native_categorical,
+    representation_has_sparse_numeric,
+    resolve_representation_matrix_output_kind,
+    validate_representation_config,
 )
 from tabular_shenanigans.preprocess_execution import resolve_preprocessing_execution_plan
 
@@ -96,10 +101,11 @@ class RepresentationConfig(BaseModel):
             "pruners": [pruner.to_payload() for pruner in self.pruners],
         }
 
-    def to_runtime_spec(self):
-        representation_spec = build_representation_spec_from_payload(self.to_payload())
-        validate_representation_spec(representation_spec)
-        return representation_spec
+    def build_representation_id(self) -> str:
+        return build_representation_id_from_config(self)
+
+    def validate_definition(self) -> None:
+        validate_representation_config(self)
 
 
 class ScreeningConfig(BaseModel):
@@ -191,7 +197,8 @@ class ModelCandidateConfig(BaseCandidateConfig):
                 "candidate.model_params and candidate.optimization are mutually exclusive. "
                 "Use model_params for fixed training or optimization for tuning, not both."
             )
-        self.representation_id = self.representation.to_runtime_spec().representation_id
+        self.representation.validate_definition()
+        self.representation_id = self.representation.build_representation_id()
         return self
 
 
@@ -312,13 +319,15 @@ class AppConfig(BaseModel):
         for candidate_index, candidate in enumerate(self.experiment.candidates, start=1):
             try:
                 if isinstance(candidate, ModelCandidateConfig):
-                    representation_spec = candidate.representation.to_runtime_spec()
-                    representation_contract = build_representation_contract(representation_spec)
+                    representation_operators, _ = normalize_representation_config(candidate.representation)
                     resolved_model_registry_key = self.resolve_model_registry_key_for_index(candidate_index - 1)
                     validate_model_representation_compatibility(
                         task_type=competition.task_type,
                         model_id=resolved_model_registry_key,
-                        representation_contract=representation_contract,
+                        has_native_categorical=representation_has_native_categorical(
+                            representation_operators
+                        ),
+                        has_sparse_numeric=representation_has_sparse_numeric(representation_operators),
                     )
                     validate_model_parameter_overrides(
                         task_type=competition.task_type,
@@ -477,15 +486,11 @@ class AppConfig(BaseModel):
             model_family=candidate.model_family,
         )
 
-    def resolve_representation_spec_for_index(self, candidate_index: int | None = None):
+    def resolve_representation_components_for_index(self, candidate_index: int | None = None):
         candidate = self.get_candidate(candidate_index)
         if not isinstance(candidate, ModelCandidateConfig):
-            raise ValueError("representation spec is only available for model candidates.")
-        return candidate.representation.to_runtime_spec()
-
-    def resolve_representation_contract_for_index(self, candidate_index: int | None = None):
-        return build_representation_contract(self.resolve_representation_spec_for_index(candidate_index))
-
+            raise ValueError("representation components are only available for model candidates.")
+        return normalize_representation_config(candidate.representation)
 
     def resolve_blend_weights_for_index(self, candidate_index: int | None = None) -> list[float]:
         candidate = self.get_candidate(candidate_index)
@@ -534,15 +539,15 @@ class AppConfig(BaseModel):
         if not isinstance(candidate, ModelCandidateConfig):
             return runtime_execution_context
 
-        representation_contract = self.resolve_representation_contract_for_index(candidate_index)
+        representation_operators, _ = self.resolve_representation_components_for_index(candidate_index)
         resolved_runtime_execution_context = resolve_model_candidate_runtime_execution(
             requested_compute_target=self.experiment.runtime.compute_target,
             requested_gpu_backend=self.experiment.runtime.gpu_backend,
             capabilities=runtime_execution_context.capabilities,
             task_type=self.competition.task_type,
             model_family=candidate.model_family,
-            has_native_categorical=representation_contract.has_native_categorical,
-            has_sparse_numeric=representation_contract.has_sparse_numeric,
+            has_native_categorical=representation_has_native_categorical(representation_operators),
+            has_sparse_numeric=representation_has_sparse_numeric(representation_operators),
         )
         return resolved_runtime_execution_context.__class__(
             requested_compute_target=resolved_runtime_execution_context.requested_compute_target,
@@ -560,11 +565,16 @@ class AppConfig(BaseModel):
         if not isinstance(candidate, ModelCandidateConfig):
             raise ValueError("preprocessing_execution_plan is only available for model candidates.")
 
-        representation_contract = self.resolve_representation_contract_for_index(candidate_index)
+        representation_operators, _ = self.resolve_representation_components_for_index(candidate_index)
         runtime_execution_context = self.runtime_execution_context_for_index(candidate_index)
         return resolve_preprocessing_execution_plan(
             runtime_execution_context=runtime_execution_context,
-            representation_contract=representation_contract,
+            matrix_output_kind=resolve_representation_matrix_output_kind(representation_operators),
+            has_native_categorical=representation_has_native_categorical(representation_operators),
+            has_frequency_categorical=representation_has_frequency_categorical(representation_operators),
+            has_cuml_compatible_numerics=representation_has_cuml_compatible_numerics(
+                representation_operators
+            ),
         )
 
     def resolve_candidate_id_for_index(self, candidate_index: int | None = None) -> str:

--- a/src/tabular_shenanigans/mlflow_store.py
+++ b/src/tabular_shenanigans/mlflow_store.py
@@ -15,8 +15,14 @@ from tabular_shenanigans.candidate_artifacts import (
 )
 from tabular_shenanigans.config import AppConfig
 from tabular_shenanigans.representations import (
-    build_representation_contract,
-    build_representation_spec_from_payload,
+    build_representation_fingerprint_payload,
+    normalize_representation_payload,
+    representation_has_dense_numeric,
+    representation_has_frequency_categorical,
+    representation_has_native_categorical,
+    representation_has_native_numeric,
+    representation_has_sparse_numeric,
+    resolve_representation_matrix_output_kind,
 )
 from tabular_shenanigans.submission_history import CandidateSubmissionHistory, SubmissionEvent
 
@@ -42,47 +48,6 @@ ACTIVE_MLFLOW_RUN_STATUSES = {"RUNNING", "SCHEDULED"}
 ExperimentRole = Literal["screening", "candidates", "submissions"]
 
 
-def _normalize_representation_component_payload(
-    component: object,
-    field_name: str,
-) -> dict[str, object]:
-    if not isinstance(component, Mapping):
-        raise ValueError(f"{field_name} entries must be mappings.")
-    component_id = component.get("id")
-    if not isinstance(component_id, str) or not component_id:
-        raise ValueError(f"{field_name} entries must include a non-empty string 'id'.")
-    return {
-        "id": component_id,
-        "params": {
-            str(key): value
-            for key, value in component.items()
-            if key != "id"
-        },
-    }
-
-
-def _extract_representation_components(
-    representation: object,
-) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
-    if not isinstance(representation, Mapping):
-        raise ValueError("representation must be a mapping.")
-    operators = representation.get("operators")
-    pruners = representation.get("pruners", [])
-    if not isinstance(operators, list) or not operators:
-        raise ValueError("representation.operators must be a non-empty list.")
-    if not isinstance(pruners, list):
-        raise ValueError("representation.pruners must be a list when provided.")
-    normalized_operators = [
-        _normalize_representation_component_payload(component, "representation.operators")
-        for component in operators
-    ]
-    normalized_pruners = [
-        _normalize_representation_component_payload(component, "representation.pruners")
-        for component in pruners
-    ]
-    return normalized_operators, normalized_pruners
-
-
 def _component_signature(component: Mapping[str, object]) -> str:
     component_id = component["id"]
     params = component["params"]
@@ -98,36 +63,39 @@ def _component_signature(component: Mapping[str, object]) -> str:
 
 
 def _representation_logging_fields(representation: object) -> dict[str, object]:
-    operators, pruners = _extract_representation_components(representation)
-    operator_ids = [str(component["id"]) for component in operators]
-    pruner_ids = [str(component["id"]) for component in pruners]
-    operator_signature = " -> ".join(_component_signature(component) for component in operators)
-    pruner_signature = " -> ".join(_component_signature(component) for component in pruners) or "none"
+    operators, pruners = normalize_representation_payload(representation)
+    normalized_payload = build_representation_fingerprint_payload(operators, pruners)
+    normalized_operators = normalized_payload["operators"]
+    normalized_pruners = normalized_payload["pruners"]
+    if not isinstance(normalized_operators, list) or not isinstance(normalized_pruners, list):
+        raise ValueError("Normalized representation payload must contain list operators/pruners.")
+
+    operator_ids = [component["id"] for component in normalized_operators]
+    pruner_ids = [component["id"] for component in normalized_pruners]
+    operator_signature = " -> ".join(_component_signature(component) for component in normalized_operators)
+    pruner_signature = " -> ".join(_component_signature(component) for component in normalized_pruners) or "none"
     return {
-        "representation__operator_count": len(operators),
+        "representation__operator_count": len(normalized_operators),
         "representation__operator_ids": " -> ".join(operator_ids),
         "representation__operator_ids_json": operator_ids,
-        "representation__operators_json": operators,
-        "representation__pruner_count": len(pruners),
+        "representation__operators_json": normalized_operators,
+        "representation__pruner_count": len(normalized_pruners),
         "representation__pruner_ids": " -> ".join(pruner_ids) if pruner_ids else "none",
         "representation__pruner_ids_json": pruner_ids,
-        "representation__pruners_json": pruners,
+        "representation__pruners_json": normalized_pruners,
         "representation__summary": f"ops: {operator_signature} | pruners: {pruner_signature}",
     }
 
 
-def _representation_contract_logging_fields(representation: object) -> dict[str, object]:
-    if not isinstance(representation, Mapping):
-        raise ValueError("representation must be a mapping.")
-    representation_spec = build_representation_spec_from_payload(dict(representation))
-    representation_contract = build_representation_contract(representation_spec)
+def _representation_runtime_logging_fields(representation: object) -> dict[str, object]:
+    operators, _ = normalize_representation_payload(representation)
     return {
-        "representation__matrix_output_kind": representation_contract.matrix_output_kind,
-        "representation__has_native_categorical": representation_contract.has_native_categorical,
-        "representation__has_sparse_numeric": representation_contract.has_sparse_numeric,
-        "representation__has_dense_numeric": representation_contract.has_dense_numeric,
-        "representation__has_native_numeric": representation_contract.has_native_numeric,
-        "representation__has_frequency_categorical": representation_contract.has_frequency_categorical,
+        "representation__matrix_output_kind": resolve_representation_matrix_output_kind(operators),
+        "representation__has_native_categorical": representation_has_native_categorical(operators),
+        "representation__has_sparse_numeric": representation_has_sparse_numeric(operators),
+        "representation__has_dense_numeric": representation_has_dense_numeric(operators),
+        "representation__has_native_numeric": representation_has_native_numeric(operators),
+        "representation__has_frequency_categorical": representation_has_frequency_categorical(operators),
     }
 
 
@@ -159,7 +127,7 @@ def _model_logging_fields(manifest: Mapping[str, object]) -> dict[str, object]:
     representation = manifest.get("representation")
     if representation is not None:
         params.update(_representation_logging_fields(representation))
-        params.update(_representation_contract_logging_fields(representation))
+        params.update(_representation_runtime_logging_fields(representation))
 
     parameter_overrides = _resolved_model_parameter_overrides(manifest)
     params["hp__source"] = _hyperparameter_source(manifest)
@@ -711,7 +679,7 @@ def create_trial_run(
     representation_payload = config.experiment.candidate.representation.to_payload()
     representation_logging = {
         **_representation_logging_fields(representation_payload),
-        **_representation_contract_logging_fields(representation_payload),
+        **_representation_runtime_logging_fields(representation_payload),
     }
     _log_params(
         client,

--- a/src/tabular_shenanigans/model_evaluation.py
+++ b/src/tabular_shenanigans/model_evaluation.py
@@ -1,5 +1,5 @@
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -20,9 +20,10 @@ from tabular_shenanigans.preprocess import prepare_feature_frames
 from tabular_shenanigans.representations import (
     CompiledRepresentation,
     ResolvedFeatureSchema,
-    build_representation_contract,
     compile_representation,
+    normalize_representation_config,
     resolve_feature_schema,
+    resolve_representation_matrix_output_kind,
 )
 from tabular_shenanigans.runtime_execution import NATIVE_GPU_BACKEND
 
@@ -199,12 +200,14 @@ def build_prepared_training_context(
         negative_label=negative_label,
         observed_label_pair=observed_label_pair,
     )
-    representation_spec = candidate.representation.to_runtime_spec()
-    representation_contract = build_representation_contract(representation_spec)
     runtime_execution_context = config.runtime_execution_context
-    if runtime_execution_context.sparse_to_dense_coercion and representation_contract.matrix_output_kind == "sparse_csr":
-        representation_contract = replace(representation_contract, matrix_output_kind="dense_array")
-    representation_id = representation_spec.representation_id
+    representation_operators, _ = normalize_representation_config(candidate.representation)
+    matrix_output_kind_override = None
+    if (
+        runtime_execution_context.sparse_to_dense_coercion
+        and resolve_representation_matrix_output_kind(representation_operators) == "sparse_csr"
+    ):
+        matrix_output_kind_override = "dense_array"
     feature_schema = resolve_feature_schema(
         x_train_raw=x_train_raw,
         force_categorical=features.force_categorical,
@@ -212,10 +215,10 @@ def build_prepared_training_context(
         low_cardinality_int_threshold=features.low_cardinality_int_threshold,
     )
     compiled_representation = compile_representation(
-        representation_spec=representation_spec,
+        representation=candidate.representation,
         feature_schema=feature_schema,
         x_train_sample=x_train_raw,
-        representation_contract=representation_contract,
+        matrix_output_kind_override=matrix_output_kind_override,
     )
     preserves_gpu_preprocessed_inputs = (
         config.resolved_model_registry_key == "xgboost"
@@ -236,7 +239,7 @@ def build_prepared_training_context(
         target_summary=target_summary,
         feature_schema=feature_schema,
         compiled_representation=compiled_representation,
-        representation_id=representation_id,
+        representation_id=compiled_representation.representation_id,
         matrix_output_kind=compiled_representation.matrix_output_kind,
         preserves_gpu_preprocessed_inputs=preserves_gpu_preprocessed_inputs,
         preprocessing_backend=compiled_representation.preprocessing_backend,

--- a/src/tabular_shenanigans/preprocess_execution.py
+++ b/src/tabular_shenanigans/preprocess_execution.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from tabular_shenanigans.representations.types import RepresentationContract
+from tabular_shenanigans.representations.types import MatrixOutputKind
 from tabular_shenanigans.runtime_execution import PATCH_GPU_BACKEND, RuntimeExecutionContext
 
 CPU_SKLEARN_PREPROCESSING_BACKEND = "cpu_sklearn"
@@ -14,7 +14,7 @@ GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND = "gpu_native_frequency"
 @dataclass(frozen=True)
 class PreprocessingExecutionPlan:
     preprocessing_backend: str
-    matrix_output_kind: str
+    matrix_output_kind: MatrixOutputKind
 
     @property
     def uses_repo_gpu_native_preprocessing(self) -> bool:
@@ -24,17 +24,18 @@ class PreprocessingExecutionPlan:
 def resolve_preprocessing_execution_plan(
     *,
     runtime_execution_context: RuntimeExecutionContext,
-    representation_contract: RepresentationContract,
+    matrix_output_kind: MatrixOutputKind,
+    has_native_categorical: bool,
+    has_frequency_categorical: bool,
+    has_cuml_compatible_numerics: bool,
 ) -> PreprocessingExecutionPlan:
-    matrix_output_kind = representation_contract.matrix_output_kind
-
     if runtime_execution_context.requested_compute_target == "cpu":
-        if representation_contract.has_native_categorical:
+        if has_native_categorical:
             return PreprocessingExecutionPlan(
                 preprocessing_backend=CPU_NATIVE_FRAME_PREPROCESSING_BACKEND,
                 matrix_output_kind=matrix_output_kind,
             )
-        if representation_contract.has_frequency_categorical:
+        if has_frequency_categorical:
             return PreprocessingExecutionPlan(
                 preprocessing_backend=CPU_FREQUENCY_PREPROCESSING_BACKEND,
                 matrix_output_kind=matrix_output_kind,
@@ -44,7 +45,7 @@ def resolve_preprocessing_execution_plan(
             matrix_output_kind=matrix_output_kind,
         )
 
-    if representation_contract.has_native_categorical:
+    if has_native_categorical:
         return PreprocessingExecutionPlan(
             preprocessing_backend=CPU_NATIVE_FRAME_PREPROCESSING_BACKEND,
             matrix_output_kind=matrix_output_kind,
@@ -55,8 +56,8 @@ def resolve_preprocessing_execution_plan(
     if (
         gpu_available
         and matrix_output_kind == "dense_array"
-        and not representation_contract.has_frequency_categorical
-        and representation_contract.has_cuml_compatible_numerics
+        and not has_frequency_categorical
+        and has_cuml_compatible_numerics
     ):
         return PreprocessingExecutionPlan(
             preprocessing_backend=GPU_CUML_PREPROCESSING_BACKEND,
@@ -65,8 +66,8 @@ def resolve_preprocessing_execution_plan(
 
     if (
         gpu_available
-        and representation_contract.has_frequency_categorical
-        and representation_contract.has_cuml_compatible_numerics
+        and has_frequency_categorical
+        and has_cuml_compatible_numerics
     ):
         return PreprocessingExecutionPlan(
             preprocessing_backend=GPU_NATIVE_FREQUENCY_PREPROCESSING_BACKEND,
@@ -79,7 +80,7 @@ def resolve_preprocessing_execution_plan(
             matrix_output_kind=matrix_output_kind,
         )
 
-    if representation_contract.has_frequency_categorical:
+    if has_frequency_categorical:
         return PreprocessingExecutionPlan(
             preprocessing_backend=CPU_FREQUENCY_PREPROCESSING_BACKEND,
             matrix_output_kind=matrix_output_kind,

--- a/src/tabular_shenanigans/representations/__init__.py
+++ b/src/tabular_shenanigans/representations/__init__.py
@@ -1,25 +1,37 @@
-from __future__ import annotations
-
-from tabular_shenanigans.naming import _short_hash
 from tabular_shenanigans.representations.compilation import (
     CompiledRepresentation,
     FittedRepresentation,
     compile_representation,
     materialize_feature_bundle,
 )
+from tabular_shenanigans.representations.definition import (
+    build_representation_fingerprint_payload,
+    build_representation_id,
+    build_representation_id_from_config,
+    build_representation_id_from_payload,
+    normalize_representation_config,
+    normalize_representation_payload,
+    representation_has_cuml_compatible_numerics,
+    representation_has_dense_numeric,
+    representation_has_frequency_categorical,
+    representation_has_native_categorical,
+    representation_has_native_numeric,
+    representation_has_native_tabular,
+    representation_has_sparse_numeric,
+    resolve_representation_matrix_output_kind,
+    resolve_representation_output_kinds,
+    validate_representation_config,
+    validate_representation_definition,
+    validate_representation_payload,
+)
 from tabular_shenanigans.representations.feature_schema import (
     ResolvedFeatureSchema,
     resolve_feature_schema,
     resolve_feature_types,
 )
-from tabular_shenanigans.operator_properties import (
-    DENSE_PRODUCING_OPERATOR_IDS,
-    SPARSE_PRODUCING_OPERATOR_IDS,
-)
 from tabular_shenanigans.representations.operators import (
     SUPPORTED_OPERATOR_IDS,
     SUPPORTED_PRUNER_IDS,
-    validate_component_params,
 )
 from tabular_shenanigans.representations.types import (
     FeatureBlock,
@@ -28,146 +40,10 @@ from tabular_shenanigans.representations.types import (
     MaterializedRepresentation,
     MatrixOutputKind,
     OutputKind,
+    RepresentationComponentConfigLike,
     RepresentationComponentSpec,
-    RepresentationContract,
-    RepresentationSpec,
+    RepresentationConfigLike,
 )
-
-
-def normalize_representation_component_payload(component: object, component_kind: str) -> dict[str, object]:
-    if not isinstance(component, dict):
-        raise ValueError(f"{component_kind} entries must be mappings.")
-    component_id = component.get("id")
-    if not isinstance(component_id, str) or not component_id:
-        raise ValueError(f"{component_kind} entries must include a non-empty string 'id'.")
-    params = {str(key): value for key, value in component.items() if key != "id"}
-    return {"id": component_id, "params": params}
-
-
-def build_representation_spec_from_payload(payload: dict[str, object]) -> RepresentationSpec:
-    operators_payload = payload.get("operators")
-    pruners_payload = payload.get("pruners", [])
-    if not isinstance(operators_payload, list) or not operators_payload:
-        raise ValueError("representation.operators must be a non-empty list.")
-    if not isinstance(pruners_payload, list):
-        raise ValueError("representation.pruners must be a list when provided.")
-
-    normalized_operators = [
-        normalize_representation_component_payload(component, "representation.operators")
-        for component in operators_payload
-    ]
-    normalized_pruners = [
-        normalize_representation_component_payload(component, "representation.pruners")
-        for component in pruners_payload
-    ]
-
-    fingerprint_payload = {
-        "operators": normalized_operators,
-        "pruners": normalized_pruners,
-    }
-    representation_id = f"repr-{_short_hash(fingerprint_payload)}"
-    return RepresentationSpec(
-        representation_id=representation_id,
-        operators=tuple(
-            RepresentationComponentSpec(
-                component_id=component["id"],
-                params=dict(component["params"]),
-            )
-            for component in normalized_operators
-        ),
-        pruners=tuple(
-            RepresentationComponentSpec(
-                component_id=component["id"],
-                params=dict(component["params"]),
-            )
-            for component in normalized_pruners
-        ),
-        fingerprint_payload=fingerprint_payload,
-    )
-
-
-def build_representation_contract(
-    representation_spec: RepresentationSpec,
-) -> RepresentationContract:
-    operator_ids = {operator.component_id for operator in representation_spec.operators}
-
-    has_dense_numeric = bool(operator_ids.intersection(DENSE_PRODUCING_OPERATOR_IDS))
-    has_sparse_numeric = bool(operator_ids.intersection(SPARSE_PRODUCING_OPERATOR_IDS))
-    has_native_categorical = "native_categorical" in operator_ids
-    has_native_numeric = "native_numeric" in operator_ids
-    has_native_tabular = has_native_categorical or has_native_numeric
-
-    if has_native_tabular and has_sparse_numeric:
-        raise ValueError(
-            "Representations cannot mix native tabular operators with sparse operators. "
-            "Use dense/native operators together or sparse/dense operators together."
-        )
-
-    if has_native_tabular:
-        matrix_output_kind: MatrixOutputKind = "native_frame"
-    elif has_sparse_numeric:
-        matrix_output_kind = "sparse_csr"
-    else:
-        matrix_output_kind = "dense_array"
-
-    has_frequency_categorical = "frequency_encode_categoricals" in operator_ids
-    has_cuml_compatible_numerics = (
-        "standardize_numeric" in operator_ids and not has_native_numeric
-    ) or (
-        has_native_numeric and "standardize_numeric" not in operator_ids
-    )
-
-    return RepresentationContract(
-        representation_id=representation_spec.representation_id,
-        output_kinds=frozenset(
-            kind
-            for kind, enabled in (
-                ("dense_numeric", has_dense_numeric),
-                ("sparse_numeric", has_sparse_numeric),
-                ("native_tabular", has_native_tabular),
-            )
-            if enabled
-        ),
-        has_dense_numeric=has_dense_numeric,
-        has_sparse_numeric=has_sparse_numeric,
-        has_native_tabular=has_native_tabular,
-        has_native_categorical=has_native_categorical,
-        has_native_numeric=has_native_numeric,
-        has_frequency_categorical=has_frequency_categorical,
-        has_cuml_compatible_numerics=has_cuml_compatible_numerics,
-        matrix_output_kind=matrix_output_kind,
-    )
-
-
-def validate_representation_spec(representation_spec: RepresentationSpec) -> None:
-    unsupported_operator_ids = sorted(
-        operator.component_id
-        for operator in representation_spec.operators
-        if operator.component_id not in SUPPORTED_OPERATOR_IDS
-    )
-    if unsupported_operator_ids:
-        raise ValueError(
-            f"Unsupported representation operators: {unsupported_operator_ids}. "
-            f"Supported operators: {sorted(SUPPORTED_OPERATOR_IDS)}"
-        )
-    for operator in representation_spec.operators:
-        validate_component_params(operator.component_id, operator.params, "operator")
-
-    unsupported_pruner_ids = sorted(
-        pruner.component_id
-        for pruner in representation_spec.pruners
-        if pruner.component_id not in SUPPORTED_PRUNER_IDS
-    )
-    if unsupported_pruner_ids:
-        raise ValueError(
-            f"Unsupported representation pruners: {unsupported_pruner_ids}. "
-            f"Supported pruners: {sorted(SUPPORTED_PRUNER_IDS)}"
-        )
-    for pruner in representation_spec.pruners:
-        validate_component_params(pruner.component_id, pruner.params, "pruner")
-
-    build_representation_contract(representation_spec)
-
 
 __all__ = [
     "CompiledRepresentation",
@@ -178,17 +54,32 @@ __all__ = [
     "MaterializedRepresentation",
     "MatrixOutputKind",
     "OutputKind",
+    "RepresentationComponentConfigLike",
     "RepresentationComponentSpec",
-    "RepresentationContract",
-    "RepresentationSpec",
+    "RepresentationConfigLike",
     "ResolvedFeatureSchema",
     "SUPPORTED_OPERATOR_IDS",
     "SUPPORTED_PRUNER_IDS",
-    "build_representation_contract",
-    "build_representation_spec_from_payload",
+    "build_representation_fingerprint_payload",
+    "build_representation_id",
+    "build_representation_id_from_config",
+    "build_representation_id_from_payload",
     "compile_representation",
     "materialize_feature_bundle",
+    "normalize_representation_config",
+    "normalize_representation_payload",
+    "representation_has_cuml_compatible_numerics",
+    "representation_has_dense_numeric",
+    "representation_has_frequency_categorical",
+    "representation_has_native_categorical",
+    "representation_has_native_numeric",
+    "representation_has_native_tabular",
+    "representation_has_sparse_numeric",
     "resolve_feature_schema",
     "resolve_feature_types",
-    "validate_representation_spec",
+    "resolve_representation_matrix_output_kind",
+    "resolve_representation_output_kinds",
+    "validate_representation_config",
+    "validate_representation_definition",
+    "validate_representation_payload",
 ]

--- a/src/tabular_shenanigans/representations/compilation.py
+++ b/src/tabular_shenanigans/representations/compilation.py
@@ -6,6 +6,20 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 
+from tabular_shenanigans.representations.definition import (
+    build_representation_id,
+    normalize_representation_config,
+    representation_has_cuml_compatible_numerics,
+    representation_has_dense_numeric,
+    representation_has_frequency_categorical,
+    representation_has_native_categorical,
+    representation_has_native_numeric,
+    representation_has_native_tabular,
+    representation_has_sparse_numeric,
+    resolve_representation_matrix_output_kind,
+    resolve_representation_output_kinds,
+    validate_representation_definition,
+)
 from tabular_shenanigans.representations.feature_schema import ResolvedFeatureSchema
 from tabular_shenanigans.representations.operators import build_feature_generator, build_feature_pruner
 from tabular_shenanigans.representations.types import (
@@ -13,8 +27,10 @@ from tabular_shenanigans.representations.types import (
     FeatureGenerator,
     FeaturePruner,
     MaterializedRepresentation,
-    RepresentationContract,
-    RepresentationSpec,
+    MatrixOutputKind,
+    OutputKind,
+    RepresentationComponentSpec,
+    RepresentationConfigLike,
 )
 
 
@@ -23,59 +39,114 @@ GENERIC_PREPROCESSING_BACKEND = "feature_bundle"
 
 @dataclass(frozen=True)
 class FittedRepresentation:
-    representation_id: str
+    compiled_representation: "CompiledRepresentation"
     fitted_generators: tuple[object, ...]
     fitted_pruners: tuple[object, ...]
-    contract: RepresentationContract
+
+    @property
+    def representation_id(self) -> str:
+        return self.compiled_representation.representation_id
+
+    @property
+    def matrix_output_kind(self) -> MatrixOutputKind:
+        return self.compiled_representation.matrix_output_kind
+
+    @property
+    def preprocessing_backend(self) -> str:
+        return self.compiled_representation.preprocessing_backend
 
     def transform(self, X: pd.DataFrame) -> object:
         bundle = FeatureBundle(blocks=tuple(generator.transform(X) for generator in self.fitted_generators))
         for pruner in self.fitted_pruners:
             bundle = pruner.transform(bundle)
-        return materialize_feature_bundle(bundle, self.contract).values
+        return materialize_feature_bundle(
+            bundle,
+            matrix_output_kind=self.matrix_output_kind,
+            preprocessing_backend=self.preprocessing_backend,
+        ).values
 
 
 @dataclass(frozen=True)
 class CompiledRepresentation:
-    representation_spec: RepresentationSpec
+    representation_id: str
+    operators: tuple[RepresentationComponentSpec, ...]
+    pruner_components: tuple[RepresentationComponentSpec, ...]
     feature_schema: ResolvedFeatureSchema
-    generators: tuple[FeatureGenerator, ...]
-    pruners: tuple[FeaturePruner, ...]
-    contract: RepresentationContract
-    matrix_output_kind: str
-    preprocessing_backend: str
+    feature_generators: tuple[FeatureGenerator, ...]
+    feature_pruners: tuple[FeaturePruner, ...]
+    matrix_output_kind_override: MatrixOutputKind | None = None
+    preprocessing_backend: str = GENERIC_PREPROCESSING_BACKEND
+
+    @property
+    def output_kinds(self) -> frozenset[OutputKind]:
+        return resolve_representation_output_kinds(self.operators)
+
+    @property
+    def has_dense_numeric(self) -> bool:
+        return representation_has_dense_numeric(self.operators)
+
+    @property
+    def has_sparse_numeric(self) -> bool:
+        return representation_has_sparse_numeric(self.operators)
+
+    @property
+    def has_native_tabular(self) -> bool:
+        return representation_has_native_tabular(self.operators)
+
+    @property
+    def has_native_categorical(self) -> bool:
+        return representation_has_native_categorical(self.operators)
+
+    @property
+    def has_native_numeric(self) -> bool:
+        return representation_has_native_numeric(self.operators)
+
+    @property
+    def has_frequency_categorical(self) -> bool:
+        return representation_has_frequency_categorical(self.operators)
+
+    @property
+    def has_cuml_compatible_numerics(self) -> bool:
+        return representation_has_cuml_compatible_numerics(self.operators)
+
+    @property
+    def matrix_output_kind(self) -> MatrixOutputKind:
+        if self.matrix_output_kind_override is not None:
+            return self.matrix_output_kind_override
+        return resolve_representation_matrix_output_kind(self.operators)
 
     def fit(self, X_train: pd.DataFrame, y_train: pd.Series) -> FittedRepresentation:
         fitted_generators = []
-        for generator in self.generators:
+        for generator in self.feature_generators:
             y_arg = y_train if generator.fit_mode == "supervised" else None
             fitted_generators.append(generator.fit(X_train, y_arg))
 
         bundle = FeatureBundle(blocks=tuple(generator.transform(X_train) for generator in fitted_generators))
         fitted_pruners = []
-        for pruner in self.pruners:
+        for pruner in self.feature_pruners:
             y_arg = y_train if pruner.fit_mode == "supervised" else None
             fitted_pruner = pruner.fit(bundle, y_arg)
             bundle = fitted_pruner.transform(bundle)
             fitted_pruners.append(fitted_pruner)
 
         return FittedRepresentation(
-            representation_id=self.representation_spec.representation_id,
+            compiled_representation=self,
             fitted_generators=tuple(fitted_generators),
             fitted_pruners=tuple(fitted_pruners),
-            contract=self.contract,
         )
 
 
 def materialize_feature_bundle(
     bundle: FeatureBundle,
-    contract: RepresentationContract,
+    *,
+    matrix_output_kind: MatrixOutputKind,
+    preprocessing_backend: str = GENERIC_PREPROCESSING_BACKEND,
 ) -> MaterializedRepresentation:
     dense_frame = bundle.dense_frame()
     native_frame = bundle.native_frame()
     sparse_matrix = bundle.sparse_matrix()
 
-    if contract.matrix_output_kind == "native_frame":
+    if matrix_output_kind == "native_frame":
         frames = [frame for frame in (native_frame, dense_frame) if not frame.empty]
         if not frames:
             values = pd.DataFrame()
@@ -86,10 +157,10 @@ def materialize_feature_bundle(
         return MaterializedRepresentation(
             matrix_output_kind="native_frame",
             values=values,
-            preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+            preprocessing_backend=preprocessing_backend,
         )
 
-    if contract.matrix_output_kind == "sparse_csr":
+    if matrix_output_kind == "sparse_csr":
         matrices = []
         if not dense_frame.empty:
             matrices.append(sparse.csr_matrix(dense_frame.to_numpy(dtype=float)))
@@ -104,7 +175,7 @@ def materialize_feature_bundle(
         return MaterializedRepresentation(
             matrix_output_kind="sparse_csr",
             values=values,
-            preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+            preprocessing_backend=preprocessing_backend,
         )
 
     dense_values = dense_frame.to_numpy(dtype=float) if not dense_frame.empty else None
@@ -121,38 +192,42 @@ def materialize_feature_bundle(
     return MaterializedRepresentation(
         matrix_output_kind="dense_array",
         values=values,
-        preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+        preprocessing_backend=preprocessing_backend,
     )
 
 
 def compile_representation(
-    representation_spec: RepresentationSpec,
+    representation: RepresentationConfigLike,
     feature_schema: ResolvedFeatureSchema,
     x_train_sample: pd.DataFrame,
-    representation_contract: RepresentationContract,
+    matrix_output_kind_override: MatrixOutputKind | None = None,
 ) -> CompiledRepresentation:
-    generators = tuple(
+    operators, pruners = normalize_representation_config(representation)
+    validate_representation_definition(operators, pruners)
+
+    feature_generators = tuple(
         build_feature_generator(
             component_id=component.component_id,
             params=component.params,
             feature_schema=feature_schema,
             X_sample=x_train_sample,
         )
-        for component in representation_spec.operators
+        for component in operators
     )
-    pruners = tuple(
+    feature_pruners = tuple(
         build_feature_pruner(
             component_id=component.component_id,
             params=component.params,
         )
-        for component in representation_spec.pruners
+        for component in pruners
     )
+
     return CompiledRepresentation(
-        representation_spec=representation_spec,
+        representation_id=build_representation_id(operators, pruners),
+        operators=operators,
+        pruner_components=pruners,
         feature_schema=feature_schema,
-        generators=generators,
-        pruners=pruners,
-        contract=representation_contract,
-        matrix_output_kind=representation_contract.matrix_output_kind,
-        preprocessing_backend=GENERIC_PREPROCESSING_BACKEND,
+        feature_generators=feature_generators,
+        feature_pruners=feature_pruners,
+        matrix_output_kind_override=matrix_output_kind_override,
     )

--- a/src/tabular_shenanigans/representations/definition.py
+++ b/src/tabular_shenanigans/representations/definition.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from tabular_shenanigans.naming import _short_hash
+from tabular_shenanigans.operator_properties import (
+    DENSE_PRODUCING_OPERATOR_IDS,
+    SPARSE_PRODUCING_OPERATOR_IDS,
+)
+from tabular_shenanigans.representations.operators import (
+    SUPPORTED_OPERATOR_IDS,
+    SUPPORTED_PRUNER_IDS,
+    validate_component_params,
+)
+from tabular_shenanigans.representations.types import (
+    MatrixOutputKind,
+    OutputKind,
+    RepresentationComponentConfigLike,
+    RepresentationComponentSpec,
+    RepresentationConfigLike,
+)
+
+
+def _normalize_component_config(
+    component: RepresentationComponentConfigLike,
+    field_name: str,
+) -> RepresentationComponentSpec:
+    component_id = getattr(component, "id", None)
+    if not isinstance(component_id, str) or not component_id:
+        raise ValueError(f"{field_name} entries must include a non-empty string 'id'.")
+
+    params_fn = getattr(component, "params", None)
+    if not callable(params_fn):
+        raise ValueError(f"{field_name} entries must expose a params() method.")
+
+    params = params_fn()
+    if not isinstance(params, dict):
+        raise ValueError(f"{field_name} params() must return a dict.")
+
+    return RepresentationComponentSpec(
+        component_id=component_id,
+        params={str(key): value for key, value in params.items()},
+    )
+
+
+def _normalize_component_payload(
+    component: object,
+    field_name: str,
+) -> RepresentationComponentSpec:
+    if not isinstance(component, Mapping):
+        raise ValueError(f"{field_name} entries must be mappings.")
+
+    component_id = component.get("id")
+    if not isinstance(component_id, str) or not component_id:
+        raise ValueError(f"{field_name} entries must include a non-empty string 'id'.")
+
+    return RepresentationComponentSpec(
+        component_id=component_id,
+        params={str(key): value for key, value in component.items() if key != "id"},
+    )
+
+
+def _normalize_component_list(
+    components: object,
+    *,
+    field_name: str,
+    component_kind: str,
+) -> list[RepresentationComponentSpec]:
+    if not isinstance(components, Sequence) or isinstance(components, str):
+        raise ValueError(f"{field_name} must be a list when provided.")
+    if component_kind == "operator" and not components:
+        raise ValueError("representation.operators must be a non-empty list.")
+    return [
+        _normalize_component_payload(component, field_name)
+        for component in components
+    ]
+
+
+def normalize_representation_config(
+    representation: RepresentationConfigLike,
+) -> tuple[tuple[RepresentationComponentSpec, ...], tuple[RepresentationComponentSpec, ...]]:
+    operators = getattr(representation, "operators", None)
+    pruners = getattr(representation, "pruners", None)
+    if not isinstance(operators, Sequence) or isinstance(operators, str) or not operators:
+        raise ValueError("representation.operators must be a non-empty list.")
+    if pruners is None:
+        pruners = ()
+    if not isinstance(pruners, Sequence) or isinstance(pruners, str):
+        raise ValueError("representation.pruners must be a list when provided.")
+
+    return (
+        tuple(
+            _normalize_component_config(component, "representation.operators")
+            for component in operators
+        ),
+        tuple(
+            _normalize_component_config(component, "representation.pruners")
+            for component in pruners
+        ),
+    )
+
+
+def normalize_representation_payload(
+    representation: object,
+) -> tuple[tuple[RepresentationComponentSpec, ...], tuple[RepresentationComponentSpec, ...]]:
+    if not isinstance(representation, Mapping):
+        raise ValueError("representation must be a mapping.")
+
+    operators = representation.get("operators")
+    pruners = representation.get("pruners", [])
+    normalized_operators = _normalize_component_list(
+        operators,
+        field_name="representation.operators",
+        component_kind="operator",
+    )
+    normalized_pruners = _normalize_component_list(
+        pruners,
+        field_name="representation.pruners",
+        component_kind="pruner",
+    )
+    return tuple(normalized_operators), tuple(normalized_pruners)
+
+
+def build_representation_fingerprint_payload(
+    operators: Sequence[RepresentationComponentSpec],
+    pruners: Sequence[RepresentationComponentSpec],
+) -> dict[str, object]:
+    return {
+        "operators": [
+            {"id": component.component_id, "params": dict(component.params)}
+            for component in operators
+        ],
+        "pruners": [
+            {"id": component.component_id, "params": dict(component.params)}
+            for component in pruners
+        ],
+    }
+
+
+def build_representation_id(
+    operators: Sequence[RepresentationComponentSpec],
+    pruners: Sequence[RepresentationComponentSpec],
+) -> str:
+    fingerprint_payload = build_representation_fingerprint_payload(operators, pruners)
+    return f"repr-{_short_hash(fingerprint_payload)}"
+
+
+def build_representation_id_from_config(representation: RepresentationConfigLike) -> str:
+    operators, pruners = normalize_representation_config(representation)
+    return build_representation_id(operators, pruners)
+
+
+def build_representation_id_from_payload(representation: object) -> str:
+    operators, pruners = normalize_representation_payload(representation)
+    return build_representation_id(operators, pruners)
+
+
+def _operator_ids(operators: Sequence[RepresentationComponentSpec]) -> set[str]:
+    return {operator.component_id for operator in operators}
+
+
+def representation_has_dense_numeric(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    return bool(_operator_ids(operators).intersection(DENSE_PRODUCING_OPERATOR_IDS))
+
+
+def representation_has_sparse_numeric(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    return bool(_operator_ids(operators).intersection(SPARSE_PRODUCING_OPERATOR_IDS))
+
+
+def representation_has_native_categorical(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    return "native_categorical" in _operator_ids(operators)
+
+
+def representation_has_native_numeric(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    return "native_numeric" in _operator_ids(operators)
+
+
+def representation_has_native_tabular(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    return representation_has_native_categorical(operators) or representation_has_native_numeric(operators)
+
+
+def representation_has_frequency_categorical(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    return "frequency_encode_categoricals" in _operator_ids(operators)
+
+
+def representation_has_cuml_compatible_numerics(operators: Sequence[RepresentationComponentSpec]) -> bool:
+    operator_ids = _operator_ids(operators)
+    has_native_numeric = "native_numeric" in operator_ids
+    has_standardized_numeric = "standardize_numeric" in operator_ids
+    return (
+        has_standardized_numeric and not has_native_numeric
+    ) or (
+        has_native_numeric and not has_standardized_numeric
+    )
+
+
+def resolve_representation_output_kinds(
+    operators: Sequence[RepresentationComponentSpec],
+) -> frozenset[OutputKind]:
+    has_dense_numeric = representation_has_dense_numeric(operators)
+    has_sparse_numeric = representation_has_sparse_numeric(operators)
+    has_native_tabular = representation_has_native_tabular(operators)
+    return frozenset(
+        kind
+        for kind, enabled in (
+            ("dense_numeric", has_dense_numeric),
+            ("sparse_numeric", has_sparse_numeric),
+            ("native_tabular", has_native_tabular),
+        )
+        if enabled
+    )
+
+
+def resolve_representation_matrix_output_kind(
+    operators: Sequence[RepresentationComponentSpec],
+) -> MatrixOutputKind:
+    has_sparse_numeric = representation_has_sparse_numeric(operators)
+    has_native_tabular = representation_has_native_tabular(operators)
+
+    if has_native_tabular and has_sparse_numeric:
+        raise ValueError(
+            "Representations cannot mix native tabular operators with sparse operators. "
+            "Use dense/native operators together or sparse/dense operators together."
+        )
+
+    if has_native_tabular:
+        return "native_frame"
+    if has_sparse_numeric:
+        return "sparse_csr"
+    return "dense_array"
+
+
+def validate_representation_definition(
+    operators: Sequence[RepresentationComponentSpec],
+    pruners: Sequence[RepresentationComponentSpec],
+) -> None:
+    unsupported_operator_ids = sorted(
+        operator.component_id
+        for operator in operators
+        if operator.component_id not in SUPPORTED_OPERATOR_IDS
+    )
+    if unsupported_operator_ids:
+        raise ValueError(
+            f"Unsupported representation operators: {unsupported_operator_ids}. "
+            f"Supported operators: {sorted(SUPPORTED_OPERATOR_IDS)}"
+        )
+    for operator in operators:
+        validate_component_params(operator.component_id, operator.params, "operator")
+
+    unsupported_pruner_ids = sorted(
+        pruner.component_id
+        for pruner in pruners
+        if pruner.component_id not in SUPPORTED_PRUNER_IDS
+    )
+    if unsupported_pruner_ids:
+        raise ValueError(
+            f"Unsupported representation pruners: {unsupported_pruner_ids}. "
+            f"Supported pruners: {sorted(SUPPORTED_PRUNER_IDS)}"
+        )
+    for pruner in pruners:
+        validate_component_params(pruner.component_id, pruner.params, "pruner")
+
+    resolve_representation_matrix_output_kind(operators)
+
+
+def validate_representation_config(representation: RepresentationConfigLike) -> None:
+    operators, pruners = normalize_representation_config(representation)
+    validate_representation_definition(operators, pruners)
+
+
+def validate_representation_payload(representation: object) -> None:
+    operators, pruners = normalize_representation_payload(representation)
+    validate_representation_definition(operators, pruners)

--- a/src/tabular_shenanigans/representations/types.py
+++ b/src/tabular_shenanigans/representations/types.py
@@ -17,12 +17,15 @@ class RepresentationComponentSpec:
     params: dict[str, object]
 
 
-@dataclass(frozen=True)
-class RepresentationSpec:
-    representation_id: str
-    operators: tuple[RepresentationComponentSpec, ...]
-    pruners: tuple[RepresentationComponentSpec, ...]
-    fingerprint_payload: dict[str, object]
+class RepresentationComponentConfigLike(Protocol):
+    id: str
+
+    def params(self) -> dict[str, object]: ...
+
+
+class RepresentationConfigLike(Protocol):
+    operators: object
+    pruners: object
 
 
 @dataclass(frozen=True)
@@ -38,20 +41,6 @@ class MaterializedRepresentation:
     matrix_output_kind: MatrixOutputKind
     values: object
     preprocessing_backend: str
-
-
-@dataclass(frozen=True)
-class RepresentationContract:
-    representation_id: str
-    output_kinds: frozenset[OutputKind]
-    has_dense_numeric: bool
-    has_sparse_numeric: bool
-    has_native_tabular: bool
-    has_native_categorical: bool
-    has_native_numeric: bool
-    has_frequency_categorical: bool
-    has_cuml_compatible_numerics: bool
-    matrix_output_kind: MatrixOutputKind
 
 
 class FittedFeatureGenerator(Protocol):


### PR DESCRIPTION
## Summary
- compile representations directly from RepresentationConfig instead of building spec/contract intermediates
- move representation normalization, validation, id derivation, and runtime property inspection into shared helpers used by config, bootstrap, and MLflow
- update training, preprocessing, and routing paths to read metadata from the compiled representation or shared helpers

## Verification
- uv run python -m compileall src/tabular_shenanigans main.py
- loaded config.binary.example.yaml and config.regression.example.yaml and confirmed bootstrap/runtime representation_id parity
- exercised direct compile/fit/transform flows for dense, sparse, and native-frame representations on synthetic data

Closes #302